### PR TITLE
fix: セキュリティ修正・招待リンク修正・残り席数キャッシュ修正

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -306,8 +306,10 @@ function AppRoutes() {
     const isCompleteProfilePage = location.pathname === '/complete-profile'
     // 認証フローページにいるログイン済み顧客はプロフィールゲート対象外（ループ防止）
     const isAuthPage = ['/signup', '/login', '/register', '/reset-password', '/set-password'].includes(location.pathname)
+    // 招待リンクはゲスト向けのため、ログイン済みでもプロフィールゲート対象外
+    const isInvitePage = location.pathname.startsWith('/group/invite/')
 
-    if (!user || user.role !== 'customer' || isCompleteProfilePage || isAuthPage) {
+    if (!user || user.role !== 'customer' || isCompleteProfilePage || isAuthPage || isInvitePage) {
       setIsProfileCheckRunning(false)
       return
     }

--- a/src/pages/PrivateGroupInvite/index.tsx
+++ b/src/pages/PrivateGroupInvite/index.tsx
@@ -1905,6 +1905,7 @@ export function PrivateGroupInvite() {
                           if (existingMemberId) {
                             const { error: deleteError } = await supabase.rpc('delete_guest_member', {
                               p_member_id: existingMemberId,
+                              p_invite_code: code ?? null,
                             })
                             if (deleteError) throw deleteError
                             toast.success('グループから退出しました')
@@ -3452,6 +3453,7 @@ export function PrivateGroupInvite() {
                   // RPC経由で削除（RLSを回避）
                   const { error: deleteError } = await supabase.rpc('delete_guest_member', {
                     p_member_id: existingMemberId,
+                    p_invite_code: code ?? null,
                   })
                   if (deleteError) throw deleteError
                   toast.success('グループから退出しました')

--- a/supabase/migrations/20260414120000_fix_private_group_member_delete_security.sql
+++ b/supabase/migrations/20260414120000_fix_private_group_member_delete_security.sql
@@ -1,0 +1,124 @@
+-- ====================================================================
+-- セキュリティ修正: private_group_members_pii と delete_guest_member RPC
+--
+-- 問題1: private_group_members_pii の UPDATE/DELETE ポリシーが USING(true) で
+--        anon が任意の行を変更・削除できた。
+--
+-- 問題2: delete_guest_member() が呼び出し元の権限を検証しておらず、
+--        member_id を知っていれば誰でも任意のメンバーを削除できた。
+-- ====================================================================
+
+-- ============================================================
+-- 1. private_group_members_pii の UPDATE/DELETE ポリシーを制限
+-- ============================================================
+
+-- 既存のポリシーを削除
+DROP POLICY IF EXISTS "private_group_members_pii_update" ON public.private_group_members_pii;
+DROP POLICY IF EXISTS "private_group_members_pii_delete" ON public.private_group_members_pii;
+
+-- UPDATE: スタッフ/管理者のみ（ゲストのPII更新はトリガー経由）
+CREATE POLICY "private_group_members_pii_update" ON public.private_group_members_pii
+  FOR UPDATE
+  USING (public.is_staff_or_admin());
+
+-- DELETE: スタッフ/管理者のみ（delete_guest_member RPC は SECURITY DEFINER で実行）
+CREATE POLICY "private_group_members_pii_delete" ON public.private_group_members_pii
+  FOR DELETE
+  USING (public.is_staff_or_admin());
+
+-- anon から直接の UPDATE/DELETE 権限を剥奪
+REVOKE UPDATE, DELETE ON public.private_group_members_pii FROM anon;
+
+-- ============================================================
+-- 2. delete_guest_member RPC に呼び出し元の権限検証を追加
+--
+-- 認証済み（authenticated）:
+--   - 本人（user_id = auth.uid()）または
+--   - そのグループの主催者のみ実行可
+--
+-- 未認証（anon/ゲスト）:
+--   - invite_code でグループ所属を確認
+--   - member_id だけでは削除不可
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.delete_guest_member(
+  p_member_id  UUID,
+  p_invite_code TEXT DEFAULT NULL  -- anon 用: グループ所属確認
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_member RECORD;
+BEGIN
+  SELECT * INTO v_member
+  FROM public.private_group_members
+  WHERE id = p_member_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Member not found' USING ERRCODE = 'P0404';
+  END IF;
+
+  IF v_member.is_organizer THEN
+    RAISE EXCEPTION 'Cannot delete organizer' USING ERRCODE = 'P0400';
+  END IF;
+
+  -- --------------------------------------------------------
+  -- 認証済みユーザー: 本人 or そのグループの主催者のみ
+  -- --------------------------------------------------------
+  IF auth.uid() IS NOT NULL THEN
+    -- 本人による退出
+    IF v_member.user_id = auth.uid() THEN
+      NULL; -- OK
+
+    -- グループの主催者による削除
+    ELSIF EXISTS (
+      SELECT 1 FROM public.private_group_members
+      WHERE group_id = v_member.group_id
+        AND user_id = auth.uid()
+        AND is_organizer = true
+    ) THEN
+      NULL; -- OK
+
+    ELSE
+      RAISE EXCEPTION 'Unauthorized: not a member or organizer of this group'
+        USING ERRCODE = 'P0401';
+    END IF;
+
+  -- --------------------------------------------------------
+  -- 未認証ゲスト: invite_code でグループ所属を確認
+  -- --------------------------------------------------------
+  ELSE
+    IF p_invite_code IS NULL OR p_invite_code = '' THEN
+      RAISE EXCEPTION 'Invite code required for guest deletion'
+        USING ERRCODE = 'P0401';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.private_groups pg
+      WHERE pg.id = v_member.group_id
+        AND pg.invite_code = p_invite_code
+    ) THEN
+      RAISE EXCEPTION 'Invalid invite code'
+        USING ERRCODE = 'P0401';
+    END IF;
+  END IF;
+
+  DELETE FROM public.private_group_members WHERE id = p_member_id;
+  RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_guest_member IS
+  'ゲストメンバーを削除する。認証済みは本人/主催者のみ、未認証は invite_code で所属確認。';
+
+-- 確認ログ
+DO $$
+BEGIN
+  RAISE NOTICE '🔒 セキュリティ修正完了:';
+  RAISE NOTICE '  - private_group_members_pii: anon の UPDATE/DELETE を禁止';
+  RAISE NOTICE '  - delete_guest_member: 呼び出し元の権限検証を追加（認証=本人/主催者, ゲスト=invite_code確認）';
+END $$;

--- a/supabase/migrations/20260414120000_fix_private_group_member_delete_security.sql
+++ b/supabase/migrations/20260414120000_fix_private_group_member_delete_security.sql
@@ -112,7 +112,7 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.delete_guest_member IS
+COMMENT ON FUNCTION public.delete_guest_member(UUID, TEXT) IS
   'ゲストメンバーを削除する。認証済みは本人/主催者のみ、未認証は invite_code で所属確認。';
 
 -- 確認ログ

--- a/supabase/rpcs/delete_guest_member.sql
+++ b/supabase/rpcs/delete_guest_member.sql
@@ -1,0 +1,80 @@
+-- 正規ソース: supabase/rpcs/delete_guest_member.sql
+-- 最終更新: 2026-04-14
+--
+-- ゲストメンバーを削除する。
+-- 認証済みは本人/主催者のみ、未認証は invite_code で所属確認。
+
+CREATE OR REPLACE FUNCTION public.delete_guest_member(
+  p_member_id  UUID,
+  p_invite_code TEXT DEFAULT NULL  -- anon 用: グループ所属確認
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_member RECORD;
+BEGIN
+  SELECT * INTO v_member
+  FROM public.private_group_members
+  WHERE id = p_member_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Member not found' USING ERRCODE = 'P0404';
+  END IF;
+
+  IF v_member.is_organizer THEN
+    RAISE EXCEPTION 'Cannot delete organizer' USING ERRCODE = 'P0400';
+  END IF;
+
+  -- --------------------------------------------------------
+  -- 認証済みユーザー: 本人 or そのグループの主催者のみ
+  -- --------------------------------------------------------
+  IF auth.uid() IS NOT NULL THEN
+    IF v_member.user_id = auth.uid() THEN
+      NULL; -- OK: 本人による退出
+
+    ELSIF EXISTS (
+      SELECT 1 FROM public.private_group_members
+      WHERE group_id = v_member.group_id
+        AND user_id = auth.uid()
+        AND is_organizer = true
+    ) THEN
+      NULL; -- OK: グループの主催者による削除
+
+    ELSE
+      RAISE EXCEPTION 'Unauthorized: not a member or organizer of this group'
+        USING ERRCODE = 'P0401';
+    END IF;
+
+  -- --------------------------------------------------------
+  -- 未認証ゲスト: invite_code でグループ所属を確認
+  -- --------------------------------------------------------
+  ELSE
+    IF p_invite_code IS NULL OR p_invite_code = '' THEN
+      RAISE EXCEPTION 'Invite code required for guest deletion'
+        USING ERRCODE = 'P0401';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.private_groups pg
+      WHERE pg.id = v_member.group_id
+        AND pg.invite_code = p_invite_code
+    ) THEN
+      RAISE EXCEPTION 'Invalid invite code'
+        USING ERRCODE = 'P0401';
+    END IF;
+  END IF;
+
+  DELETE FROM public.private_group_members WHERE id = p_member_id;
+  RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_guest_member(UUID, TEXT) IS
+  'ゲストメンバーを削除する。認証済みは本人/主催者のみ、未認証は invite_code で所属確認。';
+
+GRANT EXECUTE ON FUNCTION public.delete_guest_member(UUID, TEXT) TO anon;
+GRANT EXECUTE ON FUNCTION public.delete_guest_member(UUID, TEXT) TO authenticated;

--- a/supabase/schemas/private_group_members_pii.sql
+++ b/supabase/schemas/private_group_members_pii.sql
@@ -1,0 +1,49 @@
+-- 正規ソース: supabase/schemas/private_group_members_pii.sql
+-- 最終更新: 2026-04-14
+CREATE TABLE public.private_group_members_pii (
+  member_id  UUID PRIMARY KEY REFERENCES public.private_group_members(id) ON DELETE CASCADE,
+  guest_name TEXT,
+  guest_email TEXT,
+  guest_phone TEXT,
+  access_pin TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.private_group_members_pii IS 'グループメンバーの個人情報（管理者のみアクセス可）';
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_private_group_members_pii_email
+  ON public.private_group_members_pii(guest_email);
+
+-- RLS
+ALTER TABLE public.private_group_members_pii ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: anon 不可
+CREATE POLICY "private_group_members_pii_select_anon" ON public.private_group_members_pii
+  FOR SELECT TO anon
+  USING (false);
+
+-- SELECT: スタッフ/管理者のみ
+CREATE POLICY "private_group_members_pii_select_authenticated" ON public.private_group_members_pii
+  FOR SELECT TO authenticated
+  USING (public.is_staff_or_admin());
+
+-- INSERT: ゲスト登録用（トリガー経由）
+CREATE POLICY "private_group_members_pii_insert" ON public.private_group_members_pii
+  FOR INSERT
+  WITH CHECK (true);
+
+-- UPDATE: スタッフ/管理者のみ
+CREATE POLICY "private_group_members_pii_update" ON public.private_group_members_pii
+  FOR UPDATE
+  USING (public.is_staff_or_admin());
+
+-- DELETE: スタッフ/管理者のみ（delete_guest_member RPC は SECURITY DEFINER で実行）
+CREATE POLICY "private_group_members_pii_delete" ON public.private_group_members_pii
+  FOR DELETE
+  USING (public.is_staff_or_admin());
+
+-- Grants
+GRANT SELECT, INSERT ON public.private_group_members_pii TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.private_group_members_pii TO authenticated;


### PR DESCRIPTION
## Summary

- 予約完了後にトップページの残り席数が古い値を表示する問題を修正
- `private_group_members_pii` の UPDATE/DELETE ポリシーを anon 禁止に修正（セキュリティ）
- `delete_guest_member` RPC に呼び出し元の権限検証を追加（セキュリティ）
- ログイン済みユーザーが `/group/invite/*` にアクセスするとプロフィール補完画面にリダイレクトされる問題を修正

## DB マイグレーション（本番適用済み）

| ファイル | 内容 |
|----------|------|
| `20260414100000` | `create_reservation_with_lock_v2` 修正 |
| `20260414110000` | `authenticated` ロールへの SELECT 権限付与 |
| `20260414120000` | セキュリティ修正（PII ポリシー・RPC 権限検証） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)