### PR TITLE
fix: 画像が読み込めなくなる問題を修正

### DIFF
--- a/src/components/ui/optimized-image.tsx
+++ b/src/components/ui/optimized-image.tsx
@@ -195,7 +195,7 @@ const LazyImage: React.FC<{
         }
       },
       {
-        rootMargin: '50px', // 50px前に読み込み開始
+        rootMargin: '50px',
         threshold: 0.1
       }
     )
@@ -205,10 +205,7 @@ const LazyImage: React.FC<{
     return () => observer.disconnect()
   }, [advancedLazy])
 
-  const handleLoad = () => setHasLoaded(true)
-
   if (!isVisible) {
-    // プレースホルダー表示（親から渡されたclassNameを尊重）
     return (
       <div
         ref={imgRef}
@@ -226,7 +223,8 @@ const LazyImage: React.FC<{
       alt={alt}
       loading={lazy ? 'lazy' : undefined}
       className={`${className} ${!hasLoaded ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
-      onLoad={handleLoad}
+      onLoad={() => setHasLoaded(true)}
+      onError={() => setHasLoaded(true)}
       {...props}
     />
   )
@@ -271,7 +269,7 @@ const LazyPicture: React.FC<{
         }
       },
       {
-        rootMargin: '50px', // 50px前に読み込み開始
+        rootMargin: '50px',
         threshold: 0.1
       }
     )
@@ -281,10 +279,7 @@ const LazyPicture: React.FC<{
     return () => observer.disconnect()
   }, [advancedLazy])
 
-  const handleLoad = () => setHasLoaded(true)
-
   if (!isVisible) {
-    // プレースホルダー表示（親から渡されたclassNameを尊重）
     return (
       <div
         ref={imgRef}
@@ -312,7 +307,8 @@ const LazyPicture: React.FC<{
         alt={alt}
         loading={lazy ? 'lazy' : undefined}
         className={`${className} ${!hasLoaded ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
-        onLoad={handleLoad}
+        onLoad={() => setHasLoaded(true)}
+        onError={() => setHasLoaded(true)}
         {...props}
       />
     </picture>

--- a/src/pages/PublicBookingTop/components/ScenarioCard.tsx
+++ b/src/pages/PublicBookingTop/components/ScenarioCard.tsx
@@ -44,6 +44,7 @@ export interface ScenarioCardData {
 const LazyImage = ({ src, alt, className }: { src?: string, alt: string, className?: string }) => {
   const [isLoaded, setIsLoaded] = useState(false)
   const [isInView, setIsInView] = useState(false)
+  const [useFallback, setUseFallback] = useState(false)
   const imgRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -64,10 +65,20 @@ const LazyImage = ({ src, alt, className }: { src?: string, alt: string, classNa
     return () => observer.disconnect()
   }, [])
 
-  // 最適化された画像URL（WebP + 幅400px + 品質80%）
   const optimizedSrc = getOptimizedImageUrl(src, { width: 400, format: 'webp', quality: 80 })
-  // 背景用（さらに小さく、低品質でOK）
   const bgSrc = getOptimizedImageUrl(src, { width: 100, format: 'webp', quality: 50 })
+
+  // Transform失敗時は元URLにフォールバック
+  const displaySrc = useFallback ? src : optimizedSrc
+  const displayBgSrc = useFallback ? src : bgSrc
+
+  const handleError = () => {
+    if (!useFallback && src && src !== optimizedSrc) {
+      setUseFallback(true)
+    } else {
+      setIsLoaded(true)
+    }
+  }
 
   return (
     <div ref={imgRef} className={`relative w-full h-full bg-gray-900 overflow-hidden ${className}`}>
@@ -76,24 +87,23 @@ const LazyImage = ({ src, alt, className }: { src?: string, alt: string, classNa
           <div className="w-8 h-8 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
         </div>
       )}
-      {isInView && optimizedSrc ? (
+      {isInView && displaySrc ? (
         <>
-          {/* 背景：ぼかした画像で余白を埋める（低品質でOK） */}
           <div 
             className="absolute inset-0 scale-110"
             style={{
-              backgroundImage: `url(${bgSrc})`,
+              backgroundImage: `url(${displayBgSrc})`,
               backgroundSize: 'cover',
               backgroundPosition: 'center',
               filter: 'blur(20px) brightness(0.7)',
             }}
           />
-          {/* メイン画像：全体を表示（WebP + リサイズ済み） */}
           <img
-            src={optimizedSrc}
+            src={displaySrc}
             alt={alt}
             className={`relative w-full h-full object-contain transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
             onLoad={() => setIsLoaded(true)}
+            onError={handleError}
             loading="lazy"
           />
         </>

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -338,6 +338,11 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
               src={getOptimizedImageUrl(organizationHeaderImageUrl, { width: 1200, format: 'webp', quality: 80 }) || organizationHeaderImageUrl} 
               alt=""
               className="absolute inset-0 w-full h-full object-cover"
+              onError={(e) => {
+                if (organizationHeaderImageUrl && e.currentTarget.src !== organizationHeaderImageUrl) {
+                  e.currentTarget.src = organizationHeaderImageUrl
+                }
+              }}
             />
             {/* 暗いオーバーレイで文字を読みやすく */}
             <div className="absolute inset-0 bg-black/50" />

--- a/src/pages/ScenarioDetailPage/components/RelatedScenarios.tsx
+++ b/src/pages/ScenarioDetailPage/components/RelatedScenarios.tsx
@@ -59,6 +59,11 @@ export const RelatedScenarios = memo(function RelatedScenarios({
                     alt={scenario.title}
                     className="relative w-full h-full object-contain"
                     loading="lazy"
+                    onError={(e) => {
+                      if (scenario.key_visual_url && e.currentTarget.src !== scenario.key_visual_url) {
+                        e.currentTarget.src = scenario.key_visual_url
+                      }
+                    }}
                   />
                 </>
               ) : (

--- a/src/pages/ScenarioDetailPage/components/ScenarioInfo.tsx
+++ b/src/pages/ScenarioDetailPage/components/ScenarioInfo.tsx
@@ -38,6 +38,11 @@ export const ScenarioInfo: React.FC<ScenarioInfoProps> = ({ scenario, organizati
                 alt={scenario.scenario_title}
                 className="w-full h-full object-cover"
                 loading="lazy"
+                onError={(e) => {
+                  if (scenario.key_visual_url && e.currentTarget.src !== scenario.key_visual_url) {
+                    e.currentTarget.src = scenario.key_visual_url
+                  }
+                }}
               />
             </div>
           )}

--- a/src/pages/ScenarioDetailPage/index.tsx
+++ b/src/pages/ScenarioDetailPage/index.tsx
@@ -459,6 +459,11 @@ export function ScenarioDetailPage({ scenarioId, onClose, organizationSlug }: Sc
                     alt={scenario.scenario_title}
                     className="w-full h-full object-cover"
                     loading="lazy"
+                    onError={(e) => {
+                      if (scenario.key_visual_url && e.currentTarget.src !== scenario.key_visual_url) {
+                        e.currentTarget.src = scenario.key_visual_url
+                      }
+                    }}
                   />
                 </div>
               )}

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -39,47 +39,10 @@ export function isSupabaseStorageUrl(url: string | undefined | null): boolean {
  */
 export function getOptimizedImageUrl(
   url: string | undefined | null,
-  options: ImageResizeOptions = {}
+  _options: ImageResizeOptions = {}
 ): string | undefined {
   if (!url) return undefined
-  
-  // Supabase Storage 以外のURLはそのまま返す（外部URL対応）
-  if (!isSupabaseStorageUrl(url)) {
-    return url
-  }
-  
-  const { width, height, quality = 80, format = 'origin' } = options
-  
-  try {
-    const urlObj = new URL(url)
-    const params = new URLSearchParams()
-    
-    // リサイズパラメータ
-    if (width) params.set('width', width.toString())
-    if (height) params.set('height', height.toString())
-    
-    // 品質パラメータ
-    if (quality !== 80) params.set('quality', quality.toString())
-    
-    // フォーマット変換（WebP等）
-    if (format !== 'origin') params.set('format', format)
-    
-    // パラメータがない場合は元のURLを返す
-    if (params.toString() === '') return url
-    
-    // 既存のクエリパラメータと結合
-    const existingParams = urlObj.searchParams.toString()
-    const newParams = params.toString()
-    const combinedParams = existingParams 
-      ? `${existingParams}&${newParams}` 
-      : newParams
-    
-    return `${urlObj.origin}${urlObj.pathname}?${combinedParams}`
-  } catch (error) {
-    // URLパースエラーの場合は元のURLを返す
-    logger.warn('Failed to optimize image URL:', error)
-    return url
-  }
+  return url
 }
 
 /**


### PR DESCRIPTION
## Summary
- Supabase Storage の Image Transform パラメータが拒否されるようになり、画像がスピナーのまま表示されなくなっていた
- `getOptimizedImageUrl` を無効化し元URLをそのまま返すように変更
- 全画像コンポーネントに `onError` フォールバックを追加（今後の安全策）

## Test plan
- [ ] 公開予約ページでシナリオカードの画像が正常に表示されること
- [ ] シナリオ詳細ページのキービジュアルが正常に表示されること
- [ ] 関連シナリオの画像が正常に表示されること

Made with [Cursor](https://cursor.com)