### PR TITLE
fix: シナリオ詳細403エラー・予約後残り席数未更新の修正

### DIFF
--- a/supabase/migrations/20260414110000_fix_authenticated_role_grants.sql
+++ b/supabase/migrations/20260414110000_fix_authenticated_role_grants.sql
@@ -1,0 +1,29 @@
+-- ====================================================================
+-- 修正: authenticated ロールへのビュー SELECT 権限付与
+--
+-- 問題: セキュリティマイグレーション群（20260412100000 等）は anon のみを
+--       対象に REVOKE/GRANT を行っていたが、organization_scenarios_with_master
+--       ビューへの authenticated ロールの SELECT 権限が明示付与されていなかった。
+--       これにより、ログインユーザーがシナリオ詳細ページで 403 エラーになっていた。
+--
+-- 原因: ビューを DROP+CREATE した際に既存の GRANT が消え、
+--       authenticated への再付与が漏れていた。
+-- ====================================================================
+
+-- 1. organization_scenarios_with_master ビュー
+GRANT SELECT ON public.organization_scenarios_with_master TO authenticated;
+
+-- 2. organization_scenarios テーブル（ビューの参照元, authenticated は未明示付与だった）
+GRANT SELECT ON public.organization_scenarios TO authenticated;
+
+-- 3. scenario_masters テーブル（ビューの参照元）
+GRANT SELECT ON public.scenario_masters TO authenticated;
+
+-- 確認ログ
+DO $$
+BEGIN
+  RAISE NOTICE '✅ authenticated ロールへのSELECT権限を付与:';
+  RAISE NOTICE '  - organization_scenarios_with_master (ビュー)';
+  RAISE NOTICE '  - organization_scenarios (テーブル)';
+  RAISE NOTICE '  - scenario_masters (テーブル)';
+END $$;


### PR DESCRIPTION
## 概要

2つのバグ修正 + DBマイグレーション（ステージング・本番適用済み）。

## 修正内容

### 1. シナリオ詳細ページで 403 エラー（シナリオが見つかりませんでした）

**原因**: セキュリティマイグレーション群がビューを `DROP VIEW + CREATE VIEW` した際に `authenticated` ロールへの GRANT が消え、ログインユーザーがシナリオ詳細を取得できなくなっていた。

**修正**: `20260414110000` で `organization_scenarios_with_master`・`organization_scenarios`・`scenario_masters` への `authenticated` SELECT 権限を明示付与。

### 2. 予約後にトップページの残り席数が更新されない

**原因（2点）**:
- React Query キャッシュ・sessionStorage スナップショットが予約完了後も残っていた
- `create_reservation_with_lock_v2` RPC が `checked_in` ステータスを在庫計算から除外していた

**修正**:
- `useBookingSubmit`: 予約成功後に `invalidateQueries` + `clearBookingDataSnapshot` を追加
- `20260414100000`: RPC の在庫チェックに `checked_in` を追加、`current_participants` 更新をトリガー経由に変更

## DB マイグレーション

| ファイル | 内容 | 適用済み |
|---------|------|---------|
| `20260414100000` | RPC checked_in 修正 | ✅ ステージング・本番 |
| `20260414110000` | authenticated GRANT 修正 | ✅ ステージング・本番 |

## 動作確認（ステージング済み）

- ✅ シナリオ詳細ページが正常表示
- ✅ 予約後にトップページの残り席数が正しく減少

🤖 Generated with [Claude Code](https://claude.com/claude-code)