### PR TITLE
fix: スケジュール更新履歴が正しく記録・表示されない問題を修正

### DIFF
--- a/src/components/schedule/modal/HistoryModal.tsx
+++ b/src/components/schedule/modal/HistoryModal.tsx
@@ -1,0 +1,42 @@
+// 公演履歴を表示する専用モーダル
+// セルの右クリックメニューや公演カードから履歴を確認できる
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { EventHistoryTab } from './EventHistoryTab'
+import type { CellInfo } from '@/lib/api/eventHistoryApi'
+
+interface HistoryModalProps {
+  isOpen: boolean
+  onClose: () => void
+  eventId?: string          // 公演ID（既存公演の場合）
+  cellInfo?: CellInfo       // セル情報（削除された公演の履歴を見る場合）
+  organizationId?: string   // 組織ID
+  title?: string            // モーダルのタイトル
+}
+
+export function HistoryModal({ 
+  isOpen, 
+  onClose, 
+  eventId,
+  cellInfo,
+  organizationId,
+  title = '更新履歴'
+}: HistoryModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <div className="flex-1 overflow-hidden">
+          <EventHistoryTab 
+            eventId={eventId}
+            cellInfo={cellInfo}
+            organizationId={organizationId}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/supabase/migrations/20260113_create_schedule_event_history.sql
+++ b/supabase/migrations/20260113_create_schedule_event_history.sql
@@ -1,0 +1,41 @@
+-- schedule_event_history テーブルに不足カラムを追加
+-- セル情報（日付・店舗・時間帯）を追加して、削除後も履歴を関連付けられるようにする
+
+-- 1. 不足しているカラムを追加
+ALTER TABLE schedule_event_history 
+ADD COLUMN IF NOT EXISTS event_date DATE;
+
+ALTER TABLE schedule_event_history 
+ADD COLUMN IF NOT EXISTS store_id UUID;
+
+ALTER TABLE schedule_event_history 
+ADD COLUMN IF NOT EXISTS time_slot TEXT;
+
+ALTER TABLE schedule_event_history 
+ADD COLUMN IF NOT EXISTS deleted_event_scenario TEXT;
+
+-- 2. store_id に外部キー制約を追加（既存データがある場合を考慮してNULL許可）
+-- 注意: 既存レコードがある場合、store_id は NULL になります
+
+-- 3. インデックス作成（存在しない場合のみ）
+CREATE INDEX IF NOT EXISTS idx_schedule_event_history_event_id 
+ON schedule_event_history(schedule_event_id);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_event_history_org_id 
+ON schedule_event_history(organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_event_history_created_at 
+ON schedule_event_history(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_event_history_changed_by 
+ON schedule_event_history(changed_by_user_id);
+
+-- セル情報でのフィルタリング用インデックス（削除後の履歴検索用）
+CREATE INDEX IF NOT EXISTS idx_schedule_event_history_cell 
+ON schedule_event_history(organization_id, event_date, store_id, time_slot);
+
+-- 4. コメント追加
+COMMENT ON COLUMN schedule_event_history.event_date IS '公演日（セル特定用）';
+COMMENT ON COLUMN schedule_event_history.store_id IS '店舗ID（セル特定用）';
+COMMENT ON COLUMN schedule_event_history.time_slot IS '時間帯（朝/昼/夜）（セル特定用）';
+COMMENT ON COLUMN schedule_event_history.deleted_event_scenario IS '削除された公演のシナリオ名';


### PR DESCRIPTION
## 変更内容
- eventHistoryApiのフィールド名をDBカラム名に合わせて修正
- 削除時の履歴記録でorganizationIdが依存配列に含まれていなかった問題を修正
- 貸切予約削除時にも履歴を記録するように修正
- 履歴取得ロジックをセルベースに変更
- 右クリックメニューに「履歴を表示」を追加
- 履歴専用モーダル追加

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves incorrect schedule history recording/display and enables viewing full cell history, including deleted events.
> 
> - Aligns history fields with DB (`store_id`, `capacity`) and updates diff calculation targets
> - Switches `getEventHistory` to cell-based retrieval with de-dup/merge; also fetches by `schedule_event_id` as fallback
> - Records history on delete for normal and private reservations; adds missing `organizationId` dependency; includes `deleted_event_scenario`
> - Adds `HistoryModal` and "履歴を表示" to event/cell context menus in `ScheduleManager`; imports `Clock` icon
> - Migration adds `event_date`, `store_id`, `time_slot`, `deleted_event_scenario` columns and related indexes/comments to `schedule_event_history`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7363f9725dd7921f7c13c294e1fb7ff923249fc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->