### PR TITLE
feat: 組織別メールテンプレートを追加

### DIFF
--- a/database/migrations/017_organization_email_templates.sql
+++ b/database/migrations/017_organization_email_templates.sql
@@ -1,0 +1,97 @@
+-- =============================================================================
+-- マイグレーション 017: 組織別メールテンプレート
+-- =============================================================================
+-- 
+-- 🎯 解決する問題:
+--   メール本文が全組織で同じ内容になっている
+--
+-- 📋 追加するカスタマイズ項目:
+--   - 署名（signature）: メール末尾の署名
+--   - フッター（footer）: 追加情報やリンク
+--   - 挨拶文（greeting）: メール冒頭の挨拶
+--
+-- =============================================================================
+
+-- 1. organization_settings にメールテンプレートカラムを追加
+ALTER TABLE organization_settings
+ADD COLUMN IF NOT EXISTS email_templates JSONB DEFAULT '{}'::JSONB;
+
+COMMENT ON COLUMN organization_settings.email_templates IS 
+'メールテンプレート設定。構造:
+{
+  "greeting": "いつもご利用ありがとうございます。",
+  "signature": "株式会社○○\nTEL: 03-xxxx-xxxx\nEmail: info@example.com",
+  "footer": "※このメールは自動送信です。",
+  "booking_confirmation": { "subject_prefix": "【予約確定】", "additional_notes": "..." },
+  "cancellation_confirmation": { "subject_prefix": "【キャンセル】", ... },
+  "waitlist_notification": { "subject_prefix": "【空席のお知らせ】", ... },
+  "reminder": { "subject_prefix": "【リマインダー】", ... }
+}';
+
+-- 2. Queens Waltz のデフォルトテンプレートを設定
+UPDATE organization_settings
+SET email_templates = '{
+  "greeting": "いつもクインズワルツをご利用いただき、誠にありがとうございます。",
+  "signature": "クインズワルツ スタッフ一同\n\n━━━━━━━━━━━━━━━━━━━━\n🎭 マーダーミステリー専門店 クインズワルツ\n🌐 https://queenswaltz.com\n📧 info@mmq.game\n━━━━━━━━━━━━━━━━━━━━",
+  "footer": "※このメールは自動送信されています。\n※ご不明点がございましたら、上記メールアドレスまでお問い合わせください。"
+}'::JSONB
+WHERE organization_id = 'a0000000-0000-0000-0000-000000000001';
+
+-- 3. デフォルト値取得関数
+CREATE OR REPLACE FUNCTION get_email_template(
+  p_organization_id UUID,
+  p_template_key TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_templates JSONB;
+  v_value TEXT;
+BEGIN
+  -- 組織のテンプレートを取得
+  SELECT email_templates INTO v_templates
+  FROM organization_settings
+  WHERE organization_id = p_organization_id;
+  
+  IF v_templates IS NULL THEN
+    v_templates := '{}'::JSONB;
+  END IF;
+  
+  -- キーに対応する値を取得
+  v_value := v_templates ->> p_template_key;
+  
+  -- デフォルト値
+  IF v_value IS NULL THEN
+    CASE p_template_key
+      WHEN 'greeting' THEN
+        v_value := 'いつもご利用いただきありがとうございます。';
+      WHEN 'signature' THEN
+        v_value := 'MMQ予約システム';
+      WHEN 'footer' THEN
+        v_value := '※このメールは自動送信されています。';
+      ELSE
+        v_value := '';
+    END CASE;
+  END IF;
+  
+  RETURN v_value;
+END;
+$$;
+
+COMMENT ON FUNCTION get_email_template(UUID, TEXT) IS 
+'組織のメールテンプレートを取得。未設定時はデフォルト値を返す。';
+
+GRANT EXECUTE ON FUNCTION get_email_template(UUID, TEXT) TO service_role;
+
+-- 完了確認
+DO $$ 
+BEGIN
+  RAISE NOTICE '✅ マイグレーション 017 完了';
+  RAISE NOTICE '  - email_templates カラム追加';
+  RAISE NOTICE '  - Queens Waltz デフォルトテンプレート設定';
+  RAISE NOTICE '  - get_email_template() 関数作成';
+END $$;
+

--- a/supabase/functions/_shared/organization-settings.ts
+++ b/supabase/functions/_shared/organization-settings.ts
@@ -9,6 +9,16 @@
 
 import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
+export interface EmailTemplates {
+  greeting?: string
+  signature?: string
+  footer?: string
+  booking_confirmation?: { subject_prefix?: string; additional_notes?: string }
+  cancellation_confirmation?: { subject_prefix?: string; additional_notes?: string }
+  waitlist_notification?: { subject_prefix?: string; additional_notes?: string }
+  reminder?: { subject_prefix?: string; additional_notes?: string }
+}
+
 export interface OrganizationSettings {
   id: string
   organization_id: string
@@ -26,6 +36,9 @@ export interface OrganizationSettings {
   sender_email: string | null
   sender_name: string | null
   reply_to_email: string | null
+  
+  // メールテンプレート
+  email_templates: EmailTemplates | null
   
   // 通知設定
   notification_settings: {
@@ -107,6 +120,29 @@ export async function getEmailSettings(
     senderEmail: settings?.sender_email || Deno.env.get('SENDER_EMAIL') || 'noreply@example.com',
     senderName: settings?.sender_name || Deno.env.get('SENDER_NAME') || 'MMQ予約システム',
     replyToEmail: settings?.reply_to_email || Deno.env.get('REPLY_TO_EMAIL') || null,
+  }
+}
+
+/**
+ * メールテンプレートを取得（デフォルト値付き）
+ */
+export async function getEmailTemplates(
+  supabase: SupabaseClient,
+  organizationId: string
+): Promise<{
+  greeting: string
+  signature: string
+  footer: string
+  templates: EmailTemplates
+}> {
+  const settings = await getOrganizationSettings(supabase, organizationId)
+  const templates = settings?.email_templates || {}
+  
+  return {
+    greeting: templates.greeting || 'いつもご利用いただきありがとうございます。',
+    signature: templates.signature || 'MMQ予約システム',
+    footer: templates.footer || '※このメールは自動送信されています。',
+    templates,
   }
 }
 

--- a/supabase/functions/notify-waitlist/index.ts
+++ b/supabase/functions/notify-waitlist/index.ts
@@ -9,7 +9,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { getEmailSettings } from '../_shared/organization-settings.ts'
+import { getEmailSettings, getEmailTemplates } from '../_shared/organization-settings.ts'
 import { getCorsHeaders, verifyAuth, errorResponse, sanitizeErrorMessage, checkRateLimit, getClientIP, rateLimitResponse } from '../_shared/security.ts'
 
 interface NotifyWaitlistRequest {
@@ -190,6 +190,9 @@ serve(async (req) => {
     // 24時間後を回答期限として設定
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
 
+    // 🎨 組織別メールテンプレートを取得
+    const emailTemplates = await getEmailTemplates(serviceClient, data.organizationId)
+
     // 各エントリーにメール送信
     const emailPromises = notifiedEntries.map(async (entry) => {
       const emailHtml = `
@@ -262,8 +265,8 @@ serve(async (req) => {
   </div>
 
   <div style="text-align: center; padding-top: 20px; border-top: 1px solid #e5e7eb; color: #9ca3af; font-size: 12px;">
-    <p style="margin: 5px 0;">Murder Mystery Queue (MMQ)</p>
-    <p style="margin: 5px 0;">このメールは自動送信されています</p>
+    <p style="margin: 5px 0; white-space: pre-line;">${emailTemplates.signature}</p>
+    <p style="margin: 10px 0; font-size: 11px;">${emailTemplates.footer}</p>
   </div>
 </body>
 </html>
@@ -299,8 +302,9 @@ ${data.bookingUrl}
 
 予約が完了しましたら、キャンセル待ちは自動的に解除されます。
 
-Murder Mystery Queue (MMQ)
-このメールは自動送信されています
+${emailTemplates.signature}
+
+${emailTemplates.footer}
       `
 
       try {


### PR DESCRIPTION
## 変更内容
- organization_settingsにemail_templates JSONBカラム追加
- getEmailTemplates()ヘルパー関数追加
- notify-waitlistで署名・フッターをテンプレートから取得

## カスタマイズ可能項目
- greeting: メール冒頭の挨拶文
- signature: メール末尾の署名
- footer: 追加情報

## 適用方法
```sql
-- 017_organization_email_templates.sql を実行
```