### PR TITLE
feat: 前日リマインドメールのCronジョブを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
     <!-- Preload 重要リソース（本番ビルド後のファイル名に合わせて調整） -->
     <!-- 注意: ビルド後に生成されるハッシュ付きファイル名は自動的に処理されます -->
     
-    <!-- DNS Prefetch: Supabase への接続を事前解決 -->
-    <link rel="dns-prefetch" href="https://bgztzakvjzudvdmfyhyh.supabase.co" />
-    <link rel="preconnect" href="https://bgztzakvjzudvdmfyhyh.supabase.co" crossorigin />
+    <!-- DNS Prefetch: Supabase への接続を事前解決（本番プロジェクト） -->
+    <link rel="dns-prefetch" href="https://cznpcewciwywcqcxktba.supabase.co" />
+    <link rel="preconnect" href="https://cznpcewciwywcqcxktba.supabase.co" crossorigin />
   </head>
   <body>
     <div id="root"></div>
@@ -23,6 +23,9 @@
       // インラインなのでバンドルキャッシュに依存しない
       (function(){
         if (sessionStorage.getItem('_vck')) return; // 無限ループ防止
+        // 認証トークンがURLに含まれている場合はリロードしない（Supabase のフローを妨げない）
+        var h = location.hash || '';
+        if (h.indexOf('access_token=') !== -1 || h.indexOf('refresh_token=') !== -1 || h.indexOf('error=') !== -1) return;
         var scripts = document.querySelectorAll('script[type="module"][src]');
         var hash = null;
         for (var i = 0; i < scripts.length; i++) {

--- a/src/components/schedule/modal/ReservationList.tsx
+++ b/src/components/schedule/modal/ReservationList.tsx
@@ -18,6 +18,7 @@ import { supabase } from '@/lib/supabase'
 import { logger } from '@/utils/logger'
 import { recalculateCurrentParticipants } from '@/lib/participantUtils'
 import { getSafeErrorMessage } from '@/lib/apiErrorHandler'
+import { ACTIVE_RESERVATION_STATUSES, ACTIVE_RESERVATION_STATUSES_SET } from '@/lib/constants'
 import { showToast } from '@/utils/toast'
 import { findMatchingStaff } from '@/utils/staffUtils'
 import { getCurrentOrganizationId } from '@/lib/organization'
@@ -149,11 +150,9 @@ ${content.organizationName || '店舗'}
   })
   const [customerNames, setCustomerNames] = useState<string[]>([])
 
-  const ACTIVE_RESERVATION_STATUSES = new Set(['pending', 'confirmed', 'gm_confirmed', 'checked_in'])
-
   const sumActiveParticipants = (list: Reservation[]) =>
     list.reduce((sum, r) => {
-      if (!r?.status || !ACTIVE_RESERVATION_STATUSES.has(r.status)) return sum
+      if (!r?.status || !ACTIVE_RESERVATION_STATUSES_SET.has(r.status)) return sum
       return sum + (r.participant_count || 0)
     }, 0)
 
@@ -357,8 +356,8 @@ ${content.organizationName || '店舗'}
       )
       
       if (event?.id) {
-        const wasActive = ACTIVE_RESERVATION_STATUSES.has(oldStatus)
-        const isActive = ACTIVE_RESERVATION_STATUSES.has(newStatus)
+        const wasActive = ACTIVE_RESERVATION_STATUSES_SET.has(oldStatus)
+        const isActive = ACTIVE_RESERVATION_STATUSES_SET.has(newStatus)
         
         // アクティブ状態が変わる場合、またはチェックインの場合は再計算
         // （checked_in は pending/confirmed/gm_confirmed と同様にカウントするため）
@@ -1068,7 +1067,7 @@ ${content.organizationName || '店舗'}
                         .from('reservations')
                         .select('participant_count')
                         .eq('schedule_event_id', event.id)
-                        .in('status', ['pending', 'confirmed', 'gm_confirmed'])
+                        .in('status', [...ACTIVE_RESERVATION_STATUSES])
                       
                       const totalParticipants = updatedReservationsData?.reduce((sum, r) => sum + (r.participant_count || 0), 0) || 0
                       

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react'
-import { supabase, type AuthUser } from '@/lib/supabase'
+import { supabase, type AuthUser, sessionBackupJson } from '@/lib/supabase'
 import { authTrace, logger } from '@/utils/logger'
 import type { User } from '@supabase/supabase-js'
 import { determineUserRole } from '@/utils/authUtils'
@@ -141,6 +141,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const isProcessingRef = React.useRef<boolean>(false)
   // 最後のトークンリフレッシュ時間（重複リフレッシュ防止）
   const lastRefreshRef = React.useRef<number>(0)
+  // 明示的ログアウト中フラグ（SIGNED_OUT でリカバリーを試みないようにする）
+  const isExplicitSignOutRef = React.useRef<boolean>(false)
+  // セッション復元の試行済みフラグ（無限ループ防止）
+  const recoveryAttemptedRef = React.useRef<boolean>(false)
   // 複数タブ間の同期用BroadcastChannel
   const broadcastChannelRef = React.useRef<BroadcastChannel | null>(null)
   
@@ -218,6 +222,34 @@ export function AuthProvider({ children }: AuthProviderProps) {
     } catch (err) {
       logger.error('❌ セッションリフレッシュ例外:', err)
     }
+  }, [])
+
+  // デプロイ後のリロードでトークンリフレッシュが失敗した場合のリカバリー。
+  // Supabase クライアント初期化前に保存したバックアップから refresh_token を取り出し、
+  // setSession() で再認証を試みる。
+  const tryRecoverSession = useCallback(async (): Promise<boolean> => {
+    if (!sessionBackupJson) return false
+    try {
+      const backup = JSON.parse(sessionBackupJson)
+      if (!backup?.refresh_token) return false
+      authTrace('🔄 バックアップからセッション復元を試行')
+      const { data, error } = await supabase.auth.setSession({
+        access_token: backup.access_token ?? '',
+        refresh_token: backup.refresh_token,
+      })
+      if (!error && data.session?.user) {
+        authTrace('✅ セッション復元成功')
+        await setUserFromSession(data.session.user)
+        setLoading(false)
+        setIsInitialized(true)
+        return true
+      }
+      authTrace('❌ セッション復元失敗:', error?.message)
+    } catch (err) {
+      authTrace('❌ セッション復元例外:', err)
+    }
+    return false
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setUserFromSession は安定
   }, [])
 
   useEffect(() => {
@@ -346,6 +378,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
             setIsInitialized(true)  // エラーでも完了とみなす
           })
         } else {
+          // SIGNED_OUT でユーザーが設定済みの場合（デプロイ後のリロードでトークンリフレッシュが
+          // 失敗したケースなど）、バックアップからのリカバリーを試みる。
+          // ただし以下の場合はスキップ:
+          // - 明示的にログアウトした場合（isExplicitSignOutRef）
+          // - 既にリカバリーを試行済みの場合（無限ループ防止）
+          if (event === 'SIGNED_OUT' && userRef.current
+              && !isExplicitSignOutRef.current
+              && !recoveryAttemptedRef.current) {
+            recoveryAttemptedRef.current = true
+            authTrace('⚠️ SIGNED_OUT だがユーザー設定済み、リカバリーを試行')
+            const recovered = await tryRecoverSession()
+            if (recovered) {
+              recoveryAttemptedRef.current = false
+              return
+            }
+          }
+          
           setUser(null)
           userRef.current = null
           setStaffCache(new Map())  // セッション終了時にキャッシュもクリア
@@ -400,6 +449,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
           case 'SIGNED_OUT':
             // 他のタブでログアウトした場合、このタブもログアウト状態にする
             authTrace('🚪 他タブでログアウト検出、このタブもログアウト')
+            isExplicitSignOutRef.current = true
             setUser(null)
             userRef.current = null
             setStaffCache(new Map())  // キャッシュもクリア
@@ -465,7 +515,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
             const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession()
             if (refreshError) {
               logger.warn('⚠️ リフレッシュ失敗:', refreshError.message)
-              // リフレッシュ失敗でも、既存セッションがあれば続行
             } else if (refreshData.session) {
               session = refreshData.session
               authTrace('✅ セッションリフレッシュ成功')
@@ -488,8 +537,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
             return
           }
         } catch (refreshErr) {
-          authTrace('⏭️ リフレッシュ復元失敗（未ログイン状態）')
+          authTrace('⏭️ リフレッシュ復元失敗')
         }
+        
+        // SDK の refreshSession も失敗した場合、クライアント初期化前に保存した
+        // バックアップ（supabase.ts で保存）から復元を試みる。
+        // デプロイ後のリロードで autoRefreshToken が旧トークンを消費→
+        // レスポンス受信前にリロード→新トークン未保存、という競合で
+        // localStorage のセッションが消えるケースに対応。
+        const recovered = await tryRecoverSession()
+        if (recovered) return
+        
         authTrace('👤 セッションユーザーなし')
       }
     } catch (error) {
@@ -1001,6 +1059,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   async function signOut() {
     setLoading(true)
+    isExplicitSignOutRef.current = true
     const currentUserId = userRef.current?.id ?? null
     const currentUserRole = userRef.current?.role
     
@@ -1039,6 +1098,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       window.location.href = `/${slug}`
     } catch (error) {
       setLoading(false)
+      isExplicitSignOutRef.current = false
       throw error
     } finally {
       setLoading(false)

--- a/src/hooks/useEventOperations.ts
+++ b/src/hooks/useEventOperations.ts
@@ -219,6 +219,7 @@ interface Scenario {
   duration?: number
   player_count_max?: number
   extra_preparation_time?: number // 準備時間（分）
+  scenario_master_id?: string | null
 }
 
 interface UseEventOperationsProps {
@@ -1045,6 +1046,7 @@ export function useEventOperations({
         const matchedScenario = scenarios.find(s => s.title === performanceData.scenario)
         
         // 内部形式に変換して状態に追加
+        const effectiveMax = matchedScenario?.player_count_max || savedEvent.capacity || 8
         const formattedEvent: ScheduleEvent = {
           id: savedEvent.id,
           date: savedEvent.date,
@@ -1062,7 +1064,7 @@ export function useEventOperations({
           category: savedEvent.category,
           is_cancelled: savedEvent.is_cancelled || false,
           current_participants: savedEvent.current_participants || 0,
-          max_participants: savedEvent.capacity || 8,
+          max_participants: effectiveMax,
           notes: savedEvent.notes || ''
         }
         

--- a/src/hooks/useEventOperations.ts
+++ b/src/hooks/useEventOperations.ts
@@ -111,6 +111,101 @@ function checkTimeOverlap(
   return { overlap: false }
 }
 
+/**
+ * スケジュールイベントの日程・時間変更時に、関連データを同期する。
+ * 1. reservations.requested_datetime を schedule_events に合わせて更新
+ * 2. 貸切グループの候補日（private_group_candidate_dates）を更新
+ */
+async function syncRelatedDataOnEventDateChange(
+  eventId: string,
+  oldDate: string,
+  oldStartTime: string,
+  newDate: string,
+  newStartTime: string,
+  newEndTime: string,
+  newTimeSlotSchedule: string | null,
+  organizationId: string | null
+): Promise<void> {
+  try {
+    // 1. 紐づく全予約の requested_datetime を同期
+    const newRequestedDatetime = `${newDate}T${newStartTime}+09:00`
+    let resQuery = supabase
+      .from('reservations')
+      .select('id, private_group_id')
+      .eq('schedule_event_id', eventId)
+    if (organizationId) {
+      resQuery = resQuery.eq('organization_id', organizationId)
+    }
+    const { data: reservations } = await resQuery
+    if (!reservations || reservations.length === 0) return
+
+    for (const reservation of reservations) {
+      const { error: resUpdateError } = await supabase
+        .from('reservations')
+        .update({ requested_datetime: newRequestedDatetime })
+        .eq('id', reservation.id)
+      if (resUpdateError) {
+        logger.error('予約の requested_datetime 同期エラー:', resUpdateError)
+      } else {
+        logger.log('✅ 予約の requested_datetime を同期:', {
+          reservationId: reservation.id,
+          newRequestedDatetime,
+        })
+      }
+
+      // 2. 貸切グループの候補日を同期
+      if (!reservation.private_group_id) continue
+
+      const { data: candidates } = await supabase
+        .from('private_group_candidate_dates')
+        .select('id, date, start_time')
+        .eq('group_id', reservation.private_group_id)
+        .eq('date', oldDate)
+      if (!candidates || candidates.length === 0) continue
+
+      let targetCandidate = candidates[0]
+      for (const c of candidates) {
+        if (c.start_time === oldStartTime) {
+          targetCandidate = c
+          break
+        }
+      }
+
+      // schedule_events の time_slot(朝/昼/夜) → candidate_dates の time_slot(午前/午後/夜間)
+      let candidateTimeSlot: string | undefined
+      if (newTimeSlotSchedule === '朝') candidateTimeSlot = '午前'
+      else if (newTimeSlotSchedule === '昼') candidateTimeSlot = '午後'
+      else if (newTimeSlotSchedule === '夜') candidateTimeSlot = '夜間'
+
+      const updatePayload: Record<string, string> = {
+        date: newDate,
+        start_time: newStartTime,
+        end_time: newEndTime,
+      }
+      if (candidateTimeSlot) {
+        updatePayload.time_slot = candidateTimeSlot
+      }
+
+      const { error: cdUpdateError } = await supabase
+        .from('private_group_candidate_dates')
+        .update(updatePayload)
+        .eq('id', targetCandidate.id)
+
+      if (cdUpdateError) {
+        logger.error('貸切グループ候補日の同期エラー:', cdUpdateError)
+      } else {
+        logger.log('✅ 貸切グループ候補日を同期:', {
+          groupId: reservation.private_group_id,
+          oldDate,
+          newDate,
+        })
+      }
+    }
+  } catch (err) {
+    logger.error('日程変更時の関連データ同期でエラー:', err)
+  }
+}
+
 interface Store {
   id: string
   name: string
@@ -484,6 +579,20 @@ export function useEventOperations({
               logger.error('貸切公演移動後の顧客メール送信エラー:', notifyErr)
             }
           }
+        }
+
+        // 関連データを同期（日程・時間が変更された場合）
+        if (draggedEvent.date !== dropTarget.date || draggedEvent.start_time !== startTime || draggedEvent.end_time !== endTime) {
+          await syncRelatedDataOnEventDateChange(
+            draggedEvent.id,
+            draggedEvent.date,
+            draggedEvent.start_time,
+            dropTarget.date,
+            startTime,
+            endTime,
+            timeSlotLabel,
+            organizationId
+          )
         }
 
         // ローカル状態を更新（scenariosは元のイベントから保持）
@@ -1206,6 +1315,20 @@ export function useEventOperations({
           }
           
           await scheduleApi.update(performanceData.id, updateData)
+
+          // 関連データを同期（日程・時間が変更された場合）
+          if (oldEventData && (oldEventData.date !== updateData.date || oldEventData.start_time !== updateData.start_time || oldEventData.end_time !== updateData.end_time)) {
+            await syncRelatedDataOnEventDateChange(
+              performanceData.id!,
+              oldEventData.date,
+              oldEventData.start_time,
+              updateData.date,
+              updateData.start_time,
+              updateData.end_time,
+              updateData.time_slot || null,
+              organizationId
+            )
+          }
 
           const notifySchedulePrivateCustomer =
             !!performanceData.reservation_id &&

--- a/src/hooks/usePlayedScenarios.ts
+++ b/src/hooks/usePlayedScenarios.ts
@@ -44,7 +44,7 @@ export function usePlayedScenarios() {
         .from('reservations')
         .select('scenario_master_id')
         .eq('customer_id', customer.id)
-        .in('status', ['confirmed', 'gm_confirmed'])
+        .not('status', 'in', '("cancelled","no_show")')
         .lte('requested_datetime', new Date().toISOString())
 
       reservations?.forEach(r => {

--- a/src/hooks/useScheduleData.ts
+++ b/src/hooks/useScheduleData.ts
@@ -54,6 +54,7 @@ export async function addDemoParticipantsToPastUnderfullEvents(): Promise<{ succ
         date,
         venue,
         scenario,
+        scenario_master_id,
         gms,
         start_time,
         end_time,
@@ -61,7 +62,10 @@ export async function addDemoParticipantsToPastUnderfullEvents(): Promise<{ succ
         is_cancelled,
         current_participants,
         capacity,
-        organization_id
+        organization_id,
+        scenario_masters:scenario_master_id (
+          player_count_max
+        )
       `)
       .eq('organization_id', orgId)
       .lte('date', today.toISOString().split('T')[0])
@@ -79,11 +83,32 @@ export async function addDemoParticipantsToPastUnderfullEvents(): Promise<{ succ
       return { success: 0, failed: 0, skipped: 0 }
     }
     
+    // 組織のシナリオデータを取得（player_count_max のオーバーライド反映）
+    const { data: orgScenarios } = await supabase
+      .from('organization_scenarios_with_master')
+      .select('id, title, player_count_max')
+      .eq('organization_id', orgId)
+    
+    const orgScenarioMap = new Map<string, number>()
+    if (orgScenarios) {
+      for (const row of orgScenarios) {
+        if (row.player_count_max) {
+          orgScenarioMap.set(row.id, row.player_count_max)
+          if (row.title) orgScenarioMap.set(row.title, row.player_count_max)
+        }
+      }
+    }
+    
     logger.log(`対象公演: ${pastEvents.length}件`)
     
     for (const event of pastEvents) {
       const currentParticipants = event.current_participants || 0
-      const maxParticipants = event.capacity || 8
+      const scenarioMasterData = event.scenario_masters as { player_count_max?: number } | null
+      const maxParticipants = (event.scenario_master_id && orgScenarioMap.get(event.scenario_master_id))
+        || (event.scenario && orgScenarioMap.get(event.scenario))
+        || scenarioMasterData?.player_count_max
+        || event.capacity
+        || 8
       
       // 定員に達している場合はスキップ
       if (currentParticipants >= maxParticipants) {
@@ -956,18 +981,22 @@ export function useScheduleData(currentDate: Date) {
                     ? confirmedStoreId 
                     : '' // 店舗未定
                   
+                  const privateScenarioTitle = request.scenario_masters?.title || request.title
+                  const orgPrivateScenarioInfo = findScenario(privateScenarioTitle)
+                  const privateMaxParticipants = orgPrivateScenarioInfo?.player_count_max || request.scenario_masters?.player_count_max || 8
+                  
                   const privateEvent: ScheduleEvent = {
                     id: `${request.id}-${candidate.order}`,
                     date: candidate.date,
                     venue: venueId,
-                    scenario: request.scenario_masters?.title || request.title,
+                    scenario: privateScenarioTitle,
                     gms: gmNames,
                     start_time: candidate.startTime || '',
                     end_time: candidate.endTime || '',
                     category: 'private', // 貸切
                     is_cancelled: false,
                     current_participants: request.participant_count || 0, // Reservationのparticipant_countをScheduleEventのcurrent_participantsに変換
-                    max_participants: request.scenario_masters?.player_count_max || 8,
+                    max_participants: privateMaxParticipants,
                     notes: `【貸切${request.status === 'confirmed' ? '確定' : request.status === 'gm_confirmed' ? 'GM確認済' : '希望'}】`,
                     is_reservation_enabled: true, // 貸切公演は常に公開中
                     is_private_request: true, // 貸切リクエストフラグ
@@ -1333,18 +1362,22 @@ export function useScheduleData(currentDate: Date) {
                   ? confirmedStoreId 
                   : ''
                 
+                const privateScenarioTitle2 = request.scenario_masters?.title || request.title
+                const orgPrivateScenarioInfo2 = findScenario2(privateScenarioTitle2)
+                const privateMaxParticipants2 = orgPrivateScenarioInfo2?.player_count_max || request.scenario_masters?.player_count_max || 8
+                
                 const privateEvent: ScheduleEvent = {
                   id: `${request.id}-${candidate.order}`,
                   date: candidate.date,
                   venue: venueId,
-                  scenario: request.scenario_masters?.title || request.title,
+                  scenario: privateScenarioTitle2,
                   gms: gmNames,
                   start_time: candidate.startTime || '',
                   end_time: candidate.endTime || '',
                   category: 'private',
                   is_cancelled: false,
                   current_participants: request.participant_count || 0,
-                  max_participants: request.scenario_masters?.player_count_max || 8,
+                  max_participants: privateMaxParticipants2,
                   notes: `【貸切${request.status === 'confirmed' ? '確定' : request.status === 'gm_confirmed' ? 'GM確認済' : '希望'}】`,
                   is_reservation_enabled: true,
                   is_private_request: true,

--- a/src/lib/api/couponApi.ts
+++ b/src/lib/api/couponApi.ts
@@ -1075,6 +1075,111 @@ export async function searchCustomers(
 }
 
 /**
+ * クーポン使用を取り消して残数を復元する（管理者向け）
+ * coupon_usages を削除し、customer_coupons.uses_remaining を +1 する
+ */
+export async function restoreCouponUsage(
+  couponUsageId: string,
+  customerCouponId: string
+): Promise<{ success: boolean; error?: string }> {
+  const orgId = await getCurrentOrganizationId()
+  if (!orgId) {
+    return { success: false, error: '組織IDが取得できません' }
+  }
+
+  const { data: coupon, error: couponError } = await supabase
+    .from('customer_coupons')
+    .select('id, uses_remaining, status')
+    .eq('id', customerCouponId)
+    .eq('organization_id', orgId)
+    .single()
+
+  if (couponError || !coupon) {
+    logger.error('クーポン取得エラー:', couponError)
+    return { success: false, error: 'クーポンが見つかりません' }
+  }
+
+  const { error: deleteError } = await supabase
+    .from('coupon_usages')
+    .delete()
+    .eq('id', couponUsageId)
+    .eq('customer_coupon_id', customerCouponId)
+
+  if (deleteError) {
+    logger.error('クーポン使用記録削除エラー:', deleteError)
+    return { success: false, error: '使用記録の削除に失敗しました' }
+  }
+
+  const { error: updateError } = await supabase
+    .from('customer_coupons')
+    .update({
+      uses_remaining: coupon.uses_remaining + 1,
+      status: 'active',
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', customerCouponId)
+    .eq('organization_id', orgId)
+
+  if (updateError) {
+    logger.error('クーポン残数復元エラー:', updateError)
+    return { success: false, error: '残数の復元に失敗しました' }
+  }
+
+  logger.log(`✅ クーポン使用取り消し: usage=${couponUsageId}, coupon=${customerCouponId}`)
+  return { success: true }
+}
+
+/**
+ * 顧客クーポンの使用履歴を取得（管理者向け）
+ */
+export async function getCouponUsagesForAdmin(
+  customerCouponId: string
+): Promise<Array<{
+  id: string
+  reservation_id: string | null
+  discount_amount: number
+  used_at: string
+  reservation_title: string | null
+}>> {
+  const orgId = await getCurrentOrganizationId()
+  if (!orgId) return []
+
+  const { data: coupon } = await supabase
+    .from('customer_coupons')
+    .select('id')
+    .eq('id', customerCouponId)
+    .eq('organization_id', orgId)
+    .single()
+
+  if (!coupon) return []
+
+  const { data, error } = await supabase
+    .from('coupon_usages')
+    .select(`
+      id,
+      reservation_id,
+      discount_amount,
+      used_at,
+      reservations:reservation_id (title)
+    `)
+    .eq('customer_coupon_id', customerCouponId)
+    .order('used_at', { ascending: false })
+
+  if (error) {
+    logger.error('クーポン使用履歴取得エラー:', error)
+    return []
+  }
+
+  return (data || []).map((row: any) => ({
+    id: row.id,
+    reservation_id: row.reservation_id,
+    discount_amount: row.discount_amount,
+    used_at: row.used_at,
+    reservation_title: row.reservations?.title || null
+  }))
+}
+
+/**
  * キャンペーンに紐づくクーポン一覧を取得（顧客情報付き）
  */
 export async function getCampaignCoupons(

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -43,6 +43,55 @@ interface ScheduleEvent {
   timeSlot?: string
 }
 
+/**
+ * organization_scenarios_with_master ビューから player_count_max を取得し、
+ * scenario_master_id と title の両方でルックアップできる Map を返す。
+ * scenario_masters の値ではなく、組織オーバーライドを反映した正しい値を取得する。
+ */
+async function getOrgScenarioPlayerCounts(organizationId?: string | null): Promise<Map<string, number>> {
+  const orgId = organizationId || await getCurrentOrganizationId()
+  if (!orgId) return new Map()
+
+  const { data } = await supabase
+    .from('organization_scenarios_with_master')
+    .select('id, title, player_count_max')
+    .eq('organization_id', orgId)
+
+  const map = new Map<string, number>()
+  if (data) {
+    for (const row of data as { id: string; title: string; player_count_max: number }[]) {
+      if (row.player_count_max) {
+        map.set(row.id, row.player_count_max)
+        if (row.title) {
+          map.set(row.title, row.player_count_max)
+        }
+      }
+    }
+  }
+  return map
+}
+
+/**
+ * イベントの正しい最大参加者数を解決する。
+ * 優先順位: org override (by id) → org override (by title) → master JOIN → event fields → fallback
+ */
+function resolveMaxParticipants(
+  event: { scenario_master_id?: string | null; scenario?: string; scenario_masters?: unknown; max_participants?: number; capacity?: number },
+  orgScenarioMap: Map<string, number>
+): number {
+  if (event.scenario_master_id && orgScenarioMap.has(event.scenario_master_id)) {
+    return orgScenarioMap.get(event.scenario_master_id)!
+  }
+  if (event.scenario && orgScenarioMap.has(event.scenario)) {
+    return orgScenarioMap.get(event.scenario)!
+  }
+  const scenarioData = event.scenario_masters as { player_count_max?: number } | null
+  if (scenarioData?.player_count_max) {
+    return scenarioData.player_count_max
+  }
+  return event.max_participants || event.capacity || 8
+}
+
 // シナリオ名のエイリアスマッピング（表記ゆれ対応）
 const SCENARIO_ALIAS: Record<string, string> = {
   '真渋谷陰陽奇譚': '真・渋谷陰陽奇譚',
@@ -298,12 +347,13 @@ export const scheduleApi = {
       })
     }
 
+    const orgScenarioMap = await getOrgScenarioPlayerCounts(orgId)
+
     const myEvents = scheduleEvents.map(event => {
       const reservations = reservationsMap.get(event.id) || []
       const actualParticipants = reservations.reduce((sum, r) => sum + (r.participant_count || 0), 0)
       
-      const scenarioData = event.scenario_masters as { player_count_max?: number } | null
-      const maxParticipants = scenarioData?.player_count_max || event.max_participants || event.capacity || 8
+      const maxParticipants = resolveMaxParticipants(event, orgScenarioMap)
 
       return {
         ...event,
@@ -440,6 +490,8 @@ export const scheduleApi = {
     }
     
     // 各イベントの実際の参加者数を計算
+    const orgIdForScenarios = organizationId || await getCurrentOrganizationId()
+    const orgScenarioMap = await getOrgScenarioPlayerCounts(orgIdForScenarios || undefined)
 
     const eventsWithActualParticipants = scheduleEvents.map((event) => {
       const reservations = reservationsMap.get(event.id) || []
@@ -478,14 +530,7 @@ export const scheduleApi = {
         }
       }
       
-      // 予約から計算した参加者数が現在の値より大きい場合のみ更新
-      // （手動で設定した「満席」状態が上書きされないようにする）
-      // ただし、max_participantsを超えないようにする
-      const scenarioForSync = event.scenario_masters as { player_count_max?: number } | null
-      const maxForSync = scenarioForSync?.player_count_max ||
-                        event.max_participants ||
-                        event.capacity ||
-                        8
+      const maxForSync = resolveMaxParticipants(event, orgScenarioMap)
       const cappedActualParticipants = Math.min(actualParticipants, maxForSync)
 
       // 予約が存在する公演は、予約テーブル（active集計）を single source of truth として同期する
@@ -511,13 +556,7 @@ export const scheduleApi = {
           })
       }
       
-      const scenarioData2 = event.scenario_masters as { player_count_max?: number } | null
-      const scenarioMaxPlayers = scenarioData2?.player_count_max
-      
-      const maxParticipants = scenarioMaxPlayers ||
-                              event.max_participants ||
-                              event.capacity ||
-                              8
+      const maxParticipants = maxForSync
       
       // 表示用の参加者数
       // - 予約がある公演: 実予約数（active）を表示（キャンセルで減るのも反映）
@@ -628,6 +667,10 @@ export const scheduleApi = {
               const scenarioData = Array.isArray(booking.scenario_masters) ? booking.scenario_masters[0] : booking.scenario_masters
               const candidateTimeSlot = candidate.timeSlot || ''
               
+              const privateMaxParticipants = resolveMaxParticipants(
+                { scenario_master_id: scenarioData?.id, scenario: scenarioData?.title, scenario_masters: scenarioData },
+                orgScenarioMap
+              )
               privateEvents.push({
                 id: `private-${booking.id}-${candidate.order}`,
                 date: candidateDateStr,
@@ -641,8 +684,8 @@ export const scheduleApi = {
                 is_cancelled: false,
                 is_reservation_enabled: true,
                 current_participants: booking.participant_count,
-                max_participants: scenarioData?.player_count_max || 8,
-                capacity: scenarioData?.player_count_max || 8,
+                max_participants: privateMaxParticipants,
+                capacity: privateMaxParticipants,
                 gms: gmNames,
                 stores: booking.stores,
                 scenarios: scenarioData,
@@ -792,6 +835,8 @@ export const scheduleApi = {
       participantsByEventId.set(eventId, (participantsByEventId.get(eventId) || 0) + count)
     })
     
+    const orgScenarioMapForScenario = await getOrgScenarioPlayerCounts(orgId)
+
     const eventsWithActualParticipants = scheduleEvents.map((event) => {
       const actualParticipants = participantsByEventId.get(event.id) || 0
       
@@ -812,12 +857,7 @@ export const scheduleApi = {
           })
       }
       
-      const scenarioData3 = event.scenario_masters as { player_count_max?: number } | null
-      const scenarioMaxPlayers = scenarioData3?.player_count_max
-      const maxParticipants = scenarioMaxPlayers ||
-                              event.max_participants ||
-                              event.capacity ||
-                              8
+      const maxParticipants = resolveMaxParticipants(event, orgScenarioMapForScenario)
       
       // 現在の値と予約から計算した値の大きい方を使用
       const effectiveParticipants = Math.max(actualParticipants, event.current_participants || 0)
@@ -1155,6 +1195,7 @@ export const scheduleApi = {
       
       logger.log(`${events.length}件の公演をチェックします`)
       
+      const orgScenarioMapForDemo = await getOrgScenarioPlayerCounts(orgId)
       let successCount = 0
       let errorCount = 0
       
@@ -1182,8 +1223,11 @@ export const scheduleApi = {
           const reservedParticipants = reservations?.reduce((sum, reservation) => 
             sum + (reservation.participant_count || 0), 0) || 0
           
-          // 定員
-          const capacity = event.capacity || event.max_participants || 8
+          // 定員（organization_scenarios_with_master のオーバーライドを反映）
+          const capacity = resolveMaxParticipants(
+            { scenario_master_id: event.scenario_master_id, scenario: event.scenario, max_participants: event.max_participants, capacity: event.capacity },
+            orgScenarioMapForDemo
+          )
           
           // デモ参加者が既に存在するかチェック
           const hasDemoParticipant = reservations?.some(r => 

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -7,6 +7,7 @@ import { supabase } from '../supabase'
 import { logger } from '@/utils/logger'
 import { getCurrentOrganizationId } from '@/lib/organization'
 import { recalculateCurrentParticipants } from '@/lib/participantUtils'
+import { ACTIVE_RESERVATION_STATUSES, ACTIVE_RESERVATION_STATUSES_SET } from '@/lib/constants'
 
 // 候補日時の型定義
 interface CandidateDateTime {
@@ -439,7 +440,6 @@ export const scheduleApi = {
     }
     
     // 各イベントの実際の参加者数を計算
-    const ACTIVE_STATUSES = new Set(['confirmed', 'pending', 'gm_confirmed', 'checked_in'])
 
     const eventsWithActualParticipants = scheduleEvents.map((event) => {
       const reservations = reservationsMap.get(event.id) || []
@@ -448,7 +448,7 @@ export const scheduleApi = {
       // ※ cancelled のみのケースでも reservations は存在し得るが、人数計算は active のみで行う
       const hasAnyReservations = reservations.length > 0
       const actualParticipants = reservations.reduce((sum, reservation) => {
-        if (!reservation.status || !ACTIVE_STATUSES.has(reservation.status)) return sum
+        if (!reservation.status || !ACTIVE_RESERVATION_STATUSES_SET.has(reservation.status)) return sum
         return sum + (reservation.participant_count || 0)
       }, 0)
       
@@ -1164,7 +1164,7 @@ export const scheduleApi = {
             .from('reservations')
             .select('participant_count, participant_names')
             .eq('schedule_event_id', event.id)
-            .in('status', ['confirmed', 'pending'])
+            .in('status', [...ACTIVE_RESERVATION_STATUSES])
           
           if (reservationError) {
             if (reservationError.code !== 'PGRST116') {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * 予約ステータスの共通定義
+ *
+ * DBトリガー (recalc_current_participants_for_event) と一致させること。
+ * 変更時はマイグレーションのトリガー定義も合わせて更新が必要。
+ */
+export const ACTIVE_RESERVATION_STATUSES = ['pending', 'confirmed', 'gm_confirmed', 'checked_in'] as const
+
+export const ACTIVE_RESERVATION_STATUSES_SET = new Set<string>(ACTIVE_RESERVATION_STATUSES)

--- a/src/lib/participantUtils.ts
+++ b/src/lib/participantUtils.ts
@@ -8,6 +8,7 @@
 
 import { supabase } from './supabase'
 import { logger } from '@/utils/logger'
+import { ACTIVE_RESERVATION_STATUSES } from './constants'
 
 /**
  * 🚨 CRITICAL: 公演の参加者数を予約テーブルから再計算して更新
@@ -20,12 +21,11 @@ import { logger } from '@/utils/logger'
  */
 export async function recalculateCurrentParticipants(eventId: string): Promise<number> {
   try {
-    // 有効な予約（pending, confirmed, gm_confirmed, checked_in）の参加者数を集計
     const { data: reservations, error: fetchError } = await supabase
       .from('reservations')
       .select('participant_count')
       .eq('schedule_event_id', eventId)
-      .in('status', ['pending', 'confirmed', 'gm_confirmed', 'checked_in'])
+      .in('status', [...ACTIVE_RESERVATION_STATUSES])
 
     if (fetchError) {
       logger.error('予約データ取得エラー:', fetchError)
@@ -68,7 +68,7 @@ export async function getCurrentParticipantsCount(eventId: string): Promise<numb
       .from('reservations')
       .select('participant_count')
       .eq('schedule_event_id', eventId)
-      .in('status', ['pending', 'confirmed', 'gm_confirmed', 'checked_in'])
+      .in('status', [...ACTIVE_RESERVATION_STATUSES])
 
     if (error) {
       logger.error('予約データ取得エラー:', error)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -44,6 +44,16 @@ try {
   // noop
 }
 
+// デプロイ後のリロードでセッションが失われた場合のリカバリー用バックアップ。
+// Supabase クライアントの _initialize() がトークンリフレッシュに失敗すると
+// localStorage からセッションを削除するため、事前にバックアップしておく。
+const AUTH_STORAGE_KEY = 'mmq-supabase-auth'
+let _sessionBackupJson: string | null = null
+try {
+  _sessionBackupJson = localStorage.getItem(AUTH_STORAGE_KEY)
+} catch { /* SSR / private browsing */ }
+export const sessionBackupJson = _sessionBackupJson
+
 export const supabase = createClient(supabaseUrl, supabaseKey, {
   auth: {
     // セッションを永続化

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -134,28 +134,20 @@ function showUpdateBanner(): void {
   })
 }
 
-// Service Worker を解除するのは基本的に開発時のみ
-// 本番で毎回キャッシュを削除すると表示速度が落ちるため、必要な場合だけ明示的に無効化する
-const shouldDisableServiceWorker =
-  import.meta.env.DEV || import.meta.env.VITE_DISABLE_SW === 'true'
-
-if (shouldDisableServiceWorker && 'serviceWorker' in navigator) {
-  // すべての Service Worker を解除
+// PWA プラグインは現在使用していないため、古い Service Worker が残っている場合は常に解除する。
+// 古い SW がナビゲーションリクエストをキャッシュしていると、デプロイ後に古い HTML が返され、
+// バージョンチェックリロードと Supabase のトークンリフレッシュが競合してログインが切れる原因になる。
+if ('serviceWorker' in navigator) {
   navigator.serviceWorker.getRegistrations().then((registrations) => {
     for (const registration of registrations) {
       registration.unregister()
-      console.log('🧹 Service Worker unregistered')
     }
   })
 
-  // workbox のキャッシュを削除
   if ('caches' in window) {
     caches.keys().then((cacheNames) => {
       cacheNames.forEach((cacheName) => {
-        if (cacheName.includes('workbox')) {
-          caches.delete(cacheName)
-          console.log('🧹 Cache deleted:', cacheName)
-        }
+        caches.delete(cacheName)
       })
     })
   }

--- a/src/pages/CouponManagement/components/CampaignStats.tsx
+++ b/src/pages/CouponManagement/components/CampaignStats.tsx
@@ -6,6 +6,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -17,9 +27,16 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { Loader2, Gift, Users, CheckCircle, Ticket } from 'lucide-react'
-import { getCampaignStats, getCampaignCoupons, type CampaignStats as StatsType } from '@/lib/api/couponApi'
+import { Loader2, Gift, Users, CheckCircle, Ticket, ChevronDown, ChevronUp, RotateCcw } from 'lucide-react'
+import {
+  getCampaignStats,
+  getCampaignCoupons,
+  getCouponUsagesForAdmin,
+  restoreCouponUsage,
+  type CampaignStats as StatsType,
+} from '@/lib/api/couponApi'
 import type { CouponCampaign, CustomerCoupon } from '@/types'
+import { toast } from 'sonner'
 
 interface CampaignStatsProps {
   open: boolean
@@ -31,6 +48,14 @@ type CouponWithCustomer = CustomerCoupon & {
   customers?: { name: string; email: string } 
 }
 
+interface UsageRecord {
+  id: string
+  reservation_id: string | null
+  discount_amount: number
+  used_at: string
+  reservation_title: string | null
+}
+
 export function CampaignStats({
   open,
   onOpenChange,
@@ -39,6 +64,11 @@ export function CampaignStats({
   const [stats, setStats] = useState<StatsType | null>(null)
   const [coupons, setCoupons] = useState<CouponWithCustomer[]>([])
   const [isLoading, setIsLoading] = useState(false)
+  const [expandedCouponId, setExpandedCouponId] = useState<string | null>(null)
+  const [usages, setUsages] = useState<Record<string, UsageRecord[]>>({})
+  const [usageLoading, setUsageLoading] = useState<string | null>(null)
+  const [restoreTarget, setRestoreTarget] = useState<{ usageId: string; couponId: string; title: string | null } | null>(null)
+  const [restoring, setRestoring] = useState(false)
 
   const loadData = useCallback(async () => {
     if (!campaign) return
@@ -59,8 +89,48 @@ export function CampaignStats({
   useEffect(() => {
     if (open && campaign) {
       loadData()
+      setExpandedCouponId(null)
+      setUsages({})
     }
   }, [open, campaign, loadData])
+
+  const handleToggleUsages = async (couponId: string) => {
+    if (expandedCouponId === couponId) {
+      setExpandedCouponId(null)
+      return
+    }
+    setExpandedCouponId(couponId)
+    if (!usages[couponId]) {
+      setUsageLoading(couponId)
+      try {
+        const data = await getCouponUsagesForAdmin(couponId)
+        setUsages(prev => ({ ...prev, [couponId]: data }))
+      } finally {
+        setUsageLoading(null)
+      }
+    }
+  }
+
+  const handleRestore = async () => {
+    if (!restoreTarget) return
+    setRestoring(true)
+    try {
+      const result = await restoreCouponUsage(restoreTarget.usageId, restoreTarget.couponId)
+      if (result.success) {
+        toast.success('クーポン使用を取り消しました')
+        setUsages(prev => ({
+          ...prev,
+          [restoreTarget.couponId]: (prev[restoreTarget.couponId] || []).filter(u => u.id !== restoreTarget.usageId)
+        }))
+        await loadData()
+      } else {
+        toast.error(result.error || '復元に失敗しました')
+      }
+    } finally {
+      setRestoring(false)
+      setRestoreTarget(null)
+    }
+  }
 
   if (!campaign) return null
 
@@ -70,6 +140,17 @@ export function CampaignStats({
       year: 'numeric',
       month: '2-digit',
       day: '2-digit'
+    })
+  }
+
+  const formatDateTime = (dateStr: string) => {
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
     })
   }
 
@@ -89,109 +170,187 @@ export function CampaignStats({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
-        <DialogHeader>
-          <DialogTitle>キャンペーン統計</DialogTitle>
-          <DialogDescription>
-            「{campaign.name}」の付与・使用状況
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+          <DialogHeader>
+            <DialogTitle>キャンペーン統計</DialogTitle>
+            <DialogDescription>
+              「{campaign.name}」の付与・使用状況
+            </DialogDescription>
+          </DialogHeader>
 
-        {isLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          </div>
-        ) : (
-          <div className="flex-1 overflow-hidden flex flex-col space-y-4">
-            {stats && (
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                <div className="p-3 bg-muted rounded-lg">
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
-                    <Users className="h-4 w-4" />
-                    付与数
-                  </div>
-                  <div className="text-2xl font-bold">{stats.totalGranted}</div>
-                </div>
-                <div className="p-3 bg-muted rounded-lg">
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
-                    <CheckCircle className="h-4 w-4" />
-                    使用回数
-                  </div>
-                  <div className="text-2xl font-bold">{stats.totalUsed}</div>
-                </div>
-                <div className="p-3 bg-muted rounded-lg">
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
-                    <Ticket className="h-4 w-4" />
-                    残り回数
-                  </div>
-                  <div className="text-2xl font-bold">{stats.totalRemaining}</div>
-                </div>
-                <div className="p-3 bg-muted rounded-lg">
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
-                    <Gift className="h-4 w-4" />
-                    割引総額
-                  </div>
-                  <div className="text-2xl font-bold">¥{stats.totalDiscountAmount.toLocaleString()}</div>
-                </div>
-              </div>
-            )}
-
-            <div className="flex-1 overflow-hidden">
-              <h4 className="font-medium mb-2">付与済みクーポン一覧</h4>
-              {coupons.length === 0 ? (
-                <div className="text-center py-8 text-muted-foreground">
-                  まだクーポンが付与されていません
-                </div>
-              ) : (
-                <ScrollArea className="h-[300px] border rounded-md">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>顧客</TableHead>
-                        <TableHead className="w-[80px]">残り回数</TableHead>
-                        <TableHead className="w-[100px]">状態</TableHead>
-                        <TableHead className="w-[100px]">有効期限</TableHead>
-                        <TableHead className="w-[100px]">付与日</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {coupons.map((coupon) => (
-                        <TableRow key={coupon.id}>
-                          <TableCell>
-                            <div>
-                              <div className="font-medium">
-                                {coupon.customers?.name || '不明'}
-                              </div>
-                              <div className="text-xs text-muted-foreground">
-                                {coupon.customers?.email || ''}
-                              </div>
-                            </div>
-                          </TableCell>
-                          <TableCell>{coupon.uses_remaining}</TableCell>
-                          <TableCell>{getStatusBadge(coupon.status)}</TableCell>
-                          <TableCell className="text-sm">
-                            {coupon.expires_at ? formatDate(coupon.expires_at) : '-'}
-                          </TableCell>
-                          <TableCell className="text-sm">
-                            {formatDate(coupon.created_at)}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </ScrollArea>
-              )}
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
             </div>
-          </div>
-        )}
+          ) : (
+            <div className="flex-1 overflow-hidden flex flex-col space-y-4">
+              {stats && (
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                  <div className="p-3 bg-muted rounded-lg">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+                      <Users className="h-4 w-4" />
+                      付与数
+                    </div>
+                    <div className="text-2xl font-bold">{stats.totalGranted}</div>
+                  </div>
+                  <div className="p-3 bg-muted rounded-lg">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+                      <CheckCircle className="h-4 w-4" />
+                      使用回数
+                    </div>
+                    <div className="text-2xl font-bold">{stats.totalUsed}</div>
+                  </div>
+                  <div className="p-3 bg-muted rounded-lg">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+                      <Ticket className="h-4 w-4" />
+                      残り回数
+                    </div>
+                    <div className="text-2xl font-bold">{stats.totalRemaining}</div>
+                  </div>
+                  <div className="p-3 bg-muted rounded-lg">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+                      <Gift className="h-4 w-4" />
+                      割引総額
+                    </div>
+                    <div className="text-2xl font-bold">¥{stats.totalDiscountAmount.toLocaleString()}</div>
+                  </div>
+                </div>
+              )}
 
-        <div className="flex justify-end pt-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            閉じる
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+              <div className="flex-1 overflow-hidden">
+                <h4 className="font-medium mb-2">付与済みクーポン一覧</h4>
+                {coupons.length === 0 ? (
+                  <div className="text-center py-8 text-muted-foreground">
+                    まだクーポンが付与されていません
+                  </div>
+                ) : (
+                  <ScrollArea className="h-[350px] border rounded-md">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>顧客</TableHead>
+                          <TableHead className="w-[80px]">残り回数</TableHead>
+                          <TableHead className="w-[80px]">状態</TableHead>
+                          <TableHead className="w-[90px]">有効期限</TableHead>
+                          <TableHead className="w-[60px]">履歴</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {coupons.map((coupon) => (
+                          <>
+                            <TableRow
+                              key={coupon.id}
+                              className="cursor-pointer hover:bg-muted/50"
+                              onClick={() => handleToggleUsages(coupon.id)}
+                            >
+                              <TableCell>
+                                <div>
+                                  <div className="font-medium">
+                                    {coupon.customers?.name || '不明'}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {coupon.customers?.email || ''}
+                                  </div>
+                                </div>
+                              </TableCell>
+                              <TableCell>{coupon.uses_remaining}</TableCell>
+                              <TableCell>{getStatusBadge(coupon.status)}</TableCell>
+                              <TableCell className="text-sm">
+                                {coupon.expires_at ? formatDate(coupon.expires_at) : '-'}
+                              </TableCell>
+                              <TableCell>
+                                <Button variant="ghost" size="icon" className="h-7 w-7">
+                                  {expandedCouponId === coupon.id
+                                    ? <ChevronUp className="h-4 w-4" />
+                                    : <ChevronDown className="h-4 w-4" />}
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                            {expandedCouponId === coupon.id && (
+                              <TableRow key={`${coupon.id}-usages`}>
+                                <TableCell colSpan={5} className="p-0">
+                                  <div className="bg-muted/30 px-4 py-3">
+                                    <div className="text-xs font-medium text-muted-foreground mb-2">使用履歴</div>
+                                    {usageLoading === coupon.id ? (
+                                      <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+                                        <Loader2 className="h-3 w-3 animate-spin" />
+                                        読み込み中...
+                                      </div>
+                                    ) : (usages[coupon.id] || []).length === 0 ? (
+                                      <div className="text-xs text-muted-foreground py-1">使用履歴なし</div>
+                                    ) : (
+                                      <div className="space-y-1">
+                                        {(usages[coupon.id] || []).map((usage) => (
+                                          <div key={usage.id} className="flex items-center justify-between text-xs bg-background rounded px-3 py-2 border">
+                                            <div className="flex items-center gap-3 min-w-0">
+                                              <span className="text-muted-foreground whitespace-nowrap">{formatDateTime(usage.used_at)}</span>
+                                              <span className="truncate">{usage.reservation_title || '予約なし'}</span>
+                                              <span className="font-medium text-red-500 whitespace-nowrap">-¥{usage.discount_amount.toLocaleString()}</span>
+                                            </div>
+                                            <Button
+                                              variant="outline"
+                                              size="sm"
+                                              className="h-6 px-2 text-xs ml-2 flex-shrink-0"
+                                              onClick={(e) => {
+                                                e.stopPropagation()
+                                                setRestoreTarget({
+                                                  usageId: usage.id,
+                                                  couponId: coupon.id,
+                                                  title: usage.reservation_title
+                                                })
+                                              }}
+                                            >
+                                              <RotateCcw className="h-3 w-3 mr-1" />
+                                              復元
+                                            </Button>
+                                          </div>
+                                        ))}
+                                      </div>
+                                    )}
+                                  </div>
+                                </TableCell>
+                              </TableRow>
+                            )}
+                          </>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </ScrollArea>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end pt-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              閉じる
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={!!restoreTarget} onOpenChange={(open) => { if (!open) setRestoreTarget(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>クーポン使用を取り消しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              {restoreTarget?.title
+                ? `「${restoreTarget.title}」で使用されたクーポンを復元します。`
+                : 'このクーポン使用を取り消して、残数を1回分復元します。'}
+              この操作は元に戻せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={restoring}>キャンセル</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRestore} disabled={restoring}>
+              {restoring ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+              復元する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }

--- a/src/pages/PlatformTop/index.tsx
+++ b/src/pages/PlatformTop/index.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/utils/logger'
 import { formatDateJST } from '@/utils/dateUtils'
-import { Search, ChevronRight, ChevronDown, ChevronUp, Sparkles, Building2, Calendar, Filter, Flame, FileText, X, Gift, RefreshCw } from 'lucide-react'
+import { Search, ChevronRight, ChevronDown, ChevronUp, Sparkles, Building2, Calendar, Filter, Flame, FileText, X, Gift, RefreshCw, HelpCircle } from 'lucide-react'
 import { Footer } from '@/components/layout/Footer'
 import { useAuth } from '@/contexts/AuthContext'
 import { useFavorites } from '@/hooks/useFavorites'
@@ -22,7 +22,6 @@ import { saveScrollPositionForCurrentUrl } from '@/hooks/useScrollRestoration'
 import { useReportRouteScrollRestoration } from '@/contexts/RouteScrollRestorationContext'
 import { MYPAGE_THEME as THEME } from '@/lib/theme'
 import { ScenarioCard, type ScenarioCardData } from '@/pages/PublicBookingTop/components/ScenarioCard'
-import { HowToUseGuide } from '@/pages/PublicBookingTop/components/HowToUseGuide'
 
 // シナリオカード用の型（直近公演情報を含む）- ScenarioCardDataを拡張
 interface ScenarioWithEvents extends ScenarioCardData {
@@ -172,7 +171,6 @@ export function PlatformTop() {
     () => displaySnapshotOnMount?.blogPosts ?? []
   )
   const [showCouponPopup, setShowCouponPopup] = useState(false)
-  const [isGuideOpen, setIsGuideOpen] = useState(false)
 
   // クーポンポップアップ表示判定（非ログインユーザー & 非表示設定なし）
   useEffect(() => {
@@ -699,17 +697,16 @@ export function PlatformTop() {
                   ログイン / 新規登録
                 </Button>
               )}
-            </div>
-
-            {/* 使い方リンク */}
-            <div className="mt-4">
-              <button
-                onClick={() => setIsGuideOpen(true)}
-                className="inline-flex items-center gap-1.5 text-white/70 hover:text-white text-sm transition-colors"
+              <Button
+                size="lg"
+                variant="ghost"
+                className="border-2 border-white/50 text-white hover:bg-white/10 hover:text-white px-8 h-14 text-lg"
+                style={{ borderRadius: 0 }}
+                onClick={() => navigate('/guide')}
               >
-                <span className="w-5 h-5 rounded-full border border-white/40 flex items-center justify-center text-xs font-bold">?</span>
-                使い方
-              </button>
+                <HelpCircle className="w-5 h-5 mr-2" />
+                はじめての方へ
+              </Button>
             </div>
 
             {/* 新規登録キャンペーンバナー（コンパクト版）- 未ログインユーザーのみ表示 */}
@@ -1096,12 +1093,6 @@ export function PlatformTop() {
       {/* フッター */}
       <Footer />
 
-      {/* 使い方ガイドポップアップ */}
-      <HowToUseGuide
-        organizationName={null}
-        isOpen={isGuideOpen}
-        onClose={() => setIsGuideOpen(false)}
-      />
 
       {/* クーポンキャンペーンポップアップ */}
       {showCouponPopup && (

--- a/src/pages/PrivateBookingRequest/index.tsx
+++ b/src/pages/PrivateBookingRequest/index.tsx
@@ -75,6 +75,14 @@ export function PrivateBookingRequest({
   // 編集可能な候補日時
   const [editableTimeSlots, setEditableTimeSlots] = useState(initialTimeSlots)
 
+  // 親コンポーネントが非同期で selectedTimeSlots を更新した場合に同期
+  // （PrivateBookingRequestPage 経由のフローで初回マウント時に空→非同期で充填されるケース）
+  useEffect(() => {
+    if (initialTimeSlots.length > 0) {
+      setEditableTimeSlots(prev => prev.length === 0 ? initialTimeSlots : prev)
+    }
+  }, [initialTimeSlots])
+
   useEffect(() => {
     setEditableTimeSlots((prev) => prev.map((ts) => ({ ...ts, slot: enrichSlotEnd(ts.date, ts.slot) })))
   }, [enrichSlotEnd])
@@ -402,6 +410,17 @@ export function PrivateBookingRequest({
             <div>
               <div className="flex items-center justify-between mb-3">
                 <h2 className="text-base font-semibold">候補日時（{editableTimeSlots.length}/{MAX_TIME_SLOTS}件）</h2>
+                {!showAddForm && editableTimeSlots.length < MAX_TIME_SLOTS && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowAddForm(true)}
+                    className="text-purple-600 hover:text-purple-800 hover:bg-purple-50 h-8 px-2"
+                  >
+                    <Plus className="w-4 h-4 mr-1" />
+                    追加
+                  </Button>
+                )}
               </div>
               
               {/* 追加フォーム */}

--- a/src/pages/PublicBookingTop/components/CalendarView.tsx
+++ b/src/pages/PublicBookingTop/components/CalendarView.tsx
@@ -188,6 +188,11 @@ export const CalendarView = memo(function CalendarView({
                     const allDisplayEvents = allMergedEvents.filter((event: any) => {
                       const isPrivate = event.category === 'private' || event.is_private_booking === true
                       const isGm = event.category === 'gmtest' || event.category === 'testplay'
+                      if (hideSoldOut && (isPrivate || isGm)) return false
+                      if (hidePlayed && (isPrivate || isGm)) {
+                        const smId = event.scenario_master_id || event.scenario_id
+                        if (smId && playedScenarioIds.has(smId)) return false
+                      }
                       if (isPrivate || isGm) return true
                       if (hideSoldOut) {
                         const max = event.player_count_max || 8

--- a/src/pages/PublicBookingTop/components/ListView.tsx
+++ b/src/pages/PublicBookingTop/components/ListView.tsx
@@ -128,6 +128,11 @@ export const ListView = memo(function ListView({
     const allEvents = allMerged.filter((ev: any) => {
       const isPrivate = ev.category === 'private' || ev.is_private_booking === true
       const isGm = ev.category === 'gmtest' || ev.category === 'testplay'
+      if (hideSoldOut && (isPrivate || isGm)) return false
+      if (hidePlayed && (isPrivate || isGm)) {
+        const smId = ev.scenario_master_id || ev.scenario_id
+        if (smId && playedScenarioIds.has(smId)) return false
+      }
       if (isPrivate || isGm) return true
       if (hideSoldOut) {
         const max = ev.player_count_max || 8

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -7,7 +7,7 @@ import { NavigationBar } from '@/components/layout/NavigationBar'
 import { useAuth } from '@/contexts/AuthContext'
 import { getColorFromName } from '@/lib/utils'
 import { BOOKING_THEME, MYPAGE_THEME as THEME } from '@/lib/theme'
-import { Sparkles, MapPin, Store, BookOpen, Flame, RefreshCw } from 'lucide-react'
+import { Sparkles, MapPin, Store, BookOpen, Flame, RefreshCw, HelpCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useBookingData } from './hooks/useBookingData'
 import { useCalendarData } from './hooks/useCalendarData'
@@ -26,7 +26,6 @@ import { CalendarView } from './components/CalendarView'
 import { ListView } from './components/ListView'
 import { ScenarioCard } from './components/ScenarioCard'
 import { Footer } from '@/components/layout/Footer'
-import { HowToUseGuide, HowToUseButton, useHowToUseGuide } from './components/HowToUseGuide'
 import { getOptimizedImageUrl } from '@/utils/imageUtils'
 
 /** DB の紹介文が空のときのデフォルト（queens-waltz） */
@@ -53,7 +52,6 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
   const listMonthStorageKey = `booking-${bookingViewPersistSlug}-list-month`
   
   // 使い方ガイド
-  const { isGuideOpen, openGuide, closeGuide } = useHowToUseGuide()
   
   // タブ状態（URLパスと連携）
   const [activeTab, setActiveTab] = useState(() => {
@@ -406,15 +404,24 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
                     </span>
                   )}
                 </div>
-                {orgInfo.storeCount > 0 && (
+                <div className="flex items-center gap-2">
                   <button
-                    onClick={() => document.getElementById('store-access')?.scrollIntoView({ behavior: 'smooth' })}
+                    onClick={() => navigate('/guide')}
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-white/15 hover:bg-white/25 text-white transition-colors"
                   >
-                    <MapPin className="w-3 h-3" />
-                    アクセス
+                    <HelpCircle className="w-3 h-3" />
+                    はじめての方へ
                   </button>
-                )}
+                  {orgInfo.storeCount > 0 && (
+                    <button
+                      onClick={() => document.getElementById('store-access')?.scrollIntoView({ behavior: 'smooth' })}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-white/15 hover:bg-white/25 text-white transition-colors"
+                    >
+                      <MapPin className="w-3 h-3" />
+                      アクセス
+                    </button>
+                  )}
+                </div>
               </div>
             )}
           </div>
@@ -443,17 +450,10 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
               <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
               <span className="hidden sm:inline text-xs">更新</span>
             </Button>
-            <HowToUseButton onClick={openGuide} />
           </div>
         </div>
       </div>
 
-      {/* 使い方ガイド */}
-      <HowToUseGuide 
-        organizationName={organizationName}
-        isOpen={isGuideOpen}
-        onClose={closeGuide}
-      />
 
       {/* 残りわずか公演 */}
       {!isLoading && nearlyConfirmed.length > 0 && (

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -454,57 +454,55 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
         </div>
       </div>
 
-
-      {/* 残りわずか公演 */}
-      {!isLoading && nearlyConfirmed.length > 0 && (
-        <section className="container mx-auto max-w-7xl px-4 md:px-6 pt-6 md:pt-8">
-          <div className="flex items-center justify-between mb-4 flex-wrap gap-4">
-            <h2 className="text-lg md:text-xl font-bold text-gray-900 flex items-center gap-3">
-              <Flame className="w-5 h-5 text-orange-500" />
-              残りわずか
-              <span 
-                className="w-10 h-1 ml-2"
-                style={{ backgroundColor: '#f97316' }}
-              />
-              <span className="text-xs font-normal text-orange-600 bg-orange-50 px-2 py-0.5 rounded-full">
-                お早めに！
-              </span>
-            </h2>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
-            {nearlyConfirmed.map((scenario) => (
-              <ScenarioCard
-                key={`nearly-${scenario.scenario_id}`}
-                scenario={scenario}
-                onClick={(slugOrId) => {
-                  // 残りわずかのイベント日付・時間を渡す（next_eventsの先頭が残りわずかのイベント）
-                  const nearlyFullEvent = scenario.next_events?.[0]
-                  handleCardClick(slugOrId, nearlyFullEvent?.date, nearlyFullEvent?.time)
-                }}
-                isFavorite={isFavorite(scenario.scenario_id)}
-                isPlayed={isPlayed(scenario.scenario_id)}
-                onToggleFavorite={handleToggleFavorite}
-                onTogglePlayed={(id, title, e) => {
-                  e.stopPropagation()
-                  if (!user) { showToast.error('ログインが必要です'); return }
-                  if (isPlayed(id)) { showToast.info('既に体験済みとして登録されています'); return }
-                  setPlayedDialogTarget({ id, title })
-                }}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      <div className="container mx-auto max-w-7xl px-4 md:px-6 py-4">
+      <div className="container mx-auto max-w-7xl px-4 md:px-6 pt-4 pb-4 md:pt-6">
         {/* パフォーマンス最適化: ローディング中でもUIを即座に表示 */}
-          <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-            <TabsList className="grid w-full max-w-sm mx-auto grid-cols-3 mb-4 p-0.5 h-auto">
-              <TabsTrigger value="lineup" className="text-sm px-2 py-1.5">ラインナップ</TabsTrigger>
-              <TabsTrigger value="calendar" className="text-sm px-2 py-1.5">カレンダー</TabsTrigger>
-              <TabsTrigger value="list" className="text-sm px-2 py-1.5">リスト</TabsTrigger>
-            </TabsList>
+        <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
+          <TabsList className="grid w-full max-w-sm mx-auto grid-cols-3 mb-4 md:mb-6 p-0.5 h-auto">
+            <TabsTrigger value="lineup" className="text-sm px-2 py-1.5">ラインナップ</TabsTrigger>
+            <TabsTrigger value="calendar" className="text-sm px-2 py-1.5">カレンダー</TabsTrigger>
+            <TabsTrigger value="list" className="text-sm px-2 py-1.5">リスト</TabsTrigger>
+          </TabsList>
+
+          {/* 残りわずか公演（タブの直下） */}
+          {!isLoading && nearlyConfirmed.length > 0 && (
+            <section className="mb-6 md:mb-8">
+              <div className="flex items-center justify-between mb-4 flex-wrap gap-4">
+                <h2 className="text-lg md:text-xl font-bold text-gray-900 flex items-center gap-3">
+                  <Flame className="w-5 h-5 text-orange-500" />
+                  残りわずか
+                  <span
+                    className="w-10 h-1 ml-2"
+                    style={{ backgroundColor: '#f97316' }}
+                  />
+                  <span className="text-xs font-normal text-orange-600 bg-orange-50 px-2 py-0.5 rounded-full">
+                    お早めに！
+                  </span>
+                </h2>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
+                {nearlyConfirmed.map((scenario) => (
+                  <ScenarioCard
+                    key={`nearly-${scenario.scenario_id}`}
+                    scenario={scenario}
+                    onClick={(slugOrId) => {
+                      const nearlyFullEvent = scenario.next_events?.[0]
+                      handleCardClick(slugOrId, nearlyFullEvent?.date, nearlyFullEvent?.time)
+                    }}
+                    isFavorite={isFavorite(scenario.scenario_id)}
+                    isPlayed={isPlayed(scenario.scenario_id)}
+                    onToggleFavorite={handleToggleFavorite}
+                    onTogglePlayed={(id, title, e) => {
+                      e.stopPropagation()
+                      if (!user) { showToast.error('ログインが必要です'); return }
+                      if (isPlayed(id)) { showToast.info('既に体験済みとして登録されています'); return }
+                      setPlayedDialogTarget({ id, title })
+                    }}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
 
             {/* ラインナップ表示 */}
             <TabsContent value="lineup">

--- a/src/pages/static/GuidePage.tsx
+++ b/src/pages/static/GuidePage.tsx
@@ -596,7 +596,9 @@ export function GuidePage() {
             <p className="text-sm text-gray-600">特定の店舗のシナリオ・公演だけを表示します。遊ぶ店舗が決まっているときに便利です。</p>
           </div>
         </div>
-        <Annotation>どちらのページにも「ラインナップ」「カレンダー」「リスト」の3つのタブがあります</Annotation>
+        <Annotation>
+          各店舗・組織の予約ページ（店舗トップ）では「ラインナップ」「カレンダー」「リスト」の3つのタブで探せます。MMQトップ（全店まとめ）はタブではなく、公演ラインナップを一覧で見る構成です。
+        </Annotation>
       </section>
 
       <hr className="max-w-3xl mx-auto border-gray-200" />

--- a/src/pages/static/GuidePage.tsx
+++ b/src/pages/static/GuidePage.tsx
@@ -1,149 +1,1420 @@
 /**
  * 初めての方へ / 使い方ガイドページ
  * @path /guide
- * 組織トップのHowToUseGuideと同じ内容を表示
+ * 実際のUIコンポーネントを使ったインタラクティブなマニュアル
  */
+import { useState } from 'react'
 import { PublicLayout } from '@/components/layout/PublicLayout'
 import { MYPAGE_THEME as THEME } from '@/lib/theme'
 import { Button } from '@/components/ui/button'
-import { 
-  BookOpen, ChevronRight, Calendar, Clock, Users, HelpCircle, ArrowRight
+import { Card } from '@/components/ui/card'
+import {
+  ChevronRight, Calendar, Clock, Users, HelpCircle, ArrowRight,
+  Heart, CheckCheck, MousePointerClick, UserPlus, Settings, MessageCircle,
+  Search, BookOpen
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
+interface DemoEvent {
+  time: string
+  title: string
+  store: string
+  storeColor: string
+  imageUrl: string
+  players: number
+  seats: number
+  isConfirmed?: boolean
+}
+
+const DEMO_EVENTS: Record<string, DemoEvent[]> = {
+  '8': [
+    { time: '13:00', title: 'ある悪魔の儀式について', store: '仮設②', storeColor: '#8B5CF6', imageUrl: 'https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1761045982620-7i7qma.webp', players: 6, seats: 6 },
+    { time: '13:30', title: 'ツイン号沈没事故に関する考察', store: '大久保', storeColor: '#F97316', imageUrl: 'https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1770997291378-pa5zir.jpg', players: 6, seats: 6 },
+    { time: '19:00', title: 'クロノフォビア', store: '仮設②', storeColor: '#8B5CF6', imageUrl: 'https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1761045864807-7xn1uf.webp', players: 7, seats: 7 },
+    { time: '19:30', title: '荒廃のマリス', store: '馬場', storeColor: '#3B82F6', imageUrl: 'https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1761047653055-kg6xfr.webp', players: 7, seats: 7 },
+  ],
+  '9': [
+    { time: '13:00', title: '白いウサギは歌わない', store: '馬場', storeColor: '#3B82F6', imageUrl: 'https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1770883605761-6jmuke.jpg', players: 8, seats: 3, isConfirmed: true },
+  ],
+}
+
+interface DemoScenario {
+  title: string
+  author: string
+  duration: number
+  playerMin: number
+  playerMax: number
+  fee: number
+  badge?: string
+  badgeColor?: string
+  imageUrl?: string
+  events: Array<{
+    date: string
+    weekday: string
+    time: string
+    store: string
+    storeColor: string
+    seats: number
+    isConfirmed?: boolean
+  }>
+}
+
+const SAMPLE_SCENARIOS: DemoScenario[] = [
+  {
+    title: '白いウサギは歌わない',
+    author: 'とんとん',
+    duration: 240,
+    playerMin: 8,
+    playerMax: 8,
+    fee: 4000,
+    badge: 'おすすめ',
+    badgeColor: THEME.primary,
+    imageUrl: 'https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1770883605761-6jmuke.jpg',
+    events: [
+      { date: '4/19', weekday: '土', time: '13:00', store: '高田馬場', storeColor: '#3B82F6', seats: 3 },
+      { date: '4/26', weekday: '土', time: '18:00', store: '大久保', storeColor: '#F97316', seats: 5 },
+    ],
+  },
+  {
+    title: 'テセウスの方舟',
+    author: 'ほがらか',
+    duration: 240,
+    playerMin: 7,
+    playerMax: 7,
+    fee: 4500,
+    badge: '成立間近！',
+    badgeColor: '#DC2626',
+    imageUrl: 'https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1761046043728-lblb6.webp',
+    events: [
+      { date: '4/20', weekday: '日', time: '12:00', store: '別館①', storeColor: '#22C55E', seats: 1, isConfirmed: true },
+    ],
+  },
+]
+
+function DemoScenarioCard({ scenario }: { scenario: DemoScenario }) {
+  const formatDuration = (min: number) =>
+    min >= 60
+      ? `${Math.floor(min / 60)}h${min % 60 > 0 ? `${min % 60}m` : ''}`
+      : `${min}分`
+
+  return (
+    <div className="group">
+      <div className="relative bg-white overflow-hidden border border-gray-200 flex md:flex-col" style={{ borderRadius: 0 }}>
+        <div className="relative w-32 md:w-full aspect-[3/4] overflow-hidden flex-shrink-0 bg-gray-900">
+          {scenario.imageUrl ? (
+            <img src={scenario.imageUrl} alt={scenario.title} className="absolute inset-0 w-full h-full object-contain" loading="lazy" />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
+              <span className="text-white/20 text-4xl font-bold select-none">{scenario.title.charAt(0)}</span>
+            </div>
+          )}
+          {scenario.badge && (
+            <div className="absolute bottom-0 left-0 px-3 py-1 text-xs font-bold text-white" style={{ backgroundColor: scenario.badgeColor }}>
+              {scenario.badge}
+            </div>
+          )}
+        </div>
+        <div className="p-2 sm:p-3 flex-1 min-w-0">
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs text-gray-500">{scenario.author}</p>
+            <div className="flex items-center gap-0.5">
+              <CheckCheck className="h-4 w-4 text-gray-300" />
+              <Heart className="h-4 w-4 text-red-500 fill-red-500 opacity-100" />
+            </div>
+          </div>
+          <h3 className="text-sm font-bold text-gray-900 leading-snug mb-2 line-clamp-2">{scenario.title}</h3>
+          <div className="flex items-center gap-3 text-xs text-gray-600 mb-2">
+            <span className="flex items-center gap-1"><Users className="h-3 w-3" />{scenario.playerMax}人</span>
+            <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{formatDuration(scenario.duration)}</span>
+            <span>¥{scenario.fee.toLocaleString()}〜</span>
+          </div>
+          <div className="border-t border-gray-100 pt-2 space-y-1">
+            {scenario.events.map((event, i) => (
+              <div key={i} className="flex items-center justify-between text-xs">
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <span className="w-1 h-4 flex-shrink-0" style={{ backgroundColor: event.storeColor }} />
+                  <span className="font-medium text-gray-900">
+                    {event.date}
+                    <span className={`ml-0.5 font-normal ${event.weekday === '日' ? 'text-red-500' : event.weekday === '土' ? 'text-blue-500' : 'text-gray-400'}`}>({event.weekday})</span>
+                  </span>
+                  <span className="text-gray-500">{event.time}</span>
+                  <span className="text-gray-400 truncate">{event.store}</span>
+                </div>
+                <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+                  {event.isConfirmed && <span className="text-[10px] font-bold px-1.5 py-0.5 bg-blue-100 text-blue-700" style={{ borderRadius: 0 }}>開催決定</span>}
+                  <span className="text-[10px] font-bold px-1.5 py-0.5" style={{
+                    backgroundColor: event.seats <= 2 ? '#FEE2E2' : THEME.accentLight,
+                    color: event.seats <= 2 ? '#DC2626' : THEME.accent, borderRadius: 0,
+                  }}>残{event.seats}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CalendarEventCell({ event }: { event: DemoEvent }) {
+  return (
+    <div
+      className="text-xs border-l-2 cursor-pointer"
+      style={{ borderLeftColor: event.storeColor, backgroundColor: `${event.storeColor}15`, padding: '2px 3px' }}
+    >
+      <div className="flex gap-1">
+        <div className="hidden sm:block flex-shrink-0 w-[40px] overflow-hidden bg-gray-200" style={{ aspectRatio: '1 / 1.4' }}>
+          <img src={event.imageUrl} alt="" className="w-full h-full object-cover" loading="lazy" />
+        </div>
+        <div className="flex flex-col gap-0 flex-1 min-w-0 justify-between">
+          <div className="text-xs leading-tight" style={{ color: event.storeColor }}>{event.time.slice(0, 5)}</div>
+          <div className="text-xs leading-tight" style={{ color: event.storeColor }}>{event.store}</div>
+          <div className="text-xs leading-tight text-gray-800 overflow-hidden whitespace-nowrap" style={{ textOverflow: 'clip' }}>{event.title}</div>
+          <div className="text-xs leading-tight flex items-center gap-1">
+            {event.isConfirmed && <span className="text-[8px] font-bold px-0.5 py-0.5 bg-blue-100 text-blue-700">開催決定</span>}
+            <span className="text-gray-600">残{event.seats}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StepNumber({ n }: { n: number }) {
+  return (
+    <div className="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center text-white font-bold text-lg" style={{ backgroundColor: THEME.primary }}>
+      {n}
+    </div>
+  )
+}
+
+function Annotation({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-2 px-3 py-2 bg-amber-50 border border-amber-200 text-amber-800 text-xs sm:text-sm rounded-lg">
+      <MousePointerClick className="w-4 h-4 flex-shrink-0 mt-0.5" />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+function PostGroupSteps({ startStep }: { startStep: number }) {
+  return (
+    <>
+      {/* 共通: グループ作成後のフロー */}
+      <div className="relative mt-2 mb-2 flex items-center gap-2">
+        <div className="flex-1 border-t border-purple-200" />
+        <span className="text-xs font-medium text-purple-600 bg-purple-50 px-3 py-1 rounded-full">▼ グループ作成後の共通フロー</span>
+        <div className="flex-1 border-t border-purple-200" />
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">{startStep}</span>
+          <p className="text-sm font-bold text-gray-900">チャット画面から招待リンクを共有</p>
+        </div>
+        <p className="text-sm text-gray-600 mb-1 pl-8">グループが作成されるとチャット画面が開きます。ヘッダーの <strong className="text-purple-700">＋</strong> アイコンから招待リンクを共有しましょう。</p>
+        <p className="text-sm text-gray-500 mb-3 pl-8">※ メンバーが全員揃っていなくても、リクエストの送信や日程調整は進められます。後から招待もOKです。</p>
+        <div className="ml-8 space-y-3">
+          <DemoFrame label="グループチャット画面">
+            <div className="flex items-center gap-2.5 border-b pb-2 mb-2">
+              <span className="text-gray-400 text-sm">←</span>
+              <img src="https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1770883605761-6jmuke.jpg" alt="" className="w-7 h-7 rounded object-cover flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-medium truncate">白いウサギは歌わない</p>
+                <p className="text-[10px] text-gray-500">1名参加 • 進捗 0/5</p>
+              </div>
+              <div className="flex items-center gap-1">
+                <span className="w-7 h-7 flex items-center justify-center rounded ring-2 ring-purple-400 bg-purple-50">
+                  <UserPlus className="w-4 h-4 text-purple-600" />
+                </span>
+                <span className="w-7 h-7 flex items-center justify-center rounded text-gray-400">
+                  <Calendar className="w-4 h-4" />
+                </span>
+              </div>
+            </div>
+            <div className="h-16 flex items-center justify-center text-xs text-gray-400">
+              チャットでメンバーと相談できます
+            </div>
+          </DemoFrame>
+          <p className="text-xs text-purple-700 font-medium">↓ ＋アイコンをタップすると招待シートが開きます</p>
+          <DemoFrame label="メンバー招待シート">
+            <div className="flex justify-center mb-1">
+              <div className="w-8 h-1 bg-gray-300 rounded-full" />
+            </div>
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-semibold">メンバー招待・管理</p>
+              <span className="text-gray-400 text-sm">✕</span>
+            </div>
+            <div className="space-y-2.5">
+              <p className="text-sm font-medium text-gray-700">招待リンク</p>
+              <div className="flex items-center gap-2">
+                <div className="flex-1 h-9 rounded border border-gray-200 px-3 flex items-center text-xs text-gray-500 bg-gray-50 truncate">
+                  https://mmq.jp/group/invite/abc123...
+                </div>
+                <button className="px-2.5 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-200 rounded flex-shrink-0">コピー</button>
+              </div>
+              <button className="w-full py-2 text-sm font-medium text-[#06C755] bg-white border border-[#06C755] rounded flex items-center justify-center gap-1.5">
+                LINEで共有
+              </button>
+            </div>
+          </DemoFrame>
+        </div>
+        <Annotation>招待リンクを受け取った人は、ログインしてグループに参加できます</Annotation>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">{startStep + 1}</span>
+          <p className="text-sm font-bold text-gray-900">メンバーが候補日に回答</p>
+        </div>
+        <p className="text-sm text-gray-600 mb-3 pl-8">各候補日に「○ OK / △ 微妙 / × NG」で回答します。チャット機能で相談もできます。</p>
+        <div className="ml-8">
+          <DemoFrame label="参加者の画面イメージ">
+            <h4 className="font-medium text-sm mb-2">候補日程（3件）</h4>
+            <div className="space-y-2">
+              {[
+                { n: 1, date: '4月19日(土)', slot: '夜 18:00 - 22:00', ok: 3, maybe: 0, ng: 0, resp: 3, myResp: 'ok' as string | null },
+                { n: 2, date: '4月20日(日)', slot: '昼 13:00 - 17:00', ok: 1, maybe: 1, ng: 1, resp: 3, myResp: 'maybe' as string | null },
+                { n: 3, date: '4月26日(土)', slot: '昼 13:00 - 17:00', ok: 2, maybe: 1, ng: 0, resp: 3, myResp: null as string | null },
+              ].map((cd) => (
+                <div key={cd.n} className="px-2.5 py-2 rounded-md bg-gray-50">
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="flex-1 min-w-0 leading-tight">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-[10px] leading-none bg-purple-100 text-purple-700 px-1 py-0.5 rounded">{cd.n}</span>
+                        <span className="font-medium text-sm">{cd.date}</span>
+                      </div>
+                      <div className="text-xs text-gray-500 mt-0.5">{cd.slot}</div>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <div className="flex items-center justify-end gap-1 text-xs">
+                        <span className="text-green-600">○{cd.ok}</span>
+                        <span className="text-amber-600">△{cd.maybe}</span>
+                        <span className="text-red-600">×{cd.ng}</span>
+                      </div>
+                      <div className="text-[10px] text-gray-400 mt-0.5">{cd.resp}/3人</div>
+                    </div>
+                  </div>
+                  <div className="flex gap-1.5">
+                    <span className={`flex-1 py-1.5 rounded-md text-xs font-medium text-center ${cd.myResp === 'ok' ? 'bg-green-500 text-white' : 'bg-white border border-gray-200 text-gray-600'}`}>○ OK</span>
+                    <span className={`flex-1 py-1.5 rounded-md text-xs font-medium text-center ${cd.myResp === 'maybe' ? 'bg-amber-500 text-white' : 'bg-white border border-gray-200 text-gray-600'}`}>△ 微妙</span>
+                    <span className={`flex-1 py-1.5 rounded-md text-xs font-medium text-center ${cd.myResp === 'ng' ? 'bg-red-500 text-white' : 'bg-white border border-gray-200 text-gray-600'}`}>× NG</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </DemoFrame>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">{startStep + 2}</span>
+          <p className="text-sm font-bold text-gray-900">店舗が日程を確定</p>
+        </div>
+        <p className="text-sm text-gray-600 pl-8">店舗側で候補日を確認し、日程を確定します。確定後はメールとグループ内のチャットで通知が届きます。</p>
+      </div>
+    </>
+  )
+}
+
+function InquiryStep() {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="flex-shrink-0 w-6 h-6 rounded-full bg-gray-100 text-gray-600 flex items-center justify-center text-xs font-bold">?</span>
+        <p className="text-sm font-bold text-gray-900">店舗への問い合わせ</p>
+      </div>
+      <p className="text-sm text-gray-600 mb-3 pl-8">質問がある場合は、チャット画面ヘッダーの <Settings className="w-3.5 h-3.5 inline-block text-gray-500" /> アイコンから店舗に直接問い合わせできます。</p>
+      <div className="ml-8">
+        <DemoFrame label="設定シート内の問い合わせ">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-sm font-semibold">設定</p>
+            <span className="text-gray-400 text-sm">✕</span>
+          </div>
+          <div className="border border-gray-200 rounded-lg overflow-hidden">
+            <div className="flex items-center justify-between p-3 bg-white">
+              <div className="flex items-center gap-2">
+                <MessageCircle className="w-4 h-4 text-gray-400" />
+                <span className="text-sm font-medium">店舗への問い合わせ</span>
+              </div>
+              <ChevronRight className="w-4 h-4 text-gray-400 rotate-90" />
+            </div>
+            <div className="p-3 border-t border-gray-200 space-y-2">
+              <p className="text-xs text-gray-500">返信先メールアドレス</p>
+              <div className="h-8 rounded border border-gray-200 px-3 flex items-center text-xs text-gray-500 bg-gray-50">example@email.com</div>
+              <p className="text-xs text-gray-500">問い合わせ内容</p>
+              <div className="h-20 rounded border border-gray-200 px-3 py-2 text-xs text-gray-400 bg-gray-50">
+                予約情報が自動入力されます...
+              </div>
+              <button className="w-full py-2 text-sm font-medium text-white rounded bg-gray-900">送信する</button>
+            </div>
+          </div>
+        </DemoFrame>
+      </div>
+    </div>
+  )
+}
+
+function DemoFrame({ children, label }: { children: React.ReactNode; label?: string }) {
+  return (
+    <div className="rounded-xl border-2 border-dashed border-gray-200 bg-gray-50/50 overflow-hidden">
+      {label && (
+        <div className="px-3 py-1.5 bg-gray-100 border-b border-gray-200 text-[11px] text-gray-400 font-medium tracking-wide uppercase">{label}</div>
+      )}
+      <div className="p-3 sm:p-4">{children}</div>
+    </div>
+  )
+}
+
+function DemoTabs({ active, onChange }: { active: string; onChange: (tab: string) => void }) {
+  const tabs = [
+    { id: 'lineup', label: 'ラインナップ' },
+    { id: 'calendar', label: 'カレンダー' },
+    { id: 'list', label: 'リスト' },
+  ]
+  return (
+    <div className="flex justify-center mb-4">
+      <div className="inline-flex bg-gray-100 p-0.5 rounded-lg">
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            className={`px-4 py-1.5 text-sm font-medium transition-colors ${active === t.id ? 'rounded-md bg-white shadow-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+            onClick={() => onChange(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DemoCalendarContent() {
+  const eventDays: Record<number, string[]> = {
+    7: ['orange'], 8: ['blue', 'purple', 'orange'], 9: ['blue'],
+    11: ['orange', 'blue'], 12: ['green', 'orange'], 15: ['blue'],
+    18: ['orange', 'green'], 19: ['blue', 'orange'], 20: ['green'],
+    25: ['blue', 'purple'], 26: ['orange', 'blue'],
+  }
+  const colorMap: Record<string, string> = { blue: '#3B82F6', orange: '#F97316', green: '#22C55E', purple: '#8B5CF6' }
+
+  return (
+    <>
+      {/* カレンダーグリッド - 実際のUIと同じ */}
+      <div className="bg-white border overflow-hidden">
+        <div className="grid grid-cols-7 border-b bg-muted/30">
+          {['日', '月', '火', '水', '木', '金', '土'].map((d, i) => (
+            <div key={d} className={`text-center py-2 text-xs ${i === 0 ? 'text-red-600' : i === 6 ? 'text-blue-600' : ''}`}>{d}</div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7">
+          {/* 空セル（4/1は水曜） */}
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={`blank-${i}`} className="border-r border-b min-h-[80px] sm:min-h-[110px] bg-muted/20" />
+          ))}
+          {Array.from({ length: 30 }, (_, i) => {
+            const day = i + 1
+            const dayOfWeek = (day + 2) % 7 // 4/1=水→3
+            const events = DEMO_EVENTS[String(day)] || []
+            const dots = eventDays[day]
+
+            return (
+              <div key={day} className="border-r border-b flex flex-col min-h-[80px] sm:min-h-[110px]">
+                <div className={`text-xs p-0.5 flex-shrink-0 ${dayOfWeek === 0 ? 'text-red-600' : dayOfWeek === 6 ? 'text-blue-600' : ''}`}>
+                  {day}
+                </div>
+                <div className="space-y-0.5 overflow-y-auto">
+                  {events.length > 0
+                    ? events.slice(0, 3).map((ev, ei) => <CalendarEventCell key={ei} event={ev} />)
+                    : dots && (
+                      <div className="flex justify-center pt-1 gap-0.5">
+                        {dots.map((c, ci) => <div key={ci} className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: colorMap[c] }} />)}
+                      </div>
+                    )
+                  }
+                  {events.length > 3 && <div className="text-[10px] text-center text-blue-600">+{events.length - 3}</div>}
+                </div>
+              </div>
+            )
+          })}
+          {/* 残りの空セル */}
+          {Array.from({ length: 2 }, (_, i) => (
+            <div key={`end-${i}`} className="border-r border-b min-h-[80px] sm:min-h-[110px] bg-muted/20" />
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function DemoListContent() {
+  const storeGroups = [
+    { name: '馬場', color: '#3B82F6', events: DEMO_EVENTS['8']?.filter(e => e.store === '馬場') || [] },
+    { name: '大久保', color: '#F97316', events: DEMO_EVENTS['8']?.filter(e => e.store === '大久保') || [] },
+    { name: '仮設②', color: '#8B5CF6', events: DEMO_EVENTS['8']?.filter(e => e.store === '仮設②') || [] },
+  ]
+
+  const getSlot = (time: string) => {
+    const h = parseInt(time.split(':')[0])
+    if (h < 12) return 'morning'
+    if (h < 18) return 'afternoon'
+    return 'evening'
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full table-fixed border-collapse">
+        <colgroup>
+          <col className="w-12 sm:w-16" />
+          <col className="w-10 sm:w-16" />
+          <col />
+          <col />
+          <col />
+        </colgroup>
+        <thead>
+          <tr className="bg-muted/50">
+            <th className="border text-xs sm:text-sm py-2 px-1 text-left">日付</th>
+            <th className="border text-xs sm:text-sm py-2 px-1 text-left">会場</th>
+            <th className="border text-xs sm:text-sm py-2 px-1 text-center">
+              <span className="sm:hidden">朝</span><span className="hidden sm:inline">朝公演</span>
+              <div className="text-[10px] text-gray-400 font-normal">9:00-12:00</div>
+            </th>
+            <th className="border text-xs sm:text-sm py-2 px-1 text-center">
+              <span className="sm:hidden">昼</span><span className="hidden sm:inline">昼公演</span>
+              <div className="text-[10px] text-gray-400 font-normal">14:00-18:00</div>
+            </th>
+            <th className="border text-xs sm:text-sm py-2 px-1 text-center">
+              <span className="sm:hidden">夜</span><span className="hidden sm:inline">夜公演</span>
+              <div className="text-[10px] text-gray-400 font-normal">19:00-23:00</div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {storeGroups.map((sg, si) => (
+            <tr key={sg.name} className={si === 0 ? '' : ''}>
+              {si === 0 && (
+                <td className="border text-xs sm:text-sm px-1 py-2 align-top text-center" rowSpan={storeGroups.length}>
+                  <div>4/8</div>
+                  <div className="text-sm">水</div>
+                </td>
+              )}
+              <td className="border text-xs px-1 py-1 whitespace-nowrap" style={{ color: sg.color }}>
+                {sg.name}
+              </td>
+              {(['morning', 'afternoon', 'evening'] as const).map(slot => {
+                const slotEvents = sg.events.filter(e => getSlot(e.time) === slot)
+                return (
+                  <td key={slot} className="border p-0 align-top">
+                    {slotEvents.length > 0 ? (
+                      <div className="flex flex-col">
+                        {slotEvents.map((ev, ei) => (
+                          <div
+                            key={ei}
+                            className="text-xs border-l-2 cursor-pointer"
+                            style={{ borderLeftColor: sg.color, backgroundColor: `${sg.color}15`, padding: '2px 3px' }}
+                          >
+                            <div className="flex gap-0.5 sm:gap-2">
+                              <div className="flex-shrink-0 w-[28px] sm:w-[46px] self-stretch overflow-hidden bg-gray-200">
+                                <img src={ev.imageUrl} alt="" className="w-full h-full object-cover" loading="lazy" />
+                              </div>
+                              <div className="flex flex-col gap-0 flex-1 min-w-0 justify-between">
+                                <div className="text-xs leading-tight" style={{ color: sg.color }}>{ev.time}</div>
+                                <div className="text-xs leading-tight text-gray-800 overflow-hidden whitespace-nowrap" style={{ textOverflow: 'clip' }}>{ev.title}</div>
+                                <div className="text-xs leading-tight flex items-center justify-end gap-1">
+                                  {ev.isConfirmed && <span className="text-[10px] font-bold px-1 py-0.5 bg-blue-100 text-blue-700">開催決定</span>}
+                                  <span className="text-gray-600">残{ev.seats}</span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="p-1 sm:p-2 text-xs text-center">
+                        <button className="w-full text-xs py-1 px-1 border border-dashed border-gray-300 text-gray-500">
+                          貸切申込
+                        </button>
+                      </div>
+                    )}
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export function GuidePage() {
+  const [activeTab, setActiveTab] = useState('lineup')
+  const [privateMethod, setPrivateMethod] = useState<'scenario-direct' | 'scenario-group' | 'calendar'>('scenario-direct')
+
   return (
     <PublicLayout>
       {/* ヒーロー */}
-      <section 
-        className="relative overflow-hidden py-12 md:py-16"
-        style={{ backgroundColor: THEME.primary }}
-      >
-        <div 
-          className="absolute top-0 right-0 w-64 h-64 opacity-20"
-          style={{ 
-            background: `radial-gradient(circle at center, ${THEME.accent} 0%, transparent 70%)`,
-            transform: 'translate(30%, -30%)'
-          }}
-        />
+      <section className="relative overflow-hidden py-10 md:py-14" style={{ backgroundColor: THEME.primary }}>
+        <div className="absolute top-0 right-0 w-64 h-64 opacity-20" style={{ background: `radial-gradient(circle at center, ${THEME.accent} 0%, transparent 70%)`, transform: 'translate(30%, -30%)' }} />
         <div className="max-w-2xl mx-auto px-4 relative text-center">
           <div className="flex items-center justify-center gap-2 text-white/80 text-sm mb-4">
             <Link to="/" className="hover:text-white transition-colors">ホーム</Link>
             <ChevronRight className="w-4 h-4" />
-            <span>使い方</span>
+            <span>使い方ガイド</span>
           </div>
-          <h1 className="text-2xl md:text-3xl font-bold text-white mb-4 flex items-center justify-center gap-3">
-            <HelpCircle className="w-8 h-8" />
+          <h1 className="text-2xl md:text-3xl font-bold text-white mb-3 flex items-center justify-center gap-3">
+            <HelpCircle className="w-7 h-7 sm:w-8 sm:h-8" />
             ご予約ガイド
           </h1>
-          <p className="text-lg text-white/90">
-            かんたん3ステップで予約できます
+          <p className="text-base sm:text-lg text-white/90">かんたん4ステップで予約できます</p>
+        </div>
+      </section>
+
+      {/* ===== Step 1 ===== */}
+      <section className="max-w-3xl mx-auto px-4 pt-10 pb-6 md:pt-14 md:pb-8">
+        <div className="flex items-center gap-3 mb-4">
+          <StepNumber n={1} />
+          <div>
+            <h2 className="text-lg sm:text-xl font-bold text-gray-900">トップページにアクセス</h2>
+            <p className="text-sm text-gray-500 mt-0.5">まずはページを開きましょう</p>
+          </div>
+        </div>
+
+        <p className="text-sm sm:text-base text-gray-600 mb-4 leading-relaxed">
+          シナリオを探すページは<strong>2種類</strong>あります。
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
+          <div className="border border-gray-200 rounded-lg p-3 sm:p-4 bg-white">
+            <p className="text-sm font-bold text-gray-900 mb-1">MMQトップ</p>
+            <p className="text-xs text-gray-500 mb-2">mmq.jp</p>
+            <p className="text-sm text-gray-600">全店舗のシナリオ・公演をまとめて探せます。どの店舗で遊ぶか決まっていないときに便利です。</p>
+          </div>
+          <div className="border border-gray-200 rounded-lg p-3 sm:p-4 bg-white">
+            <p className="text-sm font-bold text-gray-900 mb-1">店舗トップ</p>
+            <p className="text-xs text-gray-500 mb-2">mmq.jp/店舗名</p>
+            <p className="text-sm text-gray-600">特定の店舗のシナリオ・公演だけを表示します。遊ぶ店舗が決まっているときに便利です。</p>
+          </div>
+        </div>
+        <Annotation>どちらのページにも「ラインナップ」「カレンダー」「リスト」の3つのタブがあります</Annotation>
+      </section>
+
+      <hr className="max-w-3xl mx-auto border-gray-200" />
+
+      {/* ===== Step 2 ===== */}
+      <section className="max-w-3xl mx-auto px-4 py-6 md:py-8">
+        <div className="flex items-center gap-3 mb-4">
+          <StepNumber n={2} />
+          <div>
+            <h2 className="text-lg sm:text-xl font-bold text-gray-900">シナリオを探す</h2>
+            <p className="text-sm text-gray-500 mt-0.5">検索・フィルターで絞り込み</p>
+          </div>
+        </div>
+
+        {/* 検索・フィルター説明 */}
+        <div className="mb-4">
+          <DemoFrame label="シナリオの探し方">
+            <div className="space-y-4">
+              {/* 検索バー + カタログ */}
+              <div>
+                <p className="text-xs font-medium text-gray-700 mb-1.5">① キーワード検索</p>
+                <div className="flex gap-2">
+                  <div className="relative flex-1">
+                    <Search className="absolute left-2.5 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+                    <div className="h-9 rounded border border-gray-200 pl-8 pr-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>シナリオを検索...</div>
+                  </div>
+                  <button className="h-9 px-3 flex items-center gap-1.5 text-sm font-medium border-2 rounded whitespace-nowrap" style={{ borderColor: '#E60012', color: '#E60012' }}>
+                    <BookOpen className="w-4 h-4" />
+                    <span>カタログ</span>
+                  </button>
+                </div>
+                <p className="text-xs text-gray-500 mt-1">シナリオ名・あらすじ・ジャンルで検索。「カタログ」で全シナリオ一覧へ</p>
+              </div>
+
+              <div className="border-t border-gray-100" />
+
+              {/* カタログページのフィルター */}
+              <div>
+                <p className="text-xs font-medium text-gray-700 mb-1.5">② カタログページのフィルター</p>
+                <div className="space-y-2.5">
+                  <div>
+                    <p className="text-[11px] text-gray-400 mb-1">ジャンルで絞り込み</p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {['推理', '協力', 'ホラー', 'ファンタジー', '感動', 'コメディ'].map((g) => (
+                        <span key={g} className={`px-2.5 py-1 rounded-full text-xs border cursor-default ${g === '推理' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-600 border-gray-200'}`}>{g}</span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                    <div className="h-9 rounded border border-gray-200 px-2 flex items-center text-xs text-gray-500" style={{ backgroundColor: '#F6F9FB' }}>所要時間 ▾</div>
+                    <div className="h-9 rounded border border-gray-200 px-2 flex items-center text-xs text-gray-500" style={{ backgroundColor: '#F6F9FB' }}>プレイ人数 ▾</div>
+                    <div className="h-9 rounded border border-gray-200 px-2 flex items-center text-xs text-gray-500" style={{ backgroundColor: '#F6F9FB' }}>店舗 ▾</div>
+                    <div className="h-9 rounded border border-gray-200 px-2 flex items-center text-xs text-gray-500" style={{ backgroundColor: '#F6F9FB' }}>並び替え ▾</div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-t border-gray-100" />
+
+              {/* 店舗フィルター */}
+              <div>
+                <p className="text-xs font-medium text-gray-700 mb-1.5">③ 店舗フィルター（トップページ）</p>
+                <p className="text-[11px] text-gray-400 mb-1.5">「直近公演」セクションで表示する店舗を選択</p>
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span className="text-xs text-gray-600 whitespace-nowrap">店舗:</span>
+                  <div className="flex-1 border border-gray-200 rounded px-3 py-1.5 flex items-center justify-between bg-white text-sm text-gray-700">
+                    <span>馬場, 別館①, 大久保</span>
+                    <ChevronRight className="w-3 h-3 text-gray-400 rotate-90" />
+                  </div>
+                </div>
+                {/* ドロップダウン展開イメージ */}
+                <div className="border border-gray-200 rounded overflow-hidden text-sm">
+                  <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-50 border-b">
+                    <span className="w-4 h-4 border bg-gray-900 border-gray-900 text-white flex items-center justify-center text-[10px]">✓</span>
+                    <span className="font-medium text-xs">東京都</span>
+                    <span className="text-[10px] text-gray-400 ml-auto">3/5店舗</span>
+                  </div>
+                  {[
+                    { name: '高田馬場本店', checked: true },
+                    { name: '別館①', checked: true },
+                    { name: '別館②', checked: false },
+                    { name: '大久保店', checked: true },
+                    { name: '大塚店', checked: false },
+                  ].map((s) => (
+                    <div key={s.name} className="flex items-center gap-2 px-3 py-1 pl-7 hover:bg-red-50">
+                      <span className={`w-4 h-4 border flex items-center justify-center text-[10px] ${s.checked ? 'bg-gray-900 border-gray-900 text-white' : 'border-gray-300'}`}>{s.checked && '✓'}</span>
+                      <span className="text-xs">{s.name}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </DemoFrame>
+        </div>
+
+        <DemoFrame label="実際の画面イメージ（タブ切り替え可能）">
+          <DemoTabs active={activeTab} onChange={setActiveTab} />
+
+          {activeTab === 'lineup' && (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pointer-events-none">
+                {SAMPLE_SCENARIOS.map((s) => (
+                  <DemoScenarioCard key={s.title} scenario={s} />
+                ))}
+              </div>
+              <div className="mt-3 space-y-2">
+                <Annotation>カードをタップするとシナリオ詳細ページに移動します</Annotation>
+                <Annotation>
+                  <Heart className="w-3 h-3 inline text-red-500 mr-1" />で「遊びたいリスト」に追加、
+                  <CheckCheck className="w-3 h-3 inline text-green-500 mx-1" />で体験済みを記録
+                </Annotation>
+              </div>
+            </>
+          )}
+
+          {activeTab === 'calendar' && (
+            <>
+              <DemoCalendarContent />
+              <div className="mt-3 space-y-2">
+                <Annotation>各日付のセル内にその日の公演が表示されます。タップで詳細へ</Annotation>
+                <Annotation>店舗ごとに色分けされた左ボーダーで、どの店舗かひと目でわかります</Annotation>
+              </div>
+            </>
+          )}
+
+          {activeTab === 'list' && (
+            <>
+              <DemoListContent />
+              <div className="mt-3 space-y-2">
+                <Annotation>日付×店舗×時間帯（朝/昼/夜）の一覧表。複数店舗の空き状況を比較できます</Annotation>
+                <Annotation>空き枠の「貸切申込」ボタンから、貸切リクエストも可能</Annotation>
+              </div>
+            </>
+          )}
+        </DemoFrame>
+      </section>
+
+      <hr className="max-w-3xl mx-auto border-gray-200" />
+
+      {/* ===== Step 3 ===== */}
+      <section className="max-w-3xl mx-auto px-4 py-6 md:py-8">
+        <div className="flex items-center gap-3 mb-4">
+          <StepNumber n={3} />
+          <div>
+            <h2 className="text-lg sm:text-xl font-bold text-gray-900">公演を選んで予約</h2>
+            <p className="text-sm text-gray-500 mt-0.5">日程・人数を決めて予約しましょう</p>
+          </div>
+        </div>
+
+        <p className="text-sm sm:text-base text-gray-600 mb-4 leading-relaxed">
+          シナリオ詳細ページでは、開催予定の公演がリストで表示されます。
+          参加したい日程の<strong>「予約する」</strong>ボタンをタップしてください。
+        </p>
+
+        <DemoFrame label="シナリオ詳細 → 公演スケジュール">
+          <h3 className="font-bold text-gray-900 mb-1">白いウサギは歌わない</h3>
+          <p className="text-xs text-gray-500 mb-3">8人 ・ 4時間 ・ ¥4,000〜</p>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between bg-white border border-gray-200 px-3 py-2.5 rounded-lg">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="w-1 h-5 rounded-full bg-blue-500 flex-shrink-0" />
+                <span className="font-medium text-gray-900">4/19<span className="text-gray-400 ml-0.5">(土)</span></span>
+                <span className="text-gray-500">13:00</span>
+                <span className="text-xs px-1.5 py-0.5 bg-blue-50 text-blue-700 rounded">馬場</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] font-bold px-1.5 py-0.5 bg-blue-100 text-blue-700">開催決定</span>
+                <span className="text-xs font-bold px-1.5 py-0.5 bg-red-50 text-red-600">残3</span>
+                <button className="px-3 py-1 text-xs font-medium text-white rounded" style={{ backgroundColor: THEME.primary }}>予約する</button>
+              </div>
+            </div>
+            <div className="flex items-center justify-between bg-white border border-gray-200 px-3 py-2.5 rounded-lg">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="w-1 h-5 rounded-full bg-orange-500 flex-shrink-0" />
+                <span className="font-medium text-gray-900">4/26<span className="text-gray-400 ml-0.5">(土)</span></span>
+                <span className="text-gray-500">18:00</span>
+                <span className="text-xs px-1.5 py-0.5 bg-orange-50 text-orange-700 rounded">大久保</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-bold px-1.5 py-0.5" style={{ backgroundColor: THEME.accentLight, color: THEME.accent }}>残5</span>
+                <button className="px-3 py-1 text-xs font-medium text-white rounded" style={{ backgroundColor: THEME.primary }}>予約する</button>
+              </div>
+            </div>
+            <div className="flex items-center justify-between bg-white border border-gray-200 px-3 py-2.5 rounded-lg opacity-70">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="w-1 h-5 rounded-full bg-purple-500 flex-shrink-0" />
+                <span className="font-medium text-gray-900">5/3<span className="text-gray-400 ml-0.5">(日)</span></span>
+                <span className="text-gray-500">13:00</span>
+                <span className="text-xs px-1.5 py-0.5 bg-purple-50 text-purple-700 rounded">仮設②</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-bold px-1.5 py-0.5 bg-gray-200 text-gray-500">満席</span>
+                <button className="px-3 py-1 text-xs font-medium text-gray-500 bg-gray-100 rounded">キャンセル待ち</button>
+              </div>
+            </div>
+          </div>
+        </DemoFrame>
+
+        <div className="mt-4 space-y-2">
+          <Annotation>「開催決定」は最少催行人数に達した公演です。確実に遊べます！</Annotation>
+          <Annotation>満席でも「キャンセル待ち」を登録しておけば、空きが出た時に通知が届きます</Annotation>
+        </div>
+      </section>
+
+      <hr className="max-w-3xl mx-auto border-gray-200" />
+
+      {/* ===== Step 4 ===== */}
+      <section className="max-w-3xl mx-auto px-4 py-6 md:py-8">
+        <div className="flex items-center gap-3 mb-4">
+          <StepNumber n={4} />
+          <div>
+            <h2 className="text-lg sm:text-xl font-bold text-gray-900">予約完了！</h2>
+            <p className="text-sm text-gray-500 mt-0.5">情報を入力して送信するだけ</p>
+          </div>
+        </div>
+
+        <p className="text-sm sm:text-base text-gray-600 mb-4 leading-relaxed">
+          お名前・連絡先を入力して送信すれば予約完了。確認メールが届きます。
+        </p>
+
+        <DemoFrame label="予約フォーム">
+          <div className="max-w-sm mx-auto space-y-3">
+            <div className="bg-white border border-gray-200 rounded-lg p-3">
+              <p className="font-bold text-sm text-gray-900">白いウサギは歌わない</p>
+              <p className="text-xs text-gray-500 mt-0.5">4/19(土) 13:00 ・ 高田馬場店</p>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-gray-700 block mb-1">参加人数</label>
+              <div className="flex items-center border border-gray-200 rounded-lg overflow-hidden w-fit">
+                <button className="px-3 py-1.5 text-gray-400 bg-gray-50">−</button>
+                <span className="px-4 py-1.5 text-sm font-medium">2名</span>
+                <button className="px-3 py-1.5 text-gray-400 bg-gray-50">+</button>
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-gray-700 block mb-1">代表者名</label>
+              <div className="w-full h-9 rounded-lg border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>お名前</div>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-gray-700 block mb-1">メールアドレス</label>
+              <div className="w-full h-9 rounded-lg border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>example@email.com</div>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-gray-700 block mb-1">電話番号</label>
+              <div className="w-full h-9 rounded-lg border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>090-0000-0000</div>
+            </div>
+            <button className="w-full py-2.5 text-sm font-bold text-white rounded-lg" style={{ backgroundColor: THEME.primary }}>予約を確定する</button>
+            <p className="text-center text-[11px] text-gray-400">予約確認メールが送信されます</p>
+          </div>
+        </DemoFrame>
+
+        <div className="mt-4">
+          <Annotation>予約にはログインが必要です。ログイン中はお名前・連絡先が自動入力されます</Annotation>
+        </div>
+      </section>
+
+      {/* ===== 貸切予約ガイド ===== */}
+      <section className="bg-purple-50/50 py-8 md:py-10">
+        <div className="max-w-3xl mx-auto px-4">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center text-white font-bold text-lg bg-purple-600">
+              <Users className="w-5 h-5 sm:w-6 sm:h-6" />
+            </div>
+            <div>
+              <h2 className="text-lg sm:text-xl font-bold text-gray-900">貸切予約ガイド</h2>
+              <p className="text-sm text-gray-500 mt-0.5">お仲間だけでシナリオを楽しむ方法</p>
+            </div>
+          </div>
+
+          <p className="text-sm sm:text-base text-gray-600 mb-4 leading-relaxed">
+            状況に合わせて<strong>3つの方法</strong>から選べます。下のタブで詳しい手順を確認してください。
           </p>
+
+          {/* 複数候補日アピール */}
+          <div className="rounded-lg border border-purple-200 overflow-hidden mb-4">
+            <div className="bg-purple-50 px-4 py-2.5 border-b border-purple-200">
+              <p className="text-sm font-bold text-purple-800">候補日をまとめて送れるからスムーズ！</p>
+            </div>
+            <div className="p-4 bg-white">
+              <div className="flex items-center gap-3 sm:gap-4">
+                {/* あなた側 */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-[10px] text-gray-400 mb-1.5 text-center">あなた</p>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-1.5 px-2 py-1 bg-purple-50 border border-purple-200 rounded text-xs">
+                      <span className="text-purple-600 font-bold">①</span>
+                      <span className="text-gray-700">4/19(土) 夜</span>
+                    </div>
+                    <div className="flex items-center gap-1.5 px-2 py-1 bg-purple-50 border border-purple-200 rounded text-xs">
+                      <span className="text-purple-600 font-bold">②</span>
+                      <span className="text-gray-700">4/20(日) 昼</span>
+                    </div>
+                    <div className="flex items-center gap-1.5 px-2 py-1 bg-purple-50 border border-purple-200 rounded text-xs">
+                      <span className="text-purple-600 font-bold">③</span>
+                      <span className="text-gray-700">4/26(土) 昼</span>
+                    </div>
+                  </div>
+                </div>
+                {/* 矢印 */}
+                <div className="flex flex-col items-center gap-1 flex-shrink-0">
+                  <ArrowRight className="w-5 h-5 text-purple-400" />
+                  <span className="text-[10px] text-purple-400">まとめて送信</span>
+                </div>
+                {/* 店舗側 */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-[10px] text-gray-400 mb-1.5 text-center">店舗</p>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-50 border border-gray-200 rounded text-xs text-gray-400 line-through">4/19(土) 夜</div>
+                    <div className="flex items-center gap-1.5 px-2 py-1 bg-green-50 border border-green-300 rounded text-xs text-green-700 font-medium">
+                      <span>4/20(日) 昼</span>
+                      <span className="ml-auto text-[10px] bg-green-100 px-1 rounded">確定！</span>
+                    </div>
+                    <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-50 border border-gray-200 rounded text-xs text-gray-400 line-through">4/26(土) 昼</div>
+                  </div>
+                </div>
+              </div>
+              <p className="text-xs text-gray-500 mt-3 text-center">1つがダメでも他の候補日から選んでもらえるので、やり取りの手間が減ります</p>
+              <div className="flex justify-center gap-3 mt-2 text-[11px] text-purple-600">
+                <span className="bg-purple-50 border border-purple-200 rounded px-2 py-0.5">直接申込: 最大<strong>6件</strong></span>
+                <span className="bg-purple-50 border border-purple-200 rounded px-2 py-0.5">グループ調整: <strong>自由に追加</strong>OK</span>
+              </div>
+            </div>
+          </div>
+
+          {/* 貸切グループの仕組み説明 */}
+          <div className="bg-white border border-purple-200 rounded-lg p-4 sm:p-5 mb-4">
+            <div className="flex items-start gap-3">
+              <div className="flex-shrink-0 w-9 h-9 rounded-full bg-purple-100 flex items-center justify-center mt-0.5">
+                <Users className="w-[18px] h-[18px] text-purple-600" />
+              </div>
+              <div>
+                <p className="text-base font-bold text-gray-900 mb-1.5">貸切予約 = 貸切グループの作成</p>
+                <p className="text-sm text-gray-700 leading-relaxed mb-3">
+                  どの方法でも、貸切リクエストを送信すると<strong>「貸切グループ」が自動で作成</strong>されます。
+                  グループが作成されると招待リンクが発行され、一緒に遊ぶメンバーを招待できるようになります。
+                </p>
+                <div className="flex items-center gap-2 text-xs sm:text-sm text-purple-700 bg-purple-50 rounded-lg px-3 py-2 flex-wrap font-medium">
+                  <span>貸切リクエスト送信</span>
+                  <ChevronRight className="w-3.5 h-3.5" />
+                  <span>グループ自動作成</span>
+                  <ChevronRight className="w-3.5 h-3.5" />
+                  <span>招待リンク発行</span>
+                  <ChevronRight className="w-3.5 h-3.5" />
+                  <span>メンバー招待</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* グループ参加について */}
+          <div className="bg-white border border-gray-200 rounded-lg p-4 sm:p-5 mb-6 space-y-3">
+            <p className="text-base font-bold text-gray-900">グループへのメンバー参加について</p>
+            <div className="space-y-3">
+              <div className="flex items-start gap-2.5">
+                <span className="flex-shrink-0 mt-0.5 w-6 h-6 rounded-full bg-green-100 text-green-600 flex items-center justify-center text-xs font-bold">✓</span>
+                <p className="text-sm text-gray-700 leading-relaxed">
+                  <strong>MMQに登録しなくても</strong>グループに参加できます（ゲスト参加OK）
+                </p>
+              </div>
+              <div className="flex items-start gap-2.5">
+                <span className="flex-shrink-0 mt-0.5 w-6 h-6 rounded-full bg-green-100 text-green-600 flex items-center justify-center text-xs font-bold">✓</span>
+                <div className="text-sm text-gray-700 leading-relaxed">
+                  <p>参加者<strong>全員をグループに追加しなくても公演に支障はありません</strong></p>
+                  <p className="text-gray-500 mt-1 text-[13px]">ただし、追加すると貸切リクエストの進捗確認・予約情報の共有・参加履歴の記録に便利です</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-2.5">
+                <span className="flex-shrink-0 mt-0.5 w-6 h-6 rounded-full bg-amber-100 text-amber-600 flex items-center justify-center text-xs font-bold">!</span>
+                <p className="text-sm text-gray-700 leading-relaxed">
+                  <strong className="text-amber-700">事前読み込みがあるシナリオ</strong>は、グループに<strong>全員の参加が必須</strong>です（事前資料の配布にグループを使用するため）
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* 方法タブ */}
+          <div className="mb-6">
+            <p className="text-sm text-gray-600 mb-3">あなたの状況に合った方法をタップしてください：</p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {([
+                { id: 'scenario-direct' as const, label: 'シナリオから直接申込', desc: 'シナリオが決まっていて日程を探したい' },
+                { id: 'scenario-group' as const, label: 'グループで日程調整', desc: 'メンバーを集めてから日程を決めたい' },
+                { id: 'calendar' as const, label: 'カレンダーから申込', desc: '日程・店舗が決まっている' },
+              ]).map((m) => (
+                <button
+                  key={m.id}
+                  onClick={() => setPrivateMethod(m.id)}
+                  className={`text-left p-3 sm:p-4 rounded-lg border-2 transition-all ${
+                    privateMethod === m.id
+                      ? 'border-purple-500 bg-purple-50'
+                      : 'border-gray-200 bg-white hover:border-purple-200'
+                  }`}
+                >
+                  <p className={`text-sm font-bold mb-0.5 ${privateMethod === m.id ? 'text-purple-700' : 'text-gray-800'}`}>{m.label}</p>
+                  <p className="text-xs text-gray-500">{m.desc}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* ===== シナリオから直接申込 ===== */}
+          {privateMethod === 'scenario-direct' && (
+            <div className="space-y-4">
+              <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">1</span>
+                  <p className="text-sm font-bold text-gray-900">シナリオ詳細ページで「貸切リクエスト」タブを開く</p>
+                </div>
+                <p className="text-sm text-gray-600 mb-3 pl-8">遊びたいシナリオの詳細ページを開き、「貸切リクエスト」タブを選択します。</p>
+                <div className="ml-8">
+                  <DemoFrame label="実際の画面イメージ">
+                    {/* タブバー（ShadCN TabsList 風） */}
+                    <div className="inline-flex w-full items-center justify-center bg-gray-100 p-1 rounded-none mb-3">
+                      <span className="flex-1 text-center px-2.5 py-1.5 text-sm font-medium text-gray-500">公演日程</span>
+                      <span className="flex-1 text-center px-2.5 py-1.5 text-sm font-medium bg-white text-gray-900 shadow-sm">貸切リクエスト</span>
+                    </div>
+                    {/* グループ作成への導線 */}
+                    <div className="p-3 bg-purple-50 border border-purple-200 rounded-lg mb-4">
+                      <p className="text-sm text-purple-800 mb-2">日程やメンバーが決まっていない場合</p>
+                      <button className="w-full py-2 text-sm font-medium text-purple-700 bg-white border border-purple-300 rounded flex items-center justify-center gap-1.5">
+                        <Users className="w-4 h-4" />
+                        まずはメンバーを招待して貸切グループを作成
+                      </button>
+                    </div>
+                    {/* 店舗選択ドロップダウン */}
+                    <div className="mb-4">
+                      <label className="text-sm font-medium text-gray-500 mb-1.5 block">希望店舗を選択</label>
+                      <button className="w-full flex items-center justify-between px-3 py-2 text-sm bg-white border border-gray-200 rounded">
+                        <span className="text-gray-700">馬場, 別館①</span>
+                        <ChevronRight className="w-3 h-3 text-gray-400 rotate-90" />
+                      </button>
+                    </div>
+                    {/* 日程選択グリッド */}
+                    <div>
+                      <h4 className="text-sm font-medium text-gray-500 mb-1.5">希望日程を選択</h4>
+                      {/* 月ナビ */}
+                      <div className="flex items-center justify-between mb-2">
+                        <button className="flex items-center gap-0.5 px-2 py-1 text-sm text-gray-500">← 前月</button>
+                        <span className="text-sm font-medium">2026年4月</span>
+                        <button className="flex items-center gap-0.5 px-2 py-1 text-sm text-gray-500">次月 →</button>
+                      </div>
+                      <div className="text-[10px] text-gray-400 text-center mb-2">候補日時を選択してください（最大6件）</div>
+                      {/* スロットグリッド */}
+                      <div className="border p-2">
+                        {[
+                          { date: '4/19', weekday: '土', wdColor: 'text-blue-600', slots: [
+                            { label: '午前', time: '10:00〜13:00', available: true, selected: false },
+                            { label: '午後', time: '13:00〜17:00', available: false, selected: false },
+                            { label: '夜', time: '18:00〜22:00', available: true, selected: true },
+                          ]},
+                          { date: '4/20', weekday: '日', wdColor: 'text-red-600', slots: [
+                            { label: '午前', time: '10:00〜13:00', available: true, selected: false },
+                            { label: '午後', time: '13:00〜17:00', available: true, selected: false },
+                            { label: '夜', time: '18:00〜22:00', available: false, selected: false },
+                          ]},
+                          { date: '4/26', weekday: '土', wdColor: 'text-blue-600', slots: [
+                            { label: '午前', time: '10:00〜13:00', available: false, selected: false },
+                            { label: '午後', time: '13:00〜17:00', available: true, selected: true },
+                            { label: '夜', time: '18:00〜22:00', available: true, selected: false },
+                          ]},
+                        ].map((row) => (
+                          <div key={row.date} className="flex items-stretch gap-1.5 border-b border-gray-100 py-1.5 last:border-b-0">
+                            <div className="flex w-10 shrink-0 flex-col justify-center text-center leading-tight">
+                              <div className="text-sm font-bold tabular-nums">{row.date}</div>
+                              <div className={`text-xs ${row.wdColor}`}>({row.weekday})</div>
+                            </div>
+                            <div className="flex gap-1.5 flex-1">
+                              {row.slots.map((slot) => (
+                                <div
+                                  key={slot.label}
+                                  className={`flex-1 py-1 px-1 border text-center ${
+                                    slot.selected
+                                      ? 'border-purple-600 bg-purple-600 text-white'
+                                      : slot.available
+                                      ? 'border-gray-200 bg-white'
+                                      : 'border-gray-100 bg-gray-50 opacity-50'
+                                  }`}
+                                >
+                                  <div className="text-xs font-medium">{slot.label}</div>
+                                  <div className={`text-[10px] ${slot.selected ? 'text-purple-100' : 'opacity-70'}`}>{slot.time}</div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    {/* 選択サマリ */}
+                    <div className="mt-3 p-3 bg-purple-50 border border-purple-200">
+                      <div className="text-sm text-purple-900 mb-1">選択中の候補日時 (2/6)</div>
+                      <div className="space-y-1 text-sm">
+                        <div className="flex items-center justify-between">
+                          <span>4/19(土) 夜 18:00〜22:00</span>
+                          <span className="text-purple-600 text-xs">✕ 取消</span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <span>4/26(土) 午後 13:00〜17:00</span>
+                          <span className="text-purple-600 text-xs">✕ 取消</span>
+                        </div>
+                      </div>
+                    </div>
+                    {/* 料金 */}
+                    <div className="mt-4">
+                      <h4 className="text-sm font-medium text-gray-500 mb-2">料金</h4>
+                      <div className="border rounded p-3 space-y-1.5">
+                        <div className="flex justify-between text-sm"><span className="text-gray-500">参加費（1名）</span><span className="font-medium">¥4,500</span></div>
+                        <div className="flex justify-between text-sm"><span className="text-gray-500">人数</span><span className="font-medium">8名</span></div>
+                        <div className="border-t pt-2 mt-2">
+                          <div className="flex justify-between items-center"><span className="text-sm text-gray-500">合計</span><span className="text-base font-bold text-[#E60012]">¥36,000</span></div>
+                        </div>
+                      </div>
+                    </div>
+                    {/* 送信ボタン */}
+                    <button className="w-full mt-4 py-2.5 text-base font-bold text-white rounded" style={{ backgroundColor: '#E60012' }}>貸切リクエスト確認へ (2件)</button>
+                  </DemoFrame>
+                </div>
+                <Annotation>紫のセルが選択済みの候補日時です。灰色のセルは既に予約が入っている時間帯です</Annotation>
+              </div>
+
+              <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">2</span>
+                  <p className="text-sm font-bold text-gray-900">お客様情報を入力して貸切リクエストを送信</p>
+                </div>
+                <p className="text-sm text-gray-600 mb-3 pl-8">お名前・連絡先を入力してリクエストを送信します。送信後、自動で貸切グループが作成されます。</p>
+                <div className="bg-gray-50 rounded-lg p-3 ml-8 space-y-2">
+                  <div className="border border-gray-200 rounded bg-white p-3 space-y-1.5">
+                    <div className="h-9 rounded border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>お名前</div>
+                    <div className="h-9 rounded border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>メールアドレス</div>
+                    <div className="h-9 rounded border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>電話番号</div>
+                  </div>
+                  <button className="w-full py-2.5 text-sm font-medium text-white rounded bg-purple-600">貸切リクエストを送信</button>
+                </div>
+                <Annotation>送信にはログインが必要です。送信後、自動で貸切グループが作成され、メンバーを招待できるようになります</Annotation>
+              </div>
+
+              <PostGroupSteps startStep={3} />
+              <InquiryStep />
+            </div>
+          )}
+
+          {/* ===== グループで日程調整 ===== */}
+          {privateMethod === 'scenario-group' && (
+            <div className="space-y-4">
+              <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">1</span>
+                  <p className="text-sm font-bold text-gray-900">シナリオ詳細ページで「貸切リクエストを作成」をタップ</p>
+                </div>
+                <p className="text-sm text-gray-600 mb-3 pl-8">シナリオ詳細ページには2箇所から貸切グループを作成できます。</p>
+                <div className="ml-8 space-y-3">
+                  {/* 入口① ヒーロー */}
+                  <div>
+                    <p className="text-xs font-medium text-purple-700 mb-1.5">入口① ヒーロー部分のリンク</p>
+                    <DemoFrame label="">
+                      <div className="bg-gray-900 rounded overflow-hidden">
+                        <div className="flex gap-3 p-3">
+                          <img src="https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1770883605761-6jmuke.jpg" alt="" className="w-20 h-28 sm:w-24 sm:h-32 rounded object-cover flex-shrink-0" />
+                          <div className="flex-1 min-w-0 text-white space-y-1.5">
+                            <h4 className="text-sm sm:text-base font-bold">白いウサギは歌わない</h4>
+                            <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-white/70">
+                              <span className="flex items-center gap-1"><Users className="w-3.5 h-3.5" />8人</span>
+                              <span className="flex items-center gap-1"><Clock className="w-3.5 h-3.5" />4時間</span>
+                              <span className="text-white font-medium">¥4,500〜</span>
+                            </div>
+                            <div className="flex gap-3 pt-1">
+                              <span className="text-[11px] text-white/60">公式サイト</span>
+                              <span className="text-[11px] text-white/60">シェア</span>
+                              <span className="text-[11px] text-purple-300 font-medium flex items-center gap-1 ring-1 ring-purple-400 rounded px-1 py-0.5">
+                                <Users className="w-3 h-3" />
+                                貸切リクエストを作成
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </DemoFrame>
+                  </div>
+                  {/* 入口② 貸切リクエストタブ */}
+                  <div>
+                    <p className="text-xs font-medium text-purple-700 mb-1.5">入口② 「貸切リクエスト」タブ内のボタン</p>
+                    <DemoFrame label="">
+                      <div className="inline-flex w-full items-center justify-center bg-gray-100 p-1 rounded-none mb-3">
+                        <span className="flex-1 text-center px-2.5 py-1.5 text-sm font-medium text-gray-500">公演日程</span>
+                        <span className="flex-1 text-center px-2.5 py-1.5 text-sm font-medium bg-white text-gray-900 shadow-sm">貸切リクエスト</span>
+                      </div>
+                      <div className="p-3 bg-purple-50 border border-purple-200 rounded-lg">
+                        <p className="text-sm text-purple-800 mb-2">日程やメンバーが決まっていない場合</p>
+                        <button className="w-full py-2 text-sm font-medium text-purple-700 bg-white border border-purple-300 rounded flex items-center justify-center gap-1.5 ring-1 ring-purple-400">
+                          <Users className="w-4 h-4" />
+                          まずはメンバーを招待して貸切グループを作成
+                        </button>
+                      </div>
+                    </DemoFrame>
+                  </div>
+                </div>
+                <Annotation>どちらをタップしても同じグループ作成ページに移動します</Annotation>
+              </div>
+
+              <PostGroupSteps startStep={2} />
+
+              <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">5</span>
+                  <p className="text-sm font-bold text-gray-900">主催者が貸切リクエストを送信</p>
+                </div>
+                <p className="text-sm text-gray-600 mb-3 pl-8">日程の回答が集まったら、主催者が「予約リクエストを作成」ボタンから店舗にリクエストを送信します。メンバーが全員揃っていなくても送信できます。</p>
+                <div className="bg-gray-50 rounded-lg p-3 ml-8">
+                  <div className="border border-gray-200 rounded bg-white p-3 space-y-2.5">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-gray-600">参加メンバー</span>
+                      <span className="font-medium text-gray-900">5/8人</span>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-gray-600">ベスト候補日</span>
+                      <span className="font-medium text-gray-900">4/19(土) 夜 <span className="text-green-600">全員◯</span></span>
+                    </div>
+                    <button className="w-full py-2.5 text-sm font-medium text-white rounded bg-purple-600">予約リクエストを作成</button>
+                  </div>
+                </div>
+                <Annotation>メンバーが全員揃っていなくても送信OK。リクエスト送信後も引き続きメンバーを招待できます</Annotation>
+              </div>
+              <InquiryStep />
+            </div>
+          )}
+
+          {/* ===== カレンダーから申込 ===== */}
+          {privateMethod === 'calendar' && (
+            <div className="space-y-4">
+              <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">1</span>
+                  <p className="text-sm font-bold text-gray-900">カレンダーで店舗を選んで、空き枠の「貸切申込」をタップ</p>
+                </div>
+                <p className="text-sm text-gray-600 mb-3 pl-8">カレンダーまたはリスト表示で、店舗フィルターを設定すると空き時間帯に「貸切申込」ボタンが表示されます。</p>
+                <div className="bg-gray-50 rounded-lg p-3 ml-8">
+                  <div className="flex items-center gap-2 text-sm text-gray-600 mb-2">
+                    <span className="px-2 py-0.5 bg-blue-50 text-blue-700 border border-blue-200 rounded text-xs">馬場</span>
+                    を選択中
+                  </div>
+                  <div className="border border-gray-200 rounded bg-white overflow-hidden">
+                    <div className="px-3 py-2 border-b border-gray-100 text-sm text-gray-600">4月19日(土)</div>
+                    <div className="p-2.5 space-y-1.5">
+                      <div className="text-sm border-l-2 px-2.5 py-1.5" style={{ borderLeftColor: '#3B82F6', backgroundColor: '#3B82F615' }}>
+                        <span style={{ color: '#3B82F6' }}>13:00 馬場</span>
+                        <span className="text-gray-800 ml-1.5">白いウサギは歌わない</span>
+                        <span className="text-gray-500 ml-1.5">残3</span>
+                      </div>
+                      <button className="w-full text-sm py-2 px-2 border border-dashed border-purple-300 text-purple-600 bg-purple-50/50 font-medium rounded">
+                        19:00〜 貸切申込
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <Annotation>店舗を選択していないと「貸切申込」ボタンは表示されません。まず店舗フィルターを設定してください</Annotation>
+              </div>
+
+              <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">2</span>
+                  <p className="text-sm font-bold text-gray-900">遊びたいシナリオを選択</p>
+                </div>
+                <p className="text-sm text-gray-600 mb-3 pl-8">シナリオ選択画面で、貸切で遊びたいシナリオを検索・選択します。</p>
+                <div className="bg-gray-50 rounded-lg p-3 ml-8">
+                  <div className="text-sm text-gray-600 mb-2">
+                    <span className="font-medium text-gray-700">選択中:</span> 4月19日(土) 夜公演
+                  </div>
+                  <div className="border border-gray-200 rounded bg-white p-3 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <img src="https://cznpcewciwywcqcxktba.supabase.co/storage/v1/object/public/key-visuals/1770883605761-6jmuke.jpg" alt="" className="w-10 h-14 rounded object-cover flex-shrink-0" />
+                      <div>
+                        <p className="text-sm font-bold text-gray-900">白いウサギは歌わない</p>
+                        <p className="text-sm text-gray-500">8人 ・ 4時間</p>
+                      </div>
+                      <span className="ml-auto text-xs px-2 py-1 bg-purple-100 text-purple-700 rounded font-medium">選択中</span>
+                    </div>
+                  </div>
+                  <div className="mt-2">
+                    <button className="w-full py-2.5 text-sm font-medium text-white rounded bg-purple-600">貸切リクエスト確認へ</button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center text-xs font-bold">3</span>
+                  <p className="text-sm font-bold text-gray-900">候補日時とお客様情報を入力して送信</p>
+                </div>
+                <p className="text-sm text-gray-600 mb-3 pl-8">候補日は最大6件まで追加できます。複数出すと、店舗側で調整しやすくなります。</p>
+                <div className="bg-gray-50 rounded-lg p-3 ml-8 space-y-2">
+                  <div className="border border-gray-200 rounded bg-white p-3 space-y-2">
+                    <p className="text-sm font-medium text-gray-700">候補日時</p>
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="px-2.5 py-1 bg-purple-50 text-purple-700 border border-purple-200 rounded">4/19(土) 夜</span>
+                      <span className="text-gray-500">第1希望</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="px-2.5 py-1 bg-gray-50 text-gray-600 border border-gray-200 rounded">+ 候補日を追加</span>
+                    </div>
+                  </div>
+                  <div className="border border-gray-200 rounded bg-white p-3 space-y-1.5">
+                    <p className="text-sm font-medium text-gray-700">お客様情報</p>
+                    <div className="h-9 rounded border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>お名前</div>
+                    <div className="h-9 rounded border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>メールアドレス</div>
+                    <div className="h-9 rounded border border-gray-200 px-3 flex items-center text-sm text-gray-400" style={{ backgroundColor: '#F6F9FB' }}>電話番号</div>
+                  </div>
+                  <button className="w-full py-2.5 text-sm font-medium text-white rounded bg-purple-600">貸切リクエストを送信</button>
+                </div>
+                <Annotation>送信にはログインが必要です。送信後、自動で貸切グループが作成され、メンバーを招待できるようになります</Annotation>
+              </div>
+
+              <PostGroupSteps startStep={4} />
+              <InquiryStep />
+            </div>
+          )}
+
+          {/* よくある質問 */}
+          <div className="mt-8 bg-white rounded-lg border border-purple-200 p-4 sm:p-5">
+            <h3 className="text-base font-bold text-purple-700 mb-4 flex items-center gap-2">
+              <HelpCircle className="w-5 h-5" />
+              貸切予約でよくある質問
+            </h3>
+            <div className="space-y-4 text-sm">
+              <div>
+                <p className="font-medium text-gray-900 mb-1.5">Q. 3つの方法はどう使い分ける？</p>
+                <ul className="text-gray-600 leading-relaxed space-y-1 ml-1">
+                  <li className="flex gap-1.5"><span className="shrink-0">•</span><span><strong>シナリオから直接申込</strong>：シナリオが決まっていて日程を探したい場合</span></li>
+                  <li className="flex gap-1.5"><span className="shrink-0">•</span><span><strong>グループで日程調整</strong>：メンバーを先に集めて日程を合わせたい場合</span></li>
+                  <li className="flex gap-1.5"><span className="shrink-0">•</span><span><strong>カレンダーから申込</strong>：日程と店舗が決まっていてシナリオを選びたい場合</span></li>
+                </ul>
+                <p className="text-gray-500 mt-1.5 text-[13px]">どの方法でも最終的に貸切グループが作成されます。</p>
+              </div>
+              <div>
+                <p className="font-medium text-gray-900 mb-1">Q. カレンダーに貸切申込ボタンが表示されません</p>
+                <p className="text-gray-600 leading-relaxed">貸切申込ボタンは、カレンダー画面上部の<strong>店舗チェックボックスで店舗を1つ以上選択</strong>すると表示されます。また、開催日の<strong>14日前</strong>を過ぎた日程には申込できません。</p>
+              </div>
+              <div>
+                <p className="font-medium text-gray-900 mb-1">Q. メンバーはMMQ登録が必要？</p>
+                <p className="text-gray-600 leading-relaxed">貸切リクエストの送信にはログインが必要ですが、<strong>グループへの参加はMMQ未登録でも可能</strong>です（ゲスト参加OK）。</p>
+              </div>
+              <div>
+                <p className="font-medium text-gray-900 mb-1">Q. メンバー全員をグループに追加しなくてもいい？</p>
+                <p className="text-gray-600 leading-relaxed mb-2">はい、<strong>全員を追加しなくても公演に支障はありません</strong>。ただし追加すると進捗確認や予約情報の共有に便利です。</p>
+                <p className="text-red-600 leading-relaxed mt-1">※ <strong>事前読み込みがあるシナリオ</strong>は、事前資料の配布にグループを使用するため<strong>全員の参加が必須</strong>です。</p>
+              </div>
+              <div>
+                <p className="font-medium text-gray-900 mb-1">Q. リクエスト送信後の流れは？</p>
+                <p className="text-gray-600 leading-relaxed">店舗側で候補日を確認し、日程を確定します。確定すると<strong>メールとグループ内の両方に通知</strong>が届きます。</p>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 
-      {/* ステップ説明 */}
-      <section className="max-w-2xl mx-auto px-4 py-12">
-        <div className="space-y-0">
-          {/* Step 1 */}
-          <div className="flex gap-4">
-            <div className="flex flex-col items-center">
-              <div 
-                className="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg"
-                style={{ backgroundColor: THEME.primary }}
-              >
-                1
-              </div>
-              <div className="w-0.5 flex-1 bg-gray-200 my-2" />
-            </div>
-            <div className="pb-8">
-              <h3 className="font-bold text-lg text-gray-900">シナリオを探す</h3>
-              <p className="text-gray-600 mt-2 leading-relaxed">
-                「ラインナップ」タブでシナリオ一覧から選べます。
-                <br />
-                「カレンダー」タブでは日程から空き状況を確認できます。
-              </p>
-            </div>
-          </div>
+      <hr className="max-w-3xl mx-auto border-gray-200" />
 
-          {/* Step 2 */}
-          <div className="flex gap-4">
-            <div className="flex flex-col items-center">
-              <div 
-                className="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg"
-                style={{ backgroundColor: THEME.primary }}
-              >
-                2
-              </div>
-              <div className="w-0.5 flex-1 bg-gray-200 my-2" />
-            </div>
-            <div className="pb-8">
-              <h3 className="font-bold text-lg text-gray-900">公演を選んで予約</h3>
-              <p className="text-gray-600 mt-2 leading-relaxed">
-                シナリオ詳細ページから参加したい日程・人数を選択します。
-              </p>
-            </div>
-          </div>
-
-          {/* Step 3 */}
-          <div className="flex gap-4">
-            <div className="flex flex-col items-center">
-              <div 
-                className="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg"
-                style={{ backgroundColor: THEME.primary }}
-              >
-                3
+      {/* ===== 便利機能 ===== */}
+      <section className="max-w-3xl mx-auto px-4 py-8 md:py-10">
+        <h2 className="text-lg sm:text-xl font-bold text-gray-900 mb-6 text-center">その他の便利な機能</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Card className="p-0 overflow-hidden border-gray-200">
+            <div className="px-4 py-3 border-b border-gray-100 bg-amber-50">
+              <div className="flex items-center gap-2">
+                <Clock className="w-4 h-4 text-amber-600" />
+                <h3 className="font-bold text-sm text-amber-700">キャンセル待ち</h3>
               </div>
             </div>
-            <div className="pb-4">
-              <h3 className="font-bold text-lg text-gray-900">予約完了！</h3>
-              <p className="text-gray-600 mt-2 leading-relaxed">
-                お名前・連絡先を入力して送信。確認メールが届きます。
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* 便利機能 */}
-      <section className="bg-gray-50 py-12">
-        <div className="max-w-2xl mx-auto px-4">
-          <h2 className="text-xl font-bold text-gray-900 mb-6 text-center">便利な機能</h2>
-          <div className="bg-white border border-gray-200 divide-y divide-gray-200">
-            <div className="px-4 py-4 flex items-start gap-3">
-              <Calendar className="w-5 h-5 text-gray-400 flex-shrink-0 mt-0.5" />
-              <div>
-                <p className="font-medium text-gray-900">カレンダーで空き確認</p>
-                <p className="text-sm text-gray-500 mt-1">店舗プルダウンで絞り込むと、その店舗の空き枠と貸切可能な日時が表示されます</p>
+            <div className="p-4">
+              <p className="text-xs text-gray-500 leading-relaxed mb-3">満席の公演でも「キャンセル待ち」ボタンから登録できます。空きが出たらメールでお知らせします。</p>
+              <div className="flex items-center gap-2 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                <span className="text-xs font-bold px-1.5 py-0.5 bg-gray-200 text-gray-500">満席</span>
+                <span className="text-xs text-gray-500">→</span>
+                <button className="px-3 py-1 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded">キャンセル待ち登録</button>
               </div>
             </div>
-            <div className="px-4 py-4 flex items-start gap-3">
-              <Users className="w-5 h-5 text-gray-400 flex-shrink-0 mt-0.5" />
-              <div>
-                <p className="font-medium text-gray-900">貸切予約</p>
-                <p className="text-sm text-gray-500 mt-1">お好きなシナリオを、お仲間だけで楽しめるプランです。カレンダーの空き枠にある「貸切申込」ボタンから日時・店舗を選んでリクエストできます</p>
+          </Card>
+          <Card className="p-0 overflow-hidden border-gray-200">
+            <div className="px-4 py-3 border-b border-gray-100 bg-pink-50">
+              <div className="flex items-center gap-2">
+                <Heart className="w-4 h-4 text-pink-500" />
+                <h3 className="font-bold text-sm text-pink-600">遊びたいリスト &amp; 体験済み</h3>
               </div>
             </div>
-            <div className="px-4 py-4 flex items-start gap-3">
-              <Clock className="w-5 h-5 text-gray-400 flex-shrink-0 mt-0.5" />
-              <div>
-                <p className="font-medium text-gray-900">キャンセル待ち</p>
-                <p className="text-sm text-gray-500 mt-1">満席の公演でもキャンセル待ち登録ができます</p>
+            <div className="p-4">
+              <p className="text-xs text-gray-500 leading-relaxed mb-3">気になるシナリオを保存して、あとからまとめてチェック。体験済みを記録すれば重複予約も防げます。</p>
+              <div className="flex items-center gap-4">
+                <div className="flex items-center gap-1.5 text-xs text-gray-600"><Heart className="w-4 h-4 text-red-500 fill-red-500" />遊びたい！</div>
+                <div className="flex items-center gap-1.5 text-xs text-gray-600"><CheckCheck className="w-4 h-4 text-green-500" />体験済み</div>
               </div>
             </div>
-          </div>
+          </Card>
+          <Card className="p-0 overflow-hidden border-gray-200">
+            <div className="px-4 py-3 border-b border-gray-100" style={{ backgroundColor: THEME.primaryLight }}>
+              <div className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" style={{ color: THEME.primary }} />
+                <h3 className="font-bold text-sm" style={{ color: THEME.primary }}>店舗フィルター</h3>
+              </div>
+            </div>
+            <div className="p-4">
+              <p className="text-xs text-gray-500 leading-relaxed mb-3">カレンダー・リスト表示では店舗で絞り込みが可能。行きやすい店舗だけを表示できます。</p>
+              <div className="flex flex-wrap gap-1.5">
+                <span className="px-2 py-0.5 text-[10px] bg-blue-50 text-blue-700 border border-blue-200 rounded">馬場</span>
+                <span className="px-2 py-0.5 text-[10px] bg-orange-50 text-orange-700 border border-orange-200 rounded">大久保</span>
+                <span className="px-2 py-0.5 text-[10px] bg-green-50 text-green-700 border border-green-200 rounded">別館①</span>
+                <span className="px-2 py-0.5 text-[10px] bg-purple-50 text-purple-700 border border-purple-200 rounded">仮設②</span>
+              </div>
+            </div>
+          </Card>
         </div>
       </section>
 
       {/* CTA */}
-      <section className="py-12">
+      <section className="py-10 md:py-12" style={{ backgroundColor: THEME.primaryLight }}>
         <div className="max-w-2xl mx-auto px-4 text-center">
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-900 mb-3">さっそくシナリオを探してみましょう！</h2>
+          <p className="text-sm text-gray-600 mb-6">100以上のマーダーミステリーシナリオからお気に入りを見つけてください</p>
           <Link to="/">
-            <Button
-              size="lg"
-              className="px-8"
-              style={{ backgroundColor: THEME.primary, borderRadius: 0 }}
-            >
+            <Button size="lg" className="px-8 text-base font-bold" style={{ backgroundColor: THEME.primary, borderRadius: 0 }}>
               シナリオを探す
               <ArrowRight className="w-5 h-5 ml-2" />
             </Button>

--- a/supabase/functions/auto-send-reminder-emails/index.ts
+++ b/supabase/functions/auto-send-reminder-emails/index.ts
@@ -20,18 +20,25 @@ serve(async (req) => {
 
     const supabaseClient = createClient(
       Deno.env.get('SUPABASE_URL') ?? '',
-      getServiceRoleKey(), // Service Role / Secret Key を使用
+      getServiceRoleKey(),
     )
 
-    // 現在の日時
+    // リクエストBodyから days_before を取得（デフォルト: 1＝前日）
+    let reminderDaysBefore = 1
+    try {
+      const body = await req.json()
+      if (body?.days_before && Number.isInteger(body.days_before) && body.days_before > 0) {
+        reminderDaysBefore = body.days_before
+      }
+    } catch {
+      // Bodyなし or パース不可 → デフォルト値を使用
+    }
+
     const now = new Date()
-    
-    // リマインダー送信設定を取得（デフォルトは3日前）
-    const reminderDaysBefore = 3
     const targetDate = new Date(now.getTime() + reminderDaysBefore * 86400000)
     const targetDateStr = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' }).format(targetDate)
 
-    console.log(`リマインダー送信対象日: ${targetDateStr}`)
+    console.log(`📧 リマインダー送信: ${reminderDaysBefore}日前 → 対象日 ${targetDateStr}`)
 
     // 対象日の予約を取得
     const { data: scheduleEvents, error: eventsError } = await supabaseClient
@@ -74,26 +81,8 @@ serve(async (req) => {
     let totalSent = 0
     let totalErrors = 0
 
-    // 各公演の予約者にリマインダーを送信（通常予約・貸切予約を含む）
     for (const event of scheduleEvents) {
       try {
-        // 該当公演の予約を取得
-        // デバッグ: まず全ての予約を確認（ステータス問わず）
-        const { data: allReservations, error: allResError } = await supabaseClient
-          .from('reservations')
-          .select('id, schedule_event_id, status, customer_id, requested_datetime')
-          .eq('schedule_event_id', event.id)
-
-        if (allResError) {
-          console.error(`公演 ${event.id} の予約取得エラー:`, allResError)
-        } else if (allReservations && allReservations.length > 0) {
-          console.log(`公演 ${event.id} の全予約数: ${allReservations.length}`, JSON.stringify(allReservations.map(r => ({ id: r.id, status: r.status, schedule_event_id: r.schedule_event_id }))))
-        } else {
-          console.log(`公演 ${event.id} にはschedule_event_idで紐付けられた予約がありません`)
-        }
-
-        // 該当公演の予約を取得（confirmed/pendingのみ）
-        // ステータスを拡張: gm_confirmedなども含める
         const { data: reservations, error: resError } = await supabaseClient
           .from('reservations')
           .select('*, customers(*)')
@@ -102,19 +91,11 @@ serve(async (req) => {
 
         if (resError) throw resError
 
-        if (!reservations || reservations.length === 0) {
-          console.log(`公演 ${event.id} に予約がありません（confirmed/pendingの予約のみ）`)
-          continue
-        }
-
-        console.log(`公演 ${event.id} の予約数: ${reservations.length}`)
+        if (!reservations || reservations.length === 0) continue
 
         // 各予約者にリマインダーメールを送信
         for (const reservation of reservations) {
-          if (!reservation.customers || !reservation.customers.email) {
-            console.log(`予約 ${reservation.id} に顧客情報がありません`)
-            continue
-          }
+          if (!reservation.customers || !reservation.customers.email) continue
 
           try {
             const { error: sendError } = await supabaseClient.functions.invoke('send-reminder-emails', {
@@ -133,7 +114,7 @@ serve(async (req) => {
                 participantCount: reservation.participant_count,
                 totalPrice: reservation.total_price || 0,
                 reservationNumber: reservation.reservation_number,
-                daysBefore: reminderDaysBefore  // 3日前なので3を渡す
+                daysBefore: reminderDaysBefore
               }
             })
 

--- a/supabase/functions/check-performance-cancellation/index.ts
+++ b/supabase/functions/check-performance-cancellation/index.ts
@@ -962,12 +962,15 @@ async function sendBusinessSummaryNotification(
       date,
       start_time,
       scenario,
+      scenario_master_id,
       current_participants,
       max_participants,
       organization_id,
       gms,
       store_id,
-      stores!inner(name)
+      stores!inner(name),
+      scenario_masters:scenario_master_id (player_count_max),
+      organization_scenarios:organization_scenario_id (override_player_count_max, scenario_masters:scenario_master_id (player_count_max))
     `)
     .eq('date', targetDateForQuery)
     .eq('is_recruitment_extended', true)
@@ -978,18 +981,27 @@ async function sendBusinessSummaryNotification(
   // 今回処理されたイベントを除外した、既に延長済みのイベント
   const alreadyExtendedDetails: EventDetail[] = (alreadyExtendedEvents || [])
     .filter(e => !processedEventIds.includes(e.id))
-    .map(e => ({
-      event_id: e.id,
-      date: e.date,
-      start_time: e.start_time,
-      scenario: e.scenario,
-      store_name: (e.stores as { name: string })?.name || '',
-      current_participants: e.current_participants || 0,
-      max_participants: e.max_participants || 8,
-      result: 'already_extended' as const,
-      organization_id: e.organization_id,
-      gms: e.gms || []
-    })) as EventDetail[]
+    .map(e => {
+      const orgScenario = e.organization_scenarios as { override_player_count_max?: number; scenario_masters?: { player_count_max?: number } } | null
+      const scenarioMaster = e.scenario_masters as { player_count_max?: number } | null
+      const maxParticipants = orgScenario?.override_player_count_max
+        || orgScenario?.scenario_masters?.player_count_max
+        || scenarioMaster?.player_count_max
+        || e.max_participants
+        || 8
+      return {
+        event_id: e.id,
+        date: e.date,
+        start_time: e.start_time,
+        scenario: e.scenario,
+        store_name: (e.stores as { name: string })?.name || '',
+        current_participants: e.current_participants || 0,
+        max_participants: maxParticipants,
+        result: 'already_extended' as const,
+        organization_id: e.organization_id,
+        gms: e.gms || []
+      }
+    }) as EventDetail[]
 
   console.log(`📊 既に延長済みのイベント: ${alreadyExtendedDetails.length}件`)
 

--- a/supabase/migrations/20260409110000_fix_cancellation_rpc_player_count.sql
+++ b/supabase/migrations/20260409110000_fix_cancellation_rpc_player_count.sql
@@ -1,0 +1,285 @@
+-- =============================================================================
+-- マイグレーション: 中止判定RPCの参加者数上限を正しく解決する
+-- =============================================================================
+--
+-- 問題:
+--   中止判定RPCが max_participants を以下の優先順位で取得していた:
+--     1. se.max_participants（イベント個別設定 - 古いデータでは8が設定されている場合あり）
+--     2. sm.player_count_max（scenario_masters経由 - organization_scenario_id JOINが必要）
+--     3. s.player_count_max（旧scenariosテーブル）
+--     4. フォールバック 8
+--
+--   これにより、組織のオーバーライド値が反映されず、
+--   6人用シナリオが8人として中止判定されるケースがあった。
+--
+-- 修正:
+--   - organization_scenarios.override_player_count_max を最優先で使用
+--   - scenario_master_id での直接JOINをフォールバックに追加
+--     （organization_scenario_id が NULL の古いイベント対応）
+--   - se.max_participants の優先順位を下げる
+-- =============================================================================
+
+-- 1. 前日判定を修正
+CREATE OR REPLACE FUNCTION check_performances_day_before()
+RETURNS TABLE(
+  events_checked INTEGER,
+  events_confirmed INTEGER,
+  events_extended INTEGER,
+  events_cancelled INTEGER,
+  details JSONB
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_events_checked INTEGER := 0;
+  v_events_confirmed INTEGER := 0;
+  v_events_extended INTEGER := 0;
+  v_events_cancelled INTEGER := 0;
+  v_details JSONB := '[]'::JSONB;
+  v_event RECORD;
+  v_current INTEGER;
+  v_reservation_count INTEGER;
+  v_unsynced_staff INTEGER;
+  v_max INTEGER;
+  v_half INTEGER;
+  v_result TEXT;
+  v_target_date_jst DATE;
+BEGIN
+  v_target_date_jst := (timezone('Asia/Tokyo', NOW())::date + 1);
+
+  FOR v_event IN
+    SELECT
+      se.id,
+      se.date,
+      se.start_time,
+      se.scenario,
+      se.gm_roles,
+      COALESCE(
+        os.override_player_count_max,
+        sm.player_count_max,
+        sm2.player_count_max,
+        se.max_participants,
+        s.player_count_max,
+        8
+      ) AS max_participants,
+      se.organization_id,
+      se.gms,
+      se.store_id,
+      st.name AS store_name
+    FROM schedule_events se
+    LEFT JOIN organization_scenarios os ON se.organization_scenario_id = os.id
+    LEFT JOIN scenario_masters sm ON os.scenario_master_id = sm.id
+    LEFT JOIN scenario_masters sm2 ON se.scenario_master_id = sm2.id
+    LEFT JOIN scenarios s ON se.scenario_id = s.id
+    LEFT JOIN stores st ON se.store_id = st.id
+    WHERE se.date = v_target_date_jst
+      AND se.is_cancelled = FALSE
+      AND se.is_recruitment_extended IS NOT TRUE
+      AND se.category = 'open'
+      AND se.scenario IS NOT NULL
+      AND se.scenario != ''
+    ORDER BY se.start_time
+  LOOP
+    v_events_checked := v_events_checked + 1;
+
+    SELECT COALESCE(SUM(r.participant_count), 0) INTO v_reservation_count
+    FROM reservations r
+    WHERE r.schedule_event_id = v_event.id
+      AND r.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in');
+
+    -- gm_roles のスタッフ参加で未同期分をカウント（サブクエリで jsonb_each_text を展開）
+    SELECT COUNT(*) INTO v_unsynced_staff
+    FROM (
+      SELECT key AS staff_name, value AS staff_role
+      FROM jsonb_each_text(COALESCE(v_event.gm_roles, '{}'::jsonb))
+    ) AS gm_staff
+    WHERE gm_staff.staff_role = 'staff'
+      AND NOT EXISTS (
+        SELECT 1 FROM reservations r2
+        WHERE r2.schedule_event_id = v_event.id
+          AND r2.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in')
+          AND r2.reservation_source = 'staff_entry'
+          AND gm_staff.staff_name = ANY(r2.participant_names)
+      );
+
+    v_current := v_reservation_count + v_unsynced_staff;
+    v_max := v_event.max_participants;
+    v_half := CEIL(v_max::NUMERIC / 2);
+
+    IF v_current >= v_half THEN
+      v_result := 'confirmed';
+      v_events_confirmed := v_events_confirmed + 1;
+    ELSE
+      v_result := 'extended';
+      v_events_extended := v_events_extended + 1;
+
+      UPDATE schedule_events
+      SET is_recruitment_extended = TRUE
+      WHERE id = v_event.id;
+    END IF;
+
+    v_details := v_details || jsonb_build_array(jsonb_build_object(
+      'event_id', v_event.id,
+      'date', v_event.date,
+      'start_time', v_event.start_time,
+      'scenario', v_event.scenario,
+      'store_name', v_event.store_name,
+      'current_participants', v_current,
+      'max_participants', v_max,
+      'half_required', v_half,
+      'result', v_result,
+      'organization_id', v_event.organization_id,
+      'gms', to_jsonb(v_event.gms)
+    ));
+  END LOOP;
+
+  RETURN QUERY SELECT v_events_checked, v_events_confirmed, v_events_extended, v_events_cancelled, v_details;
+END;
+$$;
+
+COMMENT ON FUNCTION check_performances_day_before IS
+'前日23:59に実行する公演中止判定（organization_scenariosのオーバーライドを反映）';
+
+-- 2. 4時間前判定を修正
+CREATE OR REPLACE FUNCTION check_performances_four_hours_before()
+RETURNS TABLE(
+  events_checked INTEGER,
+  events_confirmed INTEGER,
+  events_cancelled INTEGER,
+  details JSONB
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_events_checked INTEGER := 0;
+  v_events_confirmed INTEGER := 0;
+  v_events_cancelled INTEGER := 0;
+  v_details JSONB := '[]'::JSONB;
+  v_event RECORD;
+  v_current INTEGER;
+  v_reservation_count INTEGER;
+  v_unsynced_staff INTEGER;
+  v_max INTEGER;
+  v_result TEXT;
+  v_now TIMESTAMPTZ;
+  v_check_time TIMESTAMPTZ;
+BEGIN
+  v_now := NOW();
+  v_check_time := v_now + INTERVAL '4 hours';
+
+  RAISE NOTICE '4時間前チェック開始: NOW(JST)=%, CHECK_TIME(JST)=%',
+    timezone('Asia/Tokyo', v_now),
+    timezone('Asia/Tokyo', v_check_time);
+
+  FOR v_event IN
+    SELECT
+      se.id,
+      se.date,
+      se.start_time,
+      se.scenario,
+      se.gm_roles,
+      COALESCE(
+        os.override_player_count_max,
+        sm.player_count_max,
+        sm2.player_count_max,
+        se.max_participants,
+        s.player_count_max,
+        8
+      ) AS max_participants,
+      se.organization_id,
+      se.gms,
+      se.store_id,
+      st.name AS store_name,
+      (se.date::text || ' ' || se.start_time::text || '+09:00')::timestamptz AS event_datetime
+    FROM schedule_events se
+    LEFT JOIN organization_scenarios os ON se.organization_scenario_id = os.id
+    LEFT JOIN scenario_masters sm ON os.scenario_master_id = sm.id
+    LEFT JOIN scenario_masters sm2 ON se.scenario_master_id = sm2.id
+    LEFT JOIN scenarios s ON se.scenario_id = s.id
+    LEFT JOIN stores st ON se.store_id = st.id
+    WHERE se.is_recruitment_extended = TRUE
+      AND se.is_cancelled = FALSE
+      AND se.category = 'open'
+      AND se.scenario IS NOT NULL
+      AND se.scenario != ''
+      AND (se.date::text || ' ' || se.start_time::text || '+09:00')::timestamptz <= v_check_time
+      AND (se.date::text || ' ' || se.start_time::text || '+09:00')::timestamptz > v_now
+      AND NOT EXISTS (
+        SELECT 1 FROM performance_cancellation_logs pcl
+        WHERE pcl.schedule_event_id = se.id
+          AND pcl.check_type = 'four_hours_before'
+      )
+    ORDER BY se.date, se.start_time
+  LOOP
+    RAISE NOTICE 'イベント検出: id=%, scenario=%, datetime_jst=%',
+      v_event.id,
+      v_event.scenario,
+      timezone('Asia/Tokyo', v_event.event_datetime);
+
+    v_events_checked := v_events_checked + 1;
+
+    SELECT COALESCE(SUM(r.participant_count), 0) INTO v_reservation_count
+    FROM reservations r
+    WHERE r.schedule_event_id = v_event.id
+      AND r.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in');
+
+    -- gm_roles のスタッフ参加で未同期分をカウント
+    SELECT COUNT(*) INTO v_unsynced_staff
+    FROM (
+      SELECT key AS staff_name, value AS staff_role
+      FROM jsonb_each_text(COALESCE(v_event.gm_roles, '{}'::jsonb))
+    ) AS gm_staff
+    WHERE gm_staff.staff_role = 'staff'
+      AND NOT EXISTS (
+        SELECT 1 FROM reservations r2
+        WHERE r2.schedule_event_id = v_event.id
+          AND r2.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in')
+          AND r2.reservation_source = 'staff_entry'
+          AND gm_staff.staff_name = ANY(r2.participant_names)
+      );
+
+    v_current := v_reservation_count + v_unsynced_staff;
+    v_max := v_event.max_participants;
+
+    RAISE NOTICE '参加者数: reservation=%, unsynced_staff=%, total=%, max=%, half=%',
+      v_reservation_count, v_unsynced_staff, v_current, v_max, CEIL(v_max::NUMERIC / 2);
+
+    IF v_current >= 1 THEN
+      v_result := 'confirmed';
+      v_events_confirmed := v_events_confirmed + 1;
+    ELSE
+      v_result := 'cancelled';
+      v_events_cancelled := v_events_cancelled + 1;
+
+      UPDATE schedule_events
+      SET is_cancelled = TRUE
+      WHERE id = v_event.id;
+
+      INSERT INTO performance_cancellation_logs (schedule_event_id, check_type, result, participants_count, max_participants)
+      VALUES (v_event.id, 'four_hours_before', 'cancelled', v_current, v_max);
+    END IF;
+
+    v_details := v_details || jsonb_build_array(jsonb_build_object(
+      'event_id', v_event.id,
+      'date', v_event.date,
+      'start_time', v_event.start_time,
+      'scenario', v_event.scenario,
+      'store_name', v_event.store_name,
+      'current_participants', v_current,
+      'max_participants', v_max,
+      'result', v_result,
+      'organization_id', v_event.organization_id,
+      'gms', to_jsonb(v_event.gms)
+    ));
+  END LOOP;
+
+  RETURN QUERY SELECT v_events_checked, v_events_confirmed, v_events_cancelled, v_details;
+END;
+$$;
+
+COMMENT ON FUNCTION check_performances_four_hours_before IS
+'4時間前に実行する公演中止判定（organization_scenariosのオーバーライドを反映）';

--- a/supabase/migrations/20260410090000_enable_reminder_email_cron.sql
+++ b/supabase/migrations/20260410090000_enable_reminder_email_cron.sql
@@ -1,0 +1,91 @@
+-- =============================================================================
+-- マイグレーション: 前日リマインドメールの Cron ジョブを登録
+-- =============================================================================
+--
+-- 毎朝 9:00 JST (= 00:00 UTC) に auto-send-reminder-emails を呼び出し、
+-- 翌日の公演の予約者へリマインドメールを送信する。
+--
+-- Body に { "days_before": 1 } を渡すことで前日リマインドとして動作する。
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_jobid BIGINT;
+  v_supabase_url TEXT;
+  v_service_role_key TEXT;
+BEGIN
+  -- pg_cron が導入されているか確認
+  BEGIN
+    PERFORM 1 FROM cron.job LIMIT 1;
+  EXCEPTION
+    WHEN undefined_table OR undefined_object THEN
+      RAISE NOTICE 'ℹ️  cron.job が存在しません（pg_cron 未導入のためスキップ）';
+      RETURN;
+  END;
+
+  -- Supabase URL を取得
+  BEGIN
+    v_supabase_url := current_setting('app.settings.supabase_url', true);
+  EXCEPTION WHEN OTHERS THEN
+    v_supabase_url := 'https://cznpcewciwywcqcxktba.supabase.co';
+  END;
+
+  -- Service Role Key を取得
+  BEGIN
+    v_service_role_key := current_setting('app.settings.service_role_key', true);
+  EXCEPTION WHEN OTHERS THEN
+    RAISE EXCEPTION 'service_role_key が設定されていません。Supabase Dashboard の Settings > API から取得してください。';
+  END;
+
+  -- 既存のジョブを確認
+  SELECT jobid INTO v_jobid
+  FROM cron.job
+  WHERE jobname = 'auto-send-reminder-emails-day-before';
+
+  IF v_jobid IS NOT NULL THEN
+    PERFORM cron.alter_job(v_jobid, active => true);
+    RAISE NOTICE '✅ 前日リマインドメール cron を有効化しました (jobid: %)', v_jobid;
+  ELSE
+    -- 毎日 00:00 UTC = 09:00 JST
+    SELECT cron.schedule(
+      'auto-send-reminder-emails-day-before',
+      '0 0 * * *',
+      $cmd$
+      SELECT net.http_post(
+        url := current_setting('app.settings.supabase_url', true) || '/functions/v1/auto-send-reminder-emails',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || current_setting('app.settings.service_role_key', true),
+          'x-cron-secret', current_setting('app.settings.cron_secret', true)
+        ),
+        body := '{"days_before": 1}'::jsonb
+      );
+      $cmd$
+    ) INTO v_jobid;
+    RAISE NOTICE '✅ 前日リマインドメール cron を作成しました (jobid: %)', v_jobid;
+  END IF;
+END $$;
+
+-- 確認
+DO $$
+DECLARE
+  v_active BOOLEAN;
+  v_schedule TEXT;
+BEGIN
+  BEGIN
+    PERFORM 1 FROM cron.job LIMIT 1;
+  EXCEPTION
+    WHEN undefined_table OR undefined_object THEN
+      RETURN;
+  END;
+
+  SELECT active, schedule INTO v_active, v_schedule
+  FROM cron.job
+  WHERE jobname = 'auto-send-reminder-emails-day-before';
+
+  IF v_active IS NOT NULL THEN
+    RAISE NOTICE '📧 前日リマインドメール cron: active=%, schedule=%', v_active, v_schedule;
+  ELSE
+    RAISE WARNING '⚠️ 前日リマインドメール cron が見つかりませんでした';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- `auto-send-reminder-emails` Edge Function を改修し、リクエストBodyの `days_before` で送信日数を指定可能に（デフォルト: 1＝前日）
- 毎朝 9:00 JST に翌日の公演予約者へリマインドメールを自動送信する Cron ジョブをマイグレーションで登録

## 変更ファイル
- `supabase/functions/auto-send-reminder-emails/index.ts` — `days_before` パラメータ対応、デバッグログ整理
- `supabase/migrations/20260410090000_enable_reminder_email_cron.sql` — Cron ジョブ `auto-send-reminder-emails-day-before` 登録（`0 0 * * *` = 毎日 00:00 UTC = 09:00 JST）

## 動作フロー
```
毎朝 9:00 JST
 → pg_cron → POST auto-send-reminder-emails (body: {days_before: 1})
 → 翌日の schedule_events を検索（is_cancelled=false, is_reservation_enabled=true）
 → confirmed/pending/gm_confirmed の予約を取得
 → 各予約者に send-reminder-emails でリマインドメール送信
```

## Test plan
- [ ] ステージングにマイグレーション適用後、cron.job にジョブが登録されているか確認
- [ ] Edge Function のログで正常動作を確認
- [ ] テスト予約でリマインドメールが届くか確認


Made with [Cursor](https://cursor.com)