### PR TITLE
feat: 人数減少時にキャンセル待ち通知を送信

### DIFF
--- a/src/components/schedule/modal/ReservationList.tsx
+++ b/src/components/schedule/modal/ReservationList.tsx
@@ -1125,6 +1125,40 @@ ${content.organizationName || '店舗'}
                                     )
                                   )
                                   
+                                  // 🔔 人数が減少した場合、キャンセル待ちに通知
+                                  const oldCount = reservation.participant_count || 0
+                                  const freedSeats = oldCount - newCount
+                                  if (freedSeats > 0 && event) {
+                                    try {
+                                      const { data: org } = await supabase
+                                        .from('organizations')
+                                        .select('slug')
+                                        .eq('id', event.organization_id)
+                                        .single()
+                                      
+                                      const orgSlug = org?.slug || 'queens-waltz'
+                                      const bookingUrl = `${window.location.origin}/${orgSlug}`
+                                      
+                                      await supabase.functions.invoke('notify-waitlist', {
+                                        body: {
+                                          organizationId: event.organization_id,
+                                          scheduleEventId: event.id,
+                                          freedSeats,
+                                          scenarioTitle: event.scenario || '',
+                                          eventDate: event.date,
+                                          startTime: event.start_time,
+                                          endTime: event.end_time,
+                                          storeName: event.venue,
+                                          bookingUrl
+                                        }
+                                      })
+                                      logger.info('キャンセル待ち通知を送信（人数減少）:', { freedSeats })
+                                    } catch (notifyError) {
+                                      logger.warn('キャンセル待ち通知エラー:', notifyError)
+                                      // 通知失敗はエラー表示しない（メイン処理は成功しているため）
+                                    }
+                                  }
+                                  
                                   showToast.success('人数を更新しました')
                                 }}
                               >


### PR DESCRIPTION
## 変更内容
管理画面で予約の参加人数を減らした場合、空いた席数分のキャンセル待ち通知を発火

## 解決する問題
5名→3名に変更しても通知が送られなかった

## 動作
1. 管理者が予約の人数を減少させる
2. 差分（空いた席数）を計算
3. notify-waitlist Edge Functionを呼び出し
4. キャンセル待ちユーザーにメール送信