### PR TITLE
refactor: ユーザー管理から削除機能を除去

### DIFF
--- a/src/pages/AccountManagement/pages/UserManagementContent.tsx
+++ b/src/pages/AccountManagement/pages/UserManagementContent.tsx
@@ -10,8 +10,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { HelpButton } from '@/components/ui/help-button'
-import { Users, Shield, AlertCircle, Search, UserCog, User as UserIcon, Trash2 } from 'lucide-react'
-import { searchUserByEmail, getAllUsers, updateUserRole, deleteUser, type User } from '@/lib/userApi'
+import { Users, Shield, AlertCircle, Search, UserCog, User as UserIcon } from 'lucide-react'
+import { searchUserByEmail, getAllUsers, updateUserRole, type User } from '@/lib/userApi'
 import { logger } from '@/utils/logger'
 
 export function UserManagementContent() {
@@ -23,7 +23,6 @@ export function UserManagementContent() {
   const [error, setError] = useState('')
   const [message, setMessage] = useState('')
   const [showAllUsers, setShowAllUsers] = useState(false)
-  const [userToDelete, setUserToDelete] = useState<User | null>(null)
   const [roleChangeConfirm, setRoleChangeConfirm] = useState<{ user: User; newRole: 'admin' | 'staff' | 'customer' | 'license_admin' } | null>(null)
 
   // 管理者チェック（admin または license_admin）
@@ -125,40 +124,6 @@ export function UserManagementContent() {
     }
   }
 
-  // ユーザーを削除
-  const handleDeleteUser = async () => {
-    if (!userToDelete) return
-
-    setLoading(true)
-    setError('')
-    setMessage('')
-
-    try {
-      await deleteUser(userToDelete.id)
-      setMessage(`ユーザー ${userToDelete.email} を削除しました`)
-      
-      if (searchResult && searchResult.id === userToDelete.id) {
-        setSearchResult(null)
-      }
-
-      if (showAllUsers) {
-        await loadAllUsers()
-      }
-
-      setUserToDelete(null)
-    } catch (err: any) {
-      logger.error('ユーザー削除エラー:', err)
-      
-      if (err.code === '23503') {
-        setError('このユーザーは他のデータから参照されているため削除できません。先に関連データを削除してください。')
-      } else {
-        setError('ユーザーの削除に失敗しました: ' + (err.message || err.code || ''))
-      }
-    } finally {
-      setLoading(false)
-    }
-  }
-
   const getRoleIcon = (role: string) => {
     switch (role) {
       case 'admin':
@@ -253,19 +218,6 @@ export function UserManagementContent() {
                 顧客
               </Button>
             </div>
-          </div>
-
-          <div className="pt-3 sm:pt-4 border-t">
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => setUserToDelete(userData)}
-              disabled={loading}
-              className="w-full flex items-center justify-center gap-2 text-xs sm:text-sm"
-            >
-              <Trash2 className="w-4 h-4 sm:w-5 sm:h-5" />
-              ユーザーを削除
-            </Button>
           </div>
 
           <div className="pt-3 border-t text-xs text-gray-500">
@@ -416,17 +368,6 @@ export function UserManagementContent() {
                               <UserIcon className="w-4 h-4 sm:w-4 sm:h-4 text-gray-600" />
                               <span className="hidden sm:inline">顧客</span>
                             </Button>
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => setUserToDelete(userData)}
-                              disabled={loading}
-                              className="flex items-center gap-1 text-xs h-8 sm:h-auto sm:px-3 px-2"
-                              title="削除"
-                            >
-                              <Trash2 className="w-4 h-4 sm:w-4 sm:h-4" />
-                              <span className="hidden sm:inline">削除</span>
-                            </Button>
                           </div>
                         </div>
                       </div>
@@ -505,40 +446,6 @@ export function UserManagementContent() {
               disabled={loading}
             >
               {loading ? '変更中...' : '変更する'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* 削除確認ダイアログ */}
-      <Dialog open={!!userToDelete} onOpenChange={(open) => !open && setUserToDelete(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>ユーザーを削除</DialogTitle>
-            <DialogDescription>
-              本当にこのユーザーを削除しますか？この操作は取り消せません。
-            </DialogDescription>
-          </DialogHeader>
-          {userToDelete && (
-            <div className="py-4">
-              <p className="text-sm"><strong>メールアドレス:</strong> {userToDelete.email}</p>
-              <p className="text-sm"><strong>ロール:</strong> {getRoleLabel(userToDelete.role)}</p>
-            </div>
-          )}
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setUserToDelete(null)}
-              disabled={loading}
-            >
-              キャンセル
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteUser}
-              disabled={loading}
-            >
-              {loading ? '削除中...' : '削除する'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -7,8 +7,8 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { AppLayout } from '@/components/layout/AppLayout'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { HelpButton } from '@/components/ui/help-button'
-import { Users, Shield, AlertCircle, Search, UserCog, User as UserIcon, Trash2 } from 'lucide-react'
-import { searchUserByEmail, getAllUsers, updateUserRole, deleteUser, type User } from '@/lib/userApi'
+import { Users, Shield, AlertCircle, Search, UserCog, User as UserIcon } from 'lucide-react'
+import { searchUserByEmail, getAllUsers, updateUserRole, type User } from '@/lib/userApi'
 import { logger } from '@/utils/logger'
 
 export function UserManagement() {
@@ -20,7 +20,6 @@ export function UserManagement() {
   const [error, setError] = useState('')
   const [message, setMessage] = useState('')
   const [showAllUsers, setShowAllUsers] = useState(false)
-  const [userToDelete, setUserToDelete] = useState<User | null>(null)
   const [roleChangeConfirm, setRoleChangeConfirm] = useState<{ user: User; newRole: 'admin' | 'staff' | 'customer' | 'license_admin' } | null>(null)
 
   // 管理者チェック（admin または license_admin）
@@ -132,44 +131,6 @@ export function UserManagement() {
     }
   }
 
-  // ユーザーを削除
-  const handleDeleteUser = async () => {
-    if (!userToDelete) return
-
-    setLoading(true)
-    setError('')
-    setMessage('')
-
-    try {
-      await deleteUser(userToDelete.id)
-      setMessage(`ユーザー ${userToDelete.email} を削除しました`)
-      
-      // 検索結果をクリア
-      if (searchResult && searchResult.id === userToDelete.id) {
-        setSearchResult(null)
-      }
-
-      // 全ユーザー一覧を表示中の場合は再読み込み
-      if (showAllUsers) {
-        await loadAllUsers()
-      }
-
-      setUserToDelete(null)
-    } catch (err: any) {
-      logger.error('ユーザー削除エラー:', err)
-      logger.error('削除エラー詳細:', err)
-      
-      // 409エラーの場合は、より詳細なメッセージを表示
-      if (err.code === '23503') {
-        setError('このユーザーは他のデータから参照されているため削除できません。先に関連データを削除してください。')
-      } else {
-        setError('ユーザーの削除に失敗しました: ' + (err.message || err.code || ''))
-      }
-    } finally {
-      setLoading(false)
-    }
-  }
-
   const getRoleIcon = (role: string) => {
     switch (role) {
       case 'admin':
@@ -265,19 +226,6 @@ export function UserManagement() {
                 顧客
               </Button>
             </div>
-          </div>
-
-          <div className="pt-3 sm:pt-4 border-t">
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => setUserToDelete(userData)}
-              disabled={loading}
-              className="w-full flex items-center justify-center gap-2 text-xs sm:text-sm"
-            >
-              <Trash2 className="w-4 h-4 sm:w-5 sm:h-5" />
-              ユーザーを削除
-            </Button>
           </div>
 
           <div className="pt-3 border-t text-xs text-gray-500">
@@ -437,17 +385,6 @@ export function UserManagement() {
                             <UserIcon className="w-4 h-4 sm:w-4 sm:h-4 text-gray-600" />
                             <span className="hidden sm:inline">顧客</span>
                           </Button>
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => setUserToDelete(userData)}
-                            disabled={loading}
-                            className="flex items-center gap-1 text-xs h-8 sm:h-auto sm:px-3 px-2"
-                            title="削除"
-                          >
-                            <Trash2 className="w-4 h-4 sm:w-4 sm:h-4" />
-                            <span className="hidden sm:inline">削除</span>
-                          </Button>
                         </div>
                       </div>
                     </div>
@@ -528,40 +465,6 @@ export function UserManagement() {
               disabled={loading}
             >
               {loading ? '変更中...' : '変更する'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* 削除確認ダイアログ */}
-      <Dialog open={!!userToDelete} onOpenChange={(open) => !open && setUserToDelete(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>ユーザーを削除</DialogTitle>
-            <DialogDescription>
-              本当にこのユーザーを削除しますか？この操作は取り消せません。
-            </DialogDescription>
-          </DialogHeader>
-          {userToDelete && (
-            <div className="py-4">
-              <p className="text-sm"><strong>メールアドレス:</strong> {userToDelete.email}</p>
-              <p className="text-sm"><strong>ロール:</strong> {getRoleLabel(userToDelete.role)}</p>
-            </div>
-          )}
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setUserToDelete(null)}
-              disabled={loading}
-            >
-              キャンセル
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteUser}
-              disabled={loading}
-            >
-              {loading ? '削除中...' : '削除する'}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## 🎯 目的

ユーザー管理から削除機能を除去し、セキュリティとUXを改善します。

## 📝 変更内容

### 除去した機能
1. ユーザーリストの削除ボタン（2箇所）
2. 削除確認ダイアログ
3. `userApi.deleteUser(userId)` 関数（管理者が他人を削除する機能）

### 保持した機能
- `deleteMyAccount()` - **本人のアカウント削除のみ許可**（マイページから）

### 除去した理由
- 管理画面から他人のアカウントを削除する機能は不要
- 本人のアカウント削除はマイページからのみ可能にする
- 役割変更で「顧客」に変更すればユーザーリストから消える
- 誤操作や権限乱用のリスクを低減

## 🗂️ 変更ファイル (3ファイル)

- `src/lib/userApi.ts` - deleteUser(userId)を削除、deleteMyAccount()を直接実装
- `src/pages/AccountManagement/pages/UserManagementContent.tsx` - 削除ボタンとダイアログを除去
- `src/pages/UserManagement.tsx` - 削除ボタンとダイアログを除去

## ✅ 影響範囲

- ユーザー管理画面のみ
- 既存の機能には影響なし
- 本人のアカウント削除（マイページ）は引き続き動作

## 🧪 テスト

- [ ] ユーザー一覧で削除ボタンが表示されないこと
- [ ] ユーザー検索結果で削除ボタンが表示されないこと
- [ ] 役割変更で「顧客」に変更できること
- [ ] マイページからアカウント削除できること（deleteMyAccount）
- [ ] ビルドエラーがないこと