### PR TITLE
security: エラーメッセージの技術的詳細を除去

### DIFF
--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -153,6 +153,7 @@ export function handleSupabaseError(error: unknown, context?: string): ApiError 
 
 /**
  * ユーザー向けのエラーメッセージを生成
+ * 技術的詳細は含めず、一般的なメッセージを返す
  */
 export function getUserFriendlyMessage(error: ApiError): string {
   switch (error.type) {
@@ -179,7 +180,9 @@ export function getUserFriendlyMessage(error: ApiError): string {
     
     case ApiErrorType.UNKNOWN:
     default:
-      return error.message || '予期しないエラーが発生しました'
+      // 🔒 セキュリティ: 技術的詳細を含む可能性があるerror.messageは返さない
+      // 詳細はlogApiErrorでログに残す
+      return '予期しないエラーが発生しました。しばらくしてから再試行してください'
   }
 }
 

--- a/supabase/functions/_shared/security.ts
+++ b/supabase/functions/_shared/security.ts
@@ -191,5 +191,75 @@ export function successResponse(
   )
 }
 
+/**
+ * 🔒 エラーメッセージをサニタイズ
+ * 技術的詳細を含むメッセージを、ユーザーフレンドリーな汎用メッセージに変換
+ * 
+ * @param error 元のエラー
+ * @param defaultMessage デフォルトのエラーメッセージ
+ * @returns サニタイズされたメッセージ
+ */
+export function sanitizeErrorMessage(
+  error: unknown,
+  defaultMessage = 'エラーが発生しました'
+): string {
+  // 安全なメッセージのパターン（日本語のみ許可）
+  const safePatterns: Array<[RegExp, string]> = [
+    [/満席/i, 'この公演は満席です'],
+    [/空席がありません/i, '選択した人数分の空席がありません'],
+    [/公演が見つかりません/i, '公演が見つかりませんでした'],
+    [/予約が見つかりません/i, '予約が見つかりませんでした'],
+    [/参加人数が不正/i, '参加人数が不正です'],
+    [/権限がありません/i, 'この操作を実行する権限がありません'],
+    [/認証が必要/i, 'ログインが必要です'],
+    [/認証に失敗/i, 'ログインに失敗しました'],
+    [/メール送信サービスが設定されていません/i, 'メール送信サービスが設定されていません'],
+    [/キャンセル待ちリストの取得に失敗/i, 'キャンセル待ちリストの取得に失敗しました'],
+  ]
+
+  const errorMessage = error instanceof Error ? error.message : String(error)
+
+  // 安全なパターンに一致するか確認
+  for (const [pattern, safeMessage] of safePatterns) {
+    if (pattern.test(errorMessage)) {
+      return safeMessage
+    }
+  }
+
+  // 技術的な詳細を含む可能性がある場合はデフォルトメッセージを返す
+  // PostgreSQLエラーコード、スタックトレース、テーブル名などを含む場合
+  const technicalPatterns = [
+    /PGRST\d+/i,          // Supabase REST APIエラー
+    /P\d{4}/i,            // PostgreSQLエラーコード
+    /relation ".+" does not exist/i,
+    /column ".+" does not exist/i,
+    /duplicate key/i,
+    /violates .+ constraint/i,
+    /syntax error/i,
+    /at line \d+/i,
+    /JSON\.stringify/i,
+    /\{.*statusCode.*\}/i,  // JSON形式のエラー
+    /Error:/i,
+    /undefined/i,
+    /null/i,
+    /TypeError/i,
+    /ReferenceError/i,
+  ]
+
+  for (const pattern of technicalPatterns) {
+    if (pattern.test(errorMessage)) {
+      console.warn('🔒 技術的詳細を含むエラーをサニタイズ:', errorMessage)
+      return defaultMessage
+    }
+  }
+
+  // 日本語のみのメッセージはそのまま返す
+  if (/^[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\u3000-\u303F、。！？\s]+$/.test(errorMessage)) {
+    return errorMessage
+  }
+
+  // それ以外はデフォルトメッセージ
+  return defaultMessage
+}
 
 

--- a/supabase/functions/check-inventory-consistency/index.ts
+++ b/supabase/functions/check-inventory-consistency/index.ts
@@ -9,7 +9,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { getCorsHeaders, verifyAuth, errorResponse } from '../_shared/security.ts'
+import { getCorsHeaders, verifyAuth, errorResponse, sanitizeErrorMessage } from '../_shared/security.ts'
 
 /**
  * Service Role Key での呼び出しか確認（Cron用）
@@ -85,7 +85,8 @@ serve(async (req) => {
     return new Response(
       JSON.stringify({ 
         success: false, 
-        error: error.message || '在庫整合性チェックに失敗しました' 
+        // 🔒 セキュリティ: 技術的詳細をサニタイズ
+        error: sanitizeErrorMessage(error, '在庫整合性チェックに失敗しました')
       }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
     )

--- a/supabase/functions/notify-waitlist/index.ts
+++ b/supabase/functions/notify-waitlist/index.ts
@@ -10,7 +10,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings } from '../_shared/organization-settings.ts'
-import { getCorsHeaders, verifyAuth, errorResponse } from '../_shared/security.ts'
+import { getCorsHeaders, verifyAuth, errorResponse, sanitizeErrorMessage } from '../_shared/security.ts'
 
 interface NotifyWaitlistRequest {
   organizationId: string
@@ -359,7 +359,8 @@ Murder Mystery Queue (MMQ)
     return new Response(
       JSON.stringify({ 
         success: false, 
-        error: error.message || 'キャンセル待ち通知に失敗しました' 
+        // 🔒 セキュリティ: 技術的詳細をサニタイズ
+        error: sanitizeErrorMessage(error, 'キャンセル待ち通知に失敗しました')
       }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
     )


### PR DESCRIPTION
## 変更内容
- エラーメッセージから技術的詳細（DB構造、エラーコード）を除去
- 共通サニタイズ関数を追加

## 解決する問題
攻撃者がわざとエラーを発生させてDB構造を推測することを防止

## 変更ファイル
- `src/lib/apiErrorHandler.ts`: UNKNOWN時に生メッセージを返さない
- `_shared/security.ts`: sanitizeErrorMessage関数追加
- Edge Functions: サニタイザー適用