### PR TITLE
fix: セキュリティ修正・貸切スロット表示バグ修正

### DIFF
--- a/src/hooks/usePrivateBookingSlotData.ts
+++ b/src/hooks/usePrivateBookingSlotData.ts
@@ -32,6 +32,7 @@ export function usePrivateBookingSlotData({
   privateBookingTimeSlots,
 }: UsePrivateBookingSlotDataOptions): UsePrivateBookingSlotDataResult {
   const [fallbackStoreIds, setFallbackStoreIds] = useState<string[]>([])
+  const [fallbackLoading, setFallbackLoading] = useState(false)
   const [allStoreEvents, setAllStoreEvents] = useState<any[]>([])
   const [businessHoursByStore, setBusinessHoursByStore] = useState<Map<string, BusinessHoursSettingRow>>(new Map())
   const [scenarioTiming, setScenarioTiming] = useState<ScenarioTimingFromDb | null>(null)
@@ -46,9 +47,11 @@ export function usePrivateBookingSlotData({
   useEffect(() => {
     if (storeIds.length > 0 || !isActive) {
       setFallbackStoreIds([])
+      setFallbackLoading(false)
       return
     }
     let cancelled = false
+    setFallbackLoading(true)
     ;(async () => {
       try {
         const { data } = await supabase
@@ -63,6 +66,8 @@ export function usePrivateBookingSlotData({
         }
       } catch {
         if (!cancelled) setFallbackStoreIds([])
+      } finally {
+        if (!cancelled) setFallbackLoading(false)
       }
     })()
     return () => { cancelled = true }
@@ -177,7 +182,7 @@ export function usePrivateBookingSlotData({
     return () => { cancelled = true }
   }, [isActive, organizationId, scenarioId])
 
-  const loading = eventsLoading || !eventsLoaded || !businessHoursLoaded || !scenarioTimingLoaded
+  const loading = fallbackLoading || eventsLoading || !eventsLoaded || !businessHoursLoaded || !scenarioTimingLoaded
 
   const resolvedTimeSlots = privateBookingTimeSlots ?? scenarioTiming?.private_booking_time_slots ?? undefined
 

--- a/src/lib/computePrivateBookingSlots.ts
+++ b/src/lib/computePrivateBookingSlots.ts
@@ -325,10 +325,24 @@ export function computePrivateBookingSlots(
     })
   }
 
-  return results.filter((slot) =>
+  const filtered = results.filter((slot) =>
     isPrivateBookingSlotAllowedByScenarioSettings(
       slot.label,
       privateBookingTimeSlots,
     ),
   )
+
+  // 午後と夜が重複する場合は午後を除外
+  // （週末に午後スロットが夜スロットの開始時刻をまたぐケースへの対処）
+  const eveningSlot = filtered.find(s => s.key === 'evening')
+  if (eveningSlot) {
+    const eveningStartMin = timeStrToMinutes(eveningSlot.startTime) ?? (19 * 60)
+    return filtered.filter(s => {
+      if (s.key !== 'afternoon') return true
+      const afternoonEndMin = timeStrToMinutes(s.endTime) ?? 0
+      return afternoonEndMin + PRIVATE_BOOKING_EVENT_INTERVAL_MINUTES <= eveningStartMin
+    })
+  }
+
+  return filtered
 }


### PR DESCRIPTION
## Summary

- `create_private_booking_request` RPC に認証チェック追加（anon 禁止・customer_id 本人確認）
- 貸切タイムスロット: 午後・夜が重複する場合に午後を除外
- 貸切タイムスロット: フォールバック店舗読み込み前のフラッシュを修正

## DB マイグレーション（本番適用済み）

| ファイル | 内容 |
|----------|------|
| `20260414150000` | create_private_booking_request 認証チェック |

🤖 Generated with [Claude Code](https://claude.com/claude-code)