### PR TITLE
fix: セキュリティ脆弱性修正マイグレーションをリポジトリに追加

### DIFF
--- a/supabase/migrations/20260330010000_security_fix_users_role_escalation.sql
+++ b/supabase/migrations/20260330010000_security_fix_users_role_escalation.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- セキュリティ修正: users.role の権限昇格を防止
+-- =============================================================================
+-- 問題: 20260320020000 のポリシーでは、ログイン済みユーザーが
+--       自分の role を admin に書き換えられる可能性があった
+--       （WITH CHECK 句に role 変更の制限がなかったため）
+-- 修正: 一般ユーザーは role・organization_id を変更不可にする
+-- =============================================================================
+
+DROP POLICY IF EXISTS "users_update_self_or_admin" ON public.users;
+DROP POLICY IF EXISTS "users_update_self" ON public.users;
+
+CREATE POLICY "users_update_self_or_admin" ON public.users
+  FOR UPDATE
+  USING (
+    id = auth.uid()
+    OR public.is_staff_or_admin()
+    OR auth.role() = 'service_role'
+  )
+  WITH CHECK (
+    -- service_role / admin / staff は全フィールド変更可能
+    public.is_staff_or_admin()
+    OR auth.role() = 'service_role'
+    -- 一般ユーザーは自分のレコードを更新可能だが role・organization_id は変更不可
+    OR (
+      id = auth.uid()
+      AND role = (SELECT u.role FROM public.users u WHERE u.id = auth.uid())
+      AND (
+        organization_id IS NOT DISTINCT FROM
+        (SELECT u.organization_id FROM public.users u WHERE u.id = auth.uid())
+      )
+    )
+  );
+
+DO $$
+BEGIN
+  RAISE NOTICE '🔒 users テーブル: role・organization_id の自己変更を禁止しました';
+END $$;

--- a/supabase/migrations/20260330020000_security_fix_schedule_events_exposure.sql
+++ b/supabase/migrations/20260330020000_security_fix_schedule_events_exposure.sql
@@ -1,0 +1,73 @@
+-- =============================================================================
+-- セキュリティ修正: schedule_events の非公開レコード・内部カラム漏洩を修正
+-- =============================================================================
+-- 問題1（行レベル）: is_cancelled = false のみでフィルタしていたため、
+--   - is_reservation_enabled = false の非公開公演
+--   - category = 'gm_test' の内部テスト公演
+--   - is_private_booking = true の貸切公演
+--   - is_tentative = true の仮公演
+--   が anon ユーザーに見えていた
+--
+-- 問題2（カラムレベル）: select=* で以下の内部カラムが取得可能だった
+--   gms, gm_roles, notes, reservation_info,
+--   venue_rental_fee, total_revenue, gm_cost, license_cost,
+--   reservation_name, cancellation_reason 等
+-- =============================================================================
+
+-- =============================================================================
+-- 1. RLS ポリシーを更新（行レベル制限を強化）
+-- =============================================================================
+DROP POLICY IF EXISTS "schedule_events_select_public_safe" ON public.schedule_events;
+
+CREATE POLICY "schedule_events_select_public_safe" ON public.schedule_events
+  FOR SELECT
+  USING (
+    -- anon / 一般顧客: 公開条件を全て満たすレコードのみ
+    (
+      is_cancelled = false
+      AND is_reservation_enabled = true
+      AND category IN ('open', 'offsite')
+      AND (is_private_booking IS NULL OR is_private_booking = false)
+      AND (is_tentative IS NULL OR is_tentative = false)
+    )
+    -- staff / admin: 自組織の全イベントを閲覧可能
+    OR (
+      auth.uid() IS NOT NULL
+      AND organization_id = get_user_organization_id()
+    )
+  );
+
+-- =============================================================================
+-- 2. 内部カラムの anon SELECT 権限を剥奪（カラムレベルセキュリティ）
+-- =============================================================================
+-- GM・運営情報（スタッフのみ閲覧すべき）
+REVOKE SELECT (gms)                          ON public.schedule_events FROM anon;
+REVOKE SELECT (gm_roles)                     ON public.schedule_events FROM anon;
+REVOKE SELECT (notes)                        ON public.schedule_events FROM anon;
+REVOKE SELECT (reservation_info)             ON public.schedule_events FROM anon;
+REVOKE SELECT (reservation_notes)            ON public.schedule_events FROM anon;
+
+-- 財務情報（絶対非公開）
+REVOKE SELECT (venue_rental_fee)             ON public.schedule_events FROM anon;
+REVOKE SELECT (total_revenue)                ON public.schedule_events FROM anon;
+REVOKE SELECT (gm_cost)                      ON public.schedule_events FROM anon;
+REVOKE SELECT (license_cost)                 ON public.schedule_events FROM anon;
+REVOKE SELECT (participant_count)            ON public.schedule_events FROM anon;
+
+-- 予約者個人情報
+REVOKE SELECT (reservation_name)             ON public.schedule_events FROM anon;
+REVOKE SELECT (reservation_id)               ON public.schedule_events FROM anon;
+REVOKE SELECT (is_reservation_name_overwritten) ON public.schedule_events FROM anon;
+
+-- キャンセル理由（内部情報）
+REVOKE SELECT (cancellation_reason)          ON public.schedule_events FROM anon;
+REVOKE SELECT (cancelled_at)                 ON public.schedule_events FROM anon;
+
+-- 内部フラグ
+REVOKE SELECT (is_private_request)           ON public.schedule_events FROM anon;
+
+DO $$
+BEGIN
+  RAISE NOTICE '🔒 schedule_events: RLS ポリシーを強化し、公開条件を is_reservation_enabled + category でフィルタ';
+  RAISE NOTICE '🔒 schedule_events: 内部カラム（gms, gm_roles, 財務情報等）の anon SELECT を禁止';
+END $$;


### PR DESCRIPTION
## Summary

- `20260330010000`: `users.role` 権限昇格防止 — 一般ユーザーが自分の `role` / `organization_id` を変更できないよう `WITH CHECK` を強化
- `20260330020000`: `schedule_events` の anon 向け情報漏洩修正 — 非公開公演の行レベル制限強化 + 内部カラム（財務情報・GM情報等）の REVOKE

## 背景

外部セキュリティ研究者からの報告を受け、既にステージング・本番 DB に直接適用済み。リポジトリの migration ファイルとの整合性を取るために追加します。

なお、カラムレベル制限は後続の `20260412100000` でより包括的に対応済みのため、このマイグレーションは DB 適用履歴の整合性維持が主目的です。

## Test plan

- [ ] `npm run check:permissions` でパーミッション検証が通ること
- [ ] 一般ユーザーが自分の role を変更できないことを確認
- [ ] anon で schedule_events の内部カラムが取得できないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)