### PR TITLE
fix: 予約・貸切・権限の複数バグ修正まとめ

### DIFF
--- a/src/components/modals/ScenarioEditDialogV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2.tsx
@@ -54,7 +54,7 @@ const TABS = [
   { id: 'gm', label: 'GM', icon: Users },
   { id: 'costs', label: '売上', icon: TrendingUp },
   { id: 'performances', label: '公演実績', icon: CalendarDays },
-  { id: 'survey', label: 'アンケート', icon: ClipboardList },
+  { id: 'survey', label: '事前配役アンケート', icon: ClipboardList },
 ] as const
 
 type TabId = typeof TABS[number]['id']

--- a/src/components/modals/ScenarioEditDialogV2/sections/GameInfoSectionV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2/sections/GameInfoSectionV2.tsx
@@ -360,22 +360,6 @@ export function GameInfoSectionV2({ formData, setFormData }: GameInfoSectionV2Pr
             </div>
           </div>
 
-          {/* 事前読み込み */}
-          <div className="flex items-start gap-2 mt-5 pt-4 border-t">
-            <Checkbox
-              id="has_pre_reading"
-              checked={formData.has_pre_reading}
-              onCheckedChange={(checked) => setFormData(prev => ({ ...prev, has_pre_reading: checked === true }))}
-              className="mt-0.5"
-            />
-            <div>
-              <Label htmlFor="has_pre_reading" className="text-sm cursor-pointer">
-                事前読み込みあり
-              </Label>
-              <p className={hintStyle}>ONにすると予約時に「事前に資料を読む必要があります」と表示されます</p>
-            </div>
-          </div>
-
           {/* 貸切受付不可時間帯 */}
           <div className="mt-5 pt-4 border-t">
             <Label className={labelStyle}>貸切受付不可時間帯</Label>

--- a/src/components/modals/ScenarioEditDialogV2/sections/SurveySectionV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2/sections/SurveySectionV2.tsx
@@ -246,6 +246,10 @@ export function SurveySectionV2({ formData, setFormData }: SurveySectionV2Props)
                     <SelectItem value="3">3日前まで</SelectItem>
                     <SelectItem value="5">5日前まで</SelectItem>
                     <SelectItem value="7">7日前まで</SelectItem>
+                    <SelectItem value="10">10日前まで</SelectItem>
+                    <SelectItem value="14">14日前まで</SelectItem>
+                    <SelectItem value="21">21日前まで</SelectItem>
+                    <SelectItem value="30">30日前まで</SelectItem>
                   </SelectContent>
                 </Select>
                 <p className={hintStyle}>

--- a/src/components/schedule/ImportScheduleModal.tsx
+++ b/src/components/schedule/ImportScheduleModal.tsx
@@ -1147,7 +1147,7 @@ export function ImportScheduleModal({ isOpen, onClose, currentDisplayDate, onImp
         const { error, data } = await supabase
           .from('schedule_events')
           .insert(newInserts)
-          .select()
+          .select('id')
         
         logger.log('📥 新規挿入結果:', { error, insertedCount: data?.length })
         
@@ -1450,7 +1450,7 @@ export function ImportScheduleModal({ isOpen, onClose, currentDisplayDate, onImp
         const endDate = `${targetMonth.year}-${String(targetMonth.month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
         
         const { data } = await supabase
-          .from('schedule_events')
+          .from('schedule_events_staff_view')
           .select('id, date, store_id, start_time, is_cancelled, scenario, notes, gms, reservation_info')
           .gte('date', startDate)
           .lte('date', endDate)

--- a/src/components/schedule/modal/ReservationList.tsx
+++ b/src/components/schedule/modal/ReservationList.tsx
@@ -679,7 +679,7 @@ ${content.organizationName || '店舗'}
       if (isStaff && onGmsChange && cancellingReservation.participant_names?.length) {
         const staffName = cancellingReservation.participant_names[0]
         const { data: eventData } = await supabase
-          .from('schedule_events')
+          .from('schedule_events_staff_view')
           .select('gms, gm_roles')
           .eq('id', event.id)
           .single()

--- a/src/hooks/useEventOperations.ts
+++ b/src/hooks/useEventOperations.ts
@@ -1277,7 +1277,7 @@ export function useEventOperations({
           
           // 履歴用: 更新前の値を取得
           let oldEventQuery = supabase
-            .from('schedule_events')
+            .from('schedule_events_staff_view')
             .select('id, organization_id, date, venue, store_id, scenario, scenario_master_id, gms, gm_roles, start_time, end_time, category, capacity, max_participants, notes, is_cancelled, is_tentative, is_reservation_enabled, reservation_name, time_slot, venue_rental_fee')
             .eq('id', performanceData.id)
           if (organizationId) {
@@ -1482,14 +1482,14 @@ export function useEventOperations({
         if (reservation?.schedule_event_id) {
           // 削除前にイベント情報を取得（履歴用）
           let eventQuery = supabase
-            .from('schedule_events')
+            .from('schedule_events_staff_view')
             .select('id, organization_id, date, venue, store_id, scenario, scenario_master_id, gms, gm_roles, start_time, end_time, category, capacity, max_participants, notes, is_cancelled, is_tentative, is_reservation_enabled, reservation_name, time_slot, venue_rental_fee')
             .eq('id', reservation.schedule_event_id)
           if (organizationId) {
             eventQuery = eventQuery.eq('organization_id', organizationId)
           }
           const { data: eventToDelete } = await eventQuery.single()
-          
+
           let scheduleDeleteQuery = supabase
             .from('schedule_events')
             .delete()
@@ -1570,7 +1570,7 @@ export function useEventOperations({
         // 予約がない場合のみ削除を実行
         // 削除前にイベント情報を取得（履歴用）
         let eventQuery = supabase
-          .from('schedule_events')
+          .from('schedule_events_staff_view')
           .select('id, organization_id, date, venue, store_id, scenario, scenario_master_id, gms, gm_roles, start_time, end_time, category, capacity, max_participants, notes, is_cancelled, is_tentative, is_reservation_enabled, reservation_name, time_slot, venue_rental_fee')
           .eq('id', deletingEvent.id)
         if (organizationId) {
@@ -1669,7 +1669,7 @@ export function useEventOperations({
         if (reservation?.schedule_event_id) {
           // 削除前にイベント情報を取得（履歴用）
           let eventQuery = supabase
-            .from('schedule_events')
+            .from('schedule_events_staff_view')
             .select('id, organization_id, date, venue, store_id, scenario, scenario_master_id, gms, gm_roles, start_time, end_time, category, capacity, max_participants, notes, is_cancelled, is_tentative, is_reservation_enabled, reservation_name, time_slot, venue_rental_fee')
             .eq('id', reservation.schedule_event_id)
           if (organizationId) {

--- a/src/hooks/usePrivateBookingSlotData.ts
+++ b/src/hooks/usePrivateBookingSlotData.ts
@@ -99,8 +99,8 @@ export function usePrivateBookingSlotData({
         windowEnd.setDate(today.getDate() + 180)
 
         const { data, error } = await supabase
-          .from('schedule_events')
-          .select('id, date, store_id, start_time, end_time, is_cancelled, stores(id, name)')
+          .from('schedule_events_public')
+          .select('id, date, store_id, start_time, end_time, is_cancelled')
           .in('store_id', effectiveStoreIds)
           .gte('date', today.toISOString().split('T')[0])
           .lte('date', windowEnd.toISOString().split('T')[0])

--- a/src/hooks/usePrivateBookingSlotData.ts
+++ b/src/hooks/usePrivateBookingSlotData.ts
@@ -100,7 +100,7 @@ export function usePrivateBookingSlotData({
 
         const { data, error } = await supabase
           .from('schedule_events')
-          .select('*, stores(id, name)')
+          .select('id, date, store_id, start_time, end_time, is_cancelled, stores(id, name)')
           .in('store_id', effectiveStoreIds)
           .gte('date', today.toISOString().split('T')[0])
           .lte('date', windowEnd.toISOString().split('T')[0])

--- a/src/hooks/usePrivateGroup.ts
+++ b/src/hooks/usePrivateGroup.ts
@@ -156,7 +156,7 @@ async function enrichGroupWithViewData(
   try {
     const { data: viewRow } = await supabase
       .from('organization_scenarios_with_master')
-      .select('characters, player_count_min, player_count_max')
+      .select('characters, player_count_min, player_count_max, survey_enabled')
       .eq('scenario_master_id', data.scenario_master_id)
       .eq('organization_id', data.organization_id)
       .maybeSingle()
@@ -165,6 +165,7 @@ async function enrichGroupWithViewData(
     if (viewRow.characters) {
       (data.scenario_masters as Record<string, unknown>).characters = viewRow.characters
     }
+    ;(data.scenario_masters as Record<string, unknown>).survey_enabled = viewRow.survey_enabled ?? false
     if (typeof viewRow.player_count_min === 'number' && typeof viewRow.player_count_max === 'number') {
       data.scenario_masters.effective_player_count_min = viewRow.player_count_min
       data.scenario_masters.effective_player_count_max = viewRow.player_count_max

--- a/src/hooks/useScheduleData.ts
+++ b/src/hooks/useScheduleData.ts
@@ -48,7 +48,7 @@ export async function addDemoParticipantsToPastUnderfullEvents(): Promise<{ succ
     
     // 今日以前の公演を取得（中止されていない、カテゴリーがopenまたはgmtest、組織でフィルタ）
     const { data: pastEvents, error: eventsError } = await supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(`
         id,
         date,

--- a/src/lib/api/salesApi.ts
+++ b/src/lib/api/salesApi.ts
@@ -321,7 +321,7 @@ export const salesApi = {
     const orgId = await getCurrentOrganizationId()
     
     let query = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(`
         date,
         scenario_masters:scenario_master_id (

--- a/src/lib/api/salesApi.ts
+++ b/src/lib/api/salesApi.ts
@@ -18,7 +18,7 @@ export const salesApi = {
     
     // まずschedule_eventsを取得
     let query = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(SCHEDULE_EVENT_SALES_SELECT_FIELDS)
       .gte('date', startDate)
       .lte('date', endDate)
@@ -237,7 +237,7 @@ export const salesApi = {
     const orgId = await getCurrentOrganizationId()
     
     let query = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(`
         *,
         stores:store_id (
@@ -263,13 +263,13 @@ export const salesApi = {
       .gte('date', startDate)
       .lte('date', endDate)
       .eq('is_cancelled', false)
-    
+
     if (orgId) {
       query = query.eq('organization_id', orgId)
     }
-    
+
     const { data, error } = await query
-    
+
     if (error) throw error
     return data || []
   },
@@ -277,9 +277,9 @@ export const salesApi = {
   // シナリオ別売上データを取得
   async getSalesByScenario(startDate: string, endDate: string) {
     const orgId = await getCurrentOrganizationId()
-    
+
     let query = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(`
         *,
         stores:store_id (
@@ -368,7 +368,7 @@ export const salesApi = {
     const orgId = await getCurrentOrganizationId()
     
     let query = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(SCHEDULE_EVENT_SALES_SELECT_FIELDS)
       .gte('date', startDate)
       .lte('date', endDate)

--- a/src/lib/api/scenarioApi.ts
+++ b/src/lib/api/scenarioApi.ts
@@ -722,7 +722,7 @@ export const scenarioApi = {
     // 公演イベントを取得して売上・コストを集計（今日まで、出張公演除外）
     // ※ 中止公演もリスト表示のため取得（サマリー計算からは除外）
     let eventsQuery = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select('id, date, category, current_participants, total_revenue, gm_cost, license_cost, start_time, store_id, is_cancelled, stores:store_id(venue_cost_per_performance)')
       .eq('scenario_master_id', scenarioId)
       .lte('date', today)
@@ -946,7 +946,7 @@ export const scenarioApi = {
       const to = from + pageSize - 1
       
       let query = supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('scenario_master_id, is_cancelled, total_revenue, date, category')
         .lte('date', today)
         .neq('category', 'offsite')

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -1073,22 +1073,10 @@ export const scheduleApi = {
         query = query.eq('updated_at', expectedUpdatedAt)
       }
 
-      const { data, error } = await query
-        .select(`
-          *,
-          stores:store_id (
-            id,
-            name,
-            short_name
-          ),
-          scenario_masters:scenario_master_id (
-            id,
-            title
-          )
-        `)
-        .single()
+      // id のみ返す（authenticated のカラム制限を回避、楽観的ロック失敗検出には十分）
+      const { data, error } = await query.select('id').single()
 
-      if (!error) return data
+      if (!error) break
 
       // 楽観的ロック失敗（PGRST116 = 0 rows = 他の人が先に更新した）
       if (expectedUpdatedAt && error.code === 'PGRST116') {
@@ -1103,7 +1091,28 @@ export const scheduleApi = {
       logger.warn(`schedule_events update: missing column "${removal.removedColumn}", retrying without it`)
     }
 
-    throw lastError
+    if (lastError) throw lastError
+
+    // スタッフ専用ビューから全カラム（JOIN含む）を取得して返す（INSERT と同パターン）
+    const { data: fullEvent, error: fetchError } = await supabase
+      .from('schedule_events_staff_view')
+      .select(`
+        *,
+        stores:store_id (
+          id,
+          name,
+          short_name
+        ),
+        scenario_masters:scenario_master_id (
+          id,
+          title
+        )
+      `)
+      .eq('id', id)
+      .single()
+
+    if (fetchError) throw fetchError
+    return fullEvent
   },
 
   // 公演を削除（関連する予約はCASCADEで自動削除）

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -225,7 +225,7 @@ export const scheduleApi = {
     
     // 1. GM（メインGM/サブGM）として割り当てられた公演を取得
     let gmQuery = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(`
         *,
         stores:store_id (
@@ -380,9 +380,9 @@ export const scheduleApi = {
     const lastDay = new Date(year, month, 0).getDate()
     const endDate = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
     
-    // 通常公演を取得（必要なカラムのみ選択してパフォーマンス向上）
+    // 通常公演を取得（スタッフ専用ビュー経由で全カラムにアクセス）
     let query = supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select(`
         id,
         date,
@@ -760,7 +760,10 @@ export const scheduleApi = {
     let query = supabase
       .from('schedule_events')
       .select(`
-        *,
+        id, date, start_time, end_time, time_slot,
+        store_id, scenario_master_id, organization_scenario_id,
+        category, is_cancelled, is_reservation_enabled,
+        current_participants, max_participants, capacity, organization_id,
         stores:store_id (
           id,
           name,
@@ -941,28 +944,22 @@ export const scheduleApi = {
       finalData.category = 'open'
     }
     
+    // INSERT: id のみ返す（authenticated のカラム制限を回避）
+    // 全カラムの取得はスタッフ専用ビューから別途行う
     let insertPayload: Record<string, unknown> = { ...finalData }
     let lastError: { message?: string; details?: string; hint?: string } | null = null
+    let insertedId: string | null = null
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const { data, error } = await supabase
         .from('schedule_events')
         .insert([insertPayload])
-        .select(`
-          *,
-          stores:store_id (
-            id,
-            name,
-            short_name
-          ),
-          scenario_masters:scenario_master_id (
-            id,
-            title,
-            player_count_max
-          )
-        `)
+        .select('id')
         .single()
 
-      if (!error) return data
+      if (!error) {
+        insertedId = data.id
+        break
+      }
 
       lastError = error
       const removal = removeMissingScheduleColumn(insertPayload, error)
@@ -972,7 +969,29 @@ export const scheduleApi = {
       logger.warn(`schedule_events insert: missing column "${removal.removedColumn}", retrying without it`)
     }
 
-    throw lastError
+    if (!insertedId) throw lastError
+
+    // スタッフ専用ビューから全カラム（JOIN含む）を取得して返す
+    const { data: fullEvent, error: fetchError } = await supabase
+      .from('schedule_events_staff_view')
+      .select(`
+        *,
+        stores:store_id (
+          id,
+          name,
+          short_name
+        ),
+        scenario_masters:scenario_master_id (
+          id,
+          title,
+          player_count_max
+        )
+      `)
+      .eq('id', insertedId)
+      .single()
+
+    if (fetchError) throw fetchError
+    return fullEvent
   },
 
   // 公演を更新
@@ -1114,14 +1133,21 @@ export const scheduleApi = {
       updateData.cancelled_at = null
     }
     
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('schedule_events')
       .update(updateData)
       .eq('id', id)
-      .select()
-      .single()
-    
+
     if (error) throw error
+
+    // スタッフ専用ビューから更新後のデータを取得（カラム制限を回避）
+    const { data, error: fetchError } = await supabase
+      .from('schedule_events_staff_view')
+      .select()
+      .eq('id', id)
+      .single()
+
+    if (fetchError) throw fetchError
     return data
   },
 
@@ -1132,7 +1158,7 @@ export const scheduleApi = {
       const orgId = await getCurrentOrganizationId()
       
       let query = supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('id, organization_id, scenario_master_id, scenario, store_id, date, start_time, category, gms, capacity, max_participants')
         .eq('is_cancelled', false)
         .order('date', { ascending: true })

--- a/src/lib/api/staffApi.ts
+++ b/src/lib/api/staffApi.ts
@@ -113,7 +113,7 @@ export const staffApi = {
       
       // 1. schedule_eventsのgms配列を更新
       let scheduleQuery = supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('id, gms')
         .contains('gms', [oldName])
       if (orgId) scheduleQuery = scheduleQuery.eq('organization_id', orgId)

--- a/src/pages/AddDemoParticipants.tsx
+++ b/src/pages/AddDemoParticipants.tsx
@@ -91,7 +91,7 @@ export function AddDemoParticipants() {
       // 今日以前の公演を取得（全カテゴリ対象、組織フィルタ付き）
       log('公演を取得中（全カテゴリ）...', 'info')
       let eventsQuery = supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('id, date, venue, scenario, scenario_master_id, gms, start_time, end_time, category, is_cancelled, current_participants, capacity, organization_id')
         .lte('date', today.toISOString().split('T')[0])
         .eq('is_cancelled', false)

--- a/src/pages/BookingConfirmation/hooks/useBookingSubmit.ts
+++ b/src/pages/BookingConfirmation/hooks/useBookingSubmit.ts
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/utils/logger'
 import { formatDate } from '../utils/bookingFormatters'
-import { getCurrentParticipantsCount } from '@/lib/participantUtils'
 import { reservationApi } from '@/lib/reservationApi'
 import { hasNonEmptyCustomerPhone, MSG_CUSTOMER_PHONE_REQUIRED_FOR_BOOKING } from '@/lib/customerPhonePolicy'
 import { clearBookingDataSnapshot } from '@/pages/PublicBookingTop/utils/bookingDataSnapshot'
@@ -230,10 +229,11 @@ const checkReservationLimits = async (
   customerEmail?: string
 ): Promise<{ allowed: boolean; reason?: string }> => {
   try {
-    // 公演の最大参加人数とstore_idを取得（公開用ビュー）
+    // 公演の最大参加人数・現在参加人数・store_idを取得（公開用ビュー）
+    // current_participants はトリガーで常に再計算されるため、正確な集計値として使用
     const { data: eventData, error: eventError } = await supabase
       .from('schedule_events_public')
-      .select('max_participants, capacity, reservation_deadline_hours, store_id')
+      .select('max_participants, capacity, current_participants, reservation_deadline_hours, store_id')
       .eq('id', eventId)
       .single()
 
@@ -267,9 +267,11 @@ const checkReservationLimits = async (
       return { allowed: false, reason: `最大参加人数は${maxParticipants}名です` }
     }
 
-    // 🚨 CRITICAL: 現在の参加人数を予約テーブルから直接集計
-    // DBのcurrent_participantsは古い可能性があるため、信頼しない
-    const currentParticipants = await getCurrentParticipantsCount(eventId)
+    // 🚨 CRITICAL: 現在の参加人数を schedule_events_public.current_participants から取得
+    // reservations テーブルは RLS により顧客自身の行しか見えないため直接集計できない。
+    // current_participants はトリガー（recalc_current_participants_for_event）によって
+    // INSERT/UPDATE/DELETE 後に常に再計算されるため、信頼できる集計値として使用する。
+    const currentParticipants = eventData.current_participants ?? 0
     logger.log(`空席チェック: eventId=${eventId}, current=${currentParticipants}, max=${maxParticipants}, requesting=${participantCount}`)
 
     if ((currentParticipants + participantCount) > maxParticipants) {

--- a/src/pages/GMAvailabilityCheck/hooks/useAvailabilityCheck.ts
+++ b/src/pages/GMAvailabilityCheck/hooks/useAvailabilityCheck.ts
@@ -53,7 +53,7 @@ export function useAvailabilityCheck() {
     
     // その日・その店舗の既存公演を取得
     const { data: existingEvents } = await supabase
-      .from('schedule_events')
+      .from('schedule_events_staff_view')
       .select('start_time, end_time')
       .eq('date', candidate.date)
       .eq('store_id', storeId)

--- a/src/pages/GMAvailabilityCheck/hooks/useAvailabilityCheck.ts
+++ b/src/pages/GMAvailabilityCheck/hooks/useAvailabilityCheck.ts
@@ -104,7 +104,7 @@ export function useAvailabilityCheck() {
       const dates = Array.from(new Set(request.candidate_datetimes.candidates.map(c => c.date).filter(Boolean)))
       if (dates.length > 0) {
         const { data: gmEvents } = await supabase
-          .from('schedule_events')
+          .from('schedule_events_staff_view')
           .select('date, start_time, end_time, gms')
           .in('date', dates)
           .eq('is_cancelled', false)

--- a/src/pages/Manual/ReservationManual.tsx
+++ b/src/pages/Manual/ReservationManual.tsx
@@ -1,6 +1,6 @@
-import { 
-  CheckCircle2, AlertCircle, 
-  Search, Mail, MessageSquare, Clock, XCircle
+import {
+  CheckCircle2, AlertCircle,
+  Search, Mail, MessageSquare, Clock, XCircle, Trash2
 } from 'lucide-react'
 
 export function ReservationManual() {
@@ -107,6 +107,26 @@ export function ReservationManual() {
                 電話などでキャンセル連絡を受けた場合は、管理画面から手動でステータスを「キャンセル」に変更してください。
                 メモ欄に「電話にて受付（担当：〇〇）」と残しておくと、後で経緯が分かりやすくなります。
               </p>
+          </div>
+
+          <div className="border rounded-lg p-4 hover:bg-muted/20 transition-colors">
+            <div className="flex items-center gap-2 mb-2">
+              <Trash2 className="h-4 w-4 text-muted-foreground" />
+              <h4 className="font-medium text-sm">貸切グループの削除依頼が届いた場合</h4>
+            </div>
+            <div className="text-sm text-muted-foreground space-y-2">
+              <p>お客様からメールなどで「グループを消したい」と連絡が来た場合の対応手順です。</p>
+              <ol className="list-decimal pl-5 space-y-1">
+                <li>メール本文に記載の<strong>招待コード</strong>（例: A65EPKHY）を手元に控えます。</li>
+                <li>管理画面の<strong>「貸切確認」</strong>ページを開きます。</li>
+                <li>検索欄に招待コードを入力し、該当のグループを見つけます。</li>
+                <li>カードをクリックして詳細を開き、一番下にある<strong>「この申込を完全に削除する」</strong>（赤いリンク）をクリックします。</li>
+                <li>確認ダイアログが表示されたら「OK」を押して完了です。</li>
+              </ol>
+              <div className="bg-red-50 border border-red-200 rounded p-2 text-xs text-red-700 mt-2">
+                <strong>注意:</strong> 削除すると、グループ・メンバー・候補日程・チャット履歴がすべて消えます。復元はできないため、お客様の意思を必ず確認してから実行してください。
+              </div>
+            </div>
           </div>
 
           <div className="border rounded-lg p-4 hover:bg-muted/20 transition-colors">

--- a/src/pages/MyPage/pages/GmHistoryPage.tsx
+++ b/src/pages/MyPage/pages/GmHistoryPage.tsx
@@ -50,7 +50,7 @@ export function GmHistoryPage() {
     try {
       // スタッフが担当した公演を取得
       const { data, error } = await supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('scenario, date, venue')
         .contains('gms', [staffInfo.name])
         .eq('is_cancelled', false)

--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -96,7 +96,7 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
       // 🚨 CRITICAL: 同じ日時・店舗に既存の公演がないかチェック
       // 再承認の場合は、この予約に紐づくイベントを除外する
       const existingEventsQuery = supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('id, scenario, start_time, end_time, reservation_id')
         .eq('date', selectedDateYmd)
         .eq('store_id', selectedStoreId)

--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -394,48 +394,16 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
               message: confirmedMessage
             })
 
-            // 事前読み込みシナリオの場合、追加通知を送信
-            const preReadingScenarioMasterId = selectedRequest?.scenario_master_id
-            if (preReadingScenarioMasterId) {
-              const { data: scenarioData } = await supabase
-                .from('scenario_masters')
-                .select('has_pre_reading')
-                .eq('id', preReadingScenarioMasterId)
-                .single()
-
-              if (scenarioData?.has_pre_reading) {
-                // 全体設定から事前読み込み通知メッセージを取得
-                const { data: globalSettings } = await supabase
-                  .from('global_settings')
-                  .select('pre_reading_notice_message')
-                  .eq('organization_id', organizationId)
-                  .maybeSingle()
-
-                const preReadingMessage = globalSettings?.pre_reading_notice_message || 
-                  '【ご確認ください】\n\nこのシナリオには事前読み込みがございます。\n\n公演日までに参加者全員がこのグループに参加している必要があります。まだ参加されていない方がいらっしゃいましたら、招待リンクを共有してグループへの参加をお願いいたします。\n\nご不明点がございましたら、店舗までお問い合わせください。'
-
-                const preReadingSystemMessage = JSON.stringify({
-                  type: 'system',
-                  action: 'pre_reading_notice',
-                  message: preReadingMessage
-                })
-
-                await supabase.from('private_group_messages').insert({
-                  group_id: reservation.private_group_id,
-                  member_id: organizerMember.id,
-                  message: preReadingSystemMessage
-                })
-              }
-            }
-
-            // アンケートが有効な場合、回答案内を送信
+            // 事前配役アンケートが有効な場合の通知
+            // survey_enabled=true かつキャラクターあり → 事前配役シナリオ（pre-reading通知のみ、配役方法選択は客側で行う）
+            // survey_enabled=true かつキャラクターなし → 即座にアンケート通知を送信
             const scenarioMasterId = selectedRequest?.scenario_master_id
-            logger.log('📋 アンケート通知チェック:', { 
-              scenarioMasterId, 
+            logger.log('📋 事前配役アンケート通知チェック:', {
+              scenarioMasterId,
               organizationId,
               hasScenarioMasterId: !!selectedRequest?.scenario_master_id,
             })
-            
+
             if (scenarioMasterId) {
               const { data: orgScenarioData, error: orgScenarioError } = await supabase
                 .from('organization_scenarios_with_master')
@@ -446,42 +414,54 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
 
               logger.log('📋 organization_scenarios取得結果:', { orgScenarioData, orgScenarioError })
 
-              // キャラクターがあるシナリオは配役方法選択が先なので、ここではアンケート通知を送らない
               const hasPlayableCharacters = Array.isArray(orgScenarioData?.characters) && orgScenarioData.characters.some((c: any) => !c.is_npc)
 
-              if (orgScenarioData?.survey_enabled && !hasPlayableCharacters) {
-                // 確定日からアンケート期限を計算
-                const confirmedCandidate = selectedRequest.candidate_datetimes?.candidates?.find(
-                  (c: any) => c.order === selectedCandidateOrder
-                )
-                let deadlineText = ''
-                if (confirmedCandidate?.date && orgScenarioData.survey_deadline_days !== undefined) {
-                  const perfDate = new Date(confirmedCandidate.date + 'T00:00:00+09:00')
-                  perfDate.setDate(perfDate.getDate() - orgScenarioData.survey_deadline_days)
-                  deadlineText = `\n\n回答期限: ${perfDate.getMonth() + 1}月${perfDate.getDate()}日まで`
-                }
+              if (orgScenarioData?.survey_enabled) {
+                if (hasPlayableCharacters) {
+                  // 事前配役シナリオ: グループ全員の参加を促す通知を送信
+                  const { data: globalSettings } = await supabase
+                    .from('global_settings')
+                    .select('pre_reading_notice_message')
+                    .eq('organization_id', organizationId)
+                    .maybeSingle()
 
-                const surveyMessage = `【アンケートのご協力のお願い】\n\nこちらの公演では事前アンケートへのご回答をお願いしております。\n\n上記の「日程を確認・回答する」ボタンからアンケートにお答えください。${deadlineText}\n\nご不明点がございましたら、お気軽にお問い合わせください。`
+                  const preReadingMessage = globalSettings?.pre_reading_notice_message ||
+                    '【ご確認ください】\n\nこのシナリオには事前配役アンケートがございます。\n\n公演日までに参加者全員がこのグループに参加している必要があります。まだ参加されていない方がいらっしゃいましたら、招待リンクを共有してグループへの参加をお願いいたします。\n\nご不明点がございましたら、店舗までお問い合わせください。'
 
-                const surveySystemMessage = JSON.stringify({
-                  type: 'system',
-                  action: 'survey_notice',
-                  message: surveyMessage
-                })
-
-                const { error: surveyMsgError } = await supabase.from('private_group_messages').insert({
-                  group_id: reservation.private_group_id,
-                  member_id: organizerMember.id,
-                  message: surveySystemMessage
-                })
-                
-                if (surveyMsgError) {
-                  logger.error('📋 アンケート通知送信エラー:', surveyMsgError)
+                  await supabase.from('private_group_messages').insert({
+                    group_id: reservation.private_group_id,
+                    member_id: organizerMember.id,
+                    message: JSON.stringify({ type: 'system', action: 'pre_reading_notice', message: preReadingMessage })
+                  })
+                  logger.log('📋 事前配役シナリオ: pre_reading_notice送信成功')
                 } else {
-                  logger.log('📋 アンケート通知送信成功')
+                  // キャラクターなし: 即座にアンケート通知を送信
+                  const confirmedCandidate = selectedRequest.candidate_datetimes?.candidates?.find(
+                    (c: any) => c.order === selectedCandidateOrder
+                  )
+                  let deadlineText = ''
+                  if (confirmedCandidate?.date && orgScenarioData.survey_deadline_days !== undefined) {
+                    const perfDate = new Date(confirmedCandidate.date + 'T00:00:00+09:00')
+                    perfDate.setDate(perfDate.getDate() - orgScenarioData.survey_deadline_days)
+                    deadlineText = `\n\n回答期限: ${perfDate.getMonth() + 1}月${perfDate.getDate()}日まで`
+                  }
+
+                  const surveyMessage = `【事前配役アンケートのご協力のお願い】\n\nこちらの公演では事前配役アンケートへのご回答をお願いしております。\n\n上記の「日程を確認・回答する」ボタンからアンケートにお答えください。${deadlineText}\n\nご不明点がございましたら、お気軽にお問い合わせください。`
+
+                  const { error: surveyMsgError } = await supabase.from('private_group_messages').insert({
+                    group_id: reservation.private_group_id,
+                    member_id: organizerMember.id,
+                    message: JSON.stringify({ type: 'system', action: 'survey_notice', message: surveyMessage })
+                  })
+
+                  if (surveyMsgError) {
+                    logger.error('📋 アンケート通知送信エラー:', surveyMsgError)
+                  } else {
+                    logger.log('📋 アンケート通知送信成功')
+                  }
                 }
               } else {
-                logger.log('📋 アンケートが無効のためスキップ:', { survey_enabled: orgScenarioData?.survey_enabled })
+                logger.log('📋 事前配役アンケートが無効のためスキップ:', { survey_enabled: orgScenarioData?.survey_enabled })
               }
             } else {
               logger.log('📋 scenario_master_idがないためアンケート通知スキップ')

--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -261,7 +261,7 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
           const storeAddress = selectedStore?.address || undefined
           const priceToUse = updatedReservation?.final_price || updatedReservation?.total_price || 0
 
-          await supabase.functions.invoke('send-private-booking-confirmation', {
+          const { error: emailInvokeError } = await supabase.functions.invoke('send-private-booking-confirmation', {
             body: {
               organizationId,
               storeId: selectedStoreId,
@@ -280,7 +280,11 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
               notes: selectedRequest?.notes || updatedReservation?.customer_notes || undefined
             }
           })
-          logger.log('貸切予約確定メール送信成功:', customerEmail)
+          if (emailInvokeError) {
+            logger.error('貸切予約確定メール送信エラー:', emailInvokeError)
+          } else {
+            logger.log('貸切予約確定メール送信成功:', customerEmail)
+          }
         }
       } catch (emailError) {
         logger.error('メール送信エラー:', emailError)

--- a/src/pages/PrivateBookingManagement/hooks/useConflictCheck.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useConflictCheck.ts
@@ -96,7 +96,7 @@ export const useConflictCheck = () => {
       // 1. schedule_events テーブル（手動追加・インポートされた全公演）
       // ただし、この予約に紐づくイベントは除外する（再承認時のため）
       const { data: allEvents, error: eventsError } = await supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('id, scenario, date, start_time, end_time, store_id, reservation_id')
         .in('date', candidateDates)
         .eq('is_cancelled', false)
@@ -238,7 +238,7 @@ export const useConflictCheck = () => {
 
         // 🚨 CRITICAL: 1. schedule_eventsからGMの競合をチェック
         const { data: conflictEvents, error: conflictError } = await supabase
-          .from('schedule_events')
+          .from('schedule_events_staff_view')
           .select('id, gms, reservation_id')
           .eq('date', date)
           .eq('is_cancelled', false)

--- a/src/pages/PrivateBookingManagement/hooks/useStoreAndGMManagement.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useStoreAndGMManagement.ts
@@ -139,7 +139,7 @@ export function useStoreAndGMManagement() {
       // ⚠️ 全件取得するとSupabaseの1000件制限に達する可能性があるため
       // ⚠️ reservation_idも取得して、現在編集中の予約のイベントを除外する
       let scheduleQuery = supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('id, store_id, date, start_time, end_time, scenario, gms, is_cancelled, reservation_id')
         .eq('is_cancelled', false)
 

--- a/src/pages/PrivateBookingRequest/index.tsx
+++ b/src/pages/PrivateBookingRequest/index.tsx
@@ -39,6 +39,7 @@ export function PrivateBookingRequest({
   selectedStoreIds: initialStoreIds,
   stores,
   scenarioAvailableStores,
+  privateBookingTimeSlots,
   organizationSlug,
   groupId,
   onBack,
@@ -204,6 +205,7 @@ export function PrivateBookingRequest({
       scenarioTiming,
       allStoreEvents: storeEvents,
       isCustomHoliday,
+      privateBookingTimeSlots,
     })
   }, [
     pickerDate,
@@ -223,6 +225,7 @@ export function PrivateBookingRequest({
       scenarioTiming,
       allStoreEvents: storeEvents,
       isCustomHoliday,
+      privateBookingTimeSlots,
     })
     const picked = daySlots.find((s) => s.label === newSlotLabel)
     if (!picked) {

--- a/src/pages/PrivateBookingRequest/types.ts
+++ b/src/pages/PrivateBookingRequest/types.ts
@@ -21,6 +21,7 @@ export interface PrivateBookingRequestProps {
   selectedStoreIds: string[]
   stores: any[]
   scenarioAvailableStores?: string[] // シナリオ対応店舗ID（未設定=全店舗可）
+  privateBookingTimeSlots?: string[] // 受付可能時間帯（未設定=全時間帯可）
   organizationSlug?: string  // 組織slug（パス方式用）
   groupId?: string  // 貸切グループID（グループからの申請時のみ）
   onBack: () => void

--- a/src/pages/PrivateBookingRequestPage.tsx
+++ b/src/pages/PrivateBookingRequestPage.tsx
@@ -186,6 +186,9 @@ export function PrivateBookingRequestPage({ organizationSlug }: PrivateBookingRe
         scenarioTiming: { duration: scenarioDur, weekend_duration: weekendDur },
         allStoreEvents: [],
         isCustomHoliday,
+        privateBookingTimeSlots: Array.isArray(scenario.private_booking_time_slots)
+          ? scenario.private_booking_time_slots
+          : undefined,
       })
       const found = slots.find((s) => s.key === slotKey)
       if (cancelled) return
@@ -280,6 +283,11 @@ export function PrivateBookingRequestPage({ organizationSlug }: PrivateBookingRe
       selectedStoreIds={selectedStoreIds}
       stores={stores}
       scenarioAvailableStores={scenario.available_stores || []}
+      privateBookingTimeSlots={
+        Array.isArray(scenario.private_booking_time_slots)
+          ? scenario.private_booking_time_slots
+          : undefined
+      }
       organizationSlug={organizationSlug}
       groupId={groupId || undefined}
       onBack={handleBack}

--- a/src/pages/PrivateGroupInvite/index.tsx
+++ b/src/pages/PrivateGroupInvite/index.tsx
@@ -1359,9 +1359,11 @@ export function PrivateGroupInvite() {
   const isChatMode = existingMemberId && activeTab === 'chat'
 
   // 配役方法が未選択かつキャラクターが存在する場合
+  // has_pre_reading=true のシナリオのみ配役フローを表示（表示目的のキャラクター登録では発火しない）
   const charAssignmentMethod = (group as any).character_assignment_method as string | null
   const scenarioCharacters = ((group.scenario_masters as any)?.characters || []).filter((c: any) => !c.is_npc)
-  const needsCharAssignmentChoice = !!(isScheduleConfirmedUi && group.scenario_master_id && scenarioCharacters.length > 0 && charAssignmentMethod == null)
+  const scenarioSurveyEnabled = !!(group.scenario_masters as any)?.survey_enabled
+  const needsCharAssignmentChoice = !!(isScheduleConfirmedUi && group.scenario_master_id && scenarioSurveyEnabled && scenarioCharacters.length > 0 && charAssignmentMethod == null)
 
   // 進捗ステップ数の計算
   // booking_requested以降のステータスであれば、ステップ1〜4は完了済みとして扱う

--- a/src/pages/PrivateGroupInvite/index.tsx
+++ b/src/pages/PrivateGroupInvite/index.tsx
@@ -454,10 +454,63 @@ export function PrivateGroupInvite() {
         .from('private_groups')
         .update({ preferred_store_ids: selectedStoreIds })
         .eq('id', group.id)
-      
+
       if (error) throw error
-      
-      toast.success('希望店舗を更新しました')
+
+      // 店舗変更後、既存候補日がすべての新選択店舗と競合していないか確認
+      // 競合する候補日（全選択店舗が埋まっている日）は自動削除して通知する
+      const candidateDatesToCheck = group.candidate_dates || []
+      if (candidateDatesToCheck.length > 0 && selectedStoreIds.length > 0) {
+        // 競合チェックあり（toast は if/else 内で出す）
+        const today = new Date().toISOString().split('T')[0]
+        const windowEnd = new Date()
+        windowEnd.setDate(windowEnd.getDate() + 180)
+        const windowEndStr = windowEnd.toISOString().split('T')[0]
+
+        const { data: eventsForNewStores } = await supabase
+          .from('schedule_events_public')
+          .select('id, date, store_id, start_time, end_time, is_cancelled')
+          .in('store_id', selectedStoreIds)
+          .gte('date', today)
+          .lte('date', windowEndStr)
+          .eq('is_cancelled', false)
+
+        // "09:00" or "09:00:00" → 分数に変換（秒付き形式にも対応）
+        const toMin = (t: string) => {
+          const parts = t.split(':').map(Number)
+          return parts[0] * 60 + (parts[1] || 0)
+        }
+
+        const conflictingIds: string[] = []
+        for (const cd of candidateDatesToCheck) {
+          if (cd.status === 'rejected') continue
+          const cdStartMin = toMin(cd.start_time)
+          const cdEndMin = toMin(cd.end_time)
+          // 全選択店舗が当該日時に埋まっているか確認
+          const storeHasFreeSlot = selectedStoreIds.some(storeId => {
+            const storeEvents = (eventsForNewStores || []).filter(e => e.store_id === storeId && e.date === cd.date)
+            return !storeEvents.some(e =>
+              toMin(e.start_time) < cdEndMin && toMin(e.end_time) > cdStartMin
+            )
+          })
+          if (!storeHasFreeSlot) {
+            conflictingIds.push(cd.id)
+          }
+        }
+
+        if (conflictingIds.length > 0) {
+          await supabase
+            .from('private_group_candidate_dates')
+            .delete()
+            .in('id', conflictingIds)
+          toast.warning(`希望店舗を更新しました（空き枠のない候補日 ${conflictingIds.length} 件を削除しました）`)
+        } else {
+          toast.success('希望店舗を更新しました')
+        }
+      } else {
+        toast.success('希望店舗を更新しました')
+      }
+
       setShowStoreEditSheet(false)
       refetch()
     } catch (err) {
@@ -1186,6 +1239,8 @@ export function PrivateGroupInvite() {
           errorMessage = '参加人数が上限を超えています'
         } else if (rpcError.code === 'P0026') {
           errorMessage = '組織情報が見つかりません'
+        } else if (rpcError.code === 'P0030' || (rpcError.message && rpcError.message.includes('conflict'))) {
+          errorMessage = '選択された全ての候補日時が既存の公演と重複しています。別の日時をお選びください。'
         } else if (rpcError.message) {
           errorMessage = rpcError.message
         }

--- a/src/pages/PublicBookingTop/utils/bookingDataSnapshot.ts
+++ b/src/pages/PublicBookingTop/utils/bookingDataSnapshot.ts
@@ -1,6 +1,9 @@
 import type { BookingDataResult } from '../hooks/useBookingData'
 
-const SNAPSHOT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+// 5分: 空席状況はリアルタイム性が重要なため短く設定
+// refetchOnMount: 'always' で裏側で常に最新を取得するが、
+// スナップショットが古すぎると満席公演を「空きあり」と表示してしまう
+const SNAPSHOT_MAX_AGE_MS = 5 * 60 * 1000
 
 interface StoredWrapper {
   v: 1

--- a/src/pages/SalaryCalculation/hooks/useSalaryData.ts
+++ b/src/pages/SalaryCalculation/hooks/useSalaryData.ts
@@ -64,7 +64,7 @@ export function useSalaryData(year: number, month: number, storeIds: string[]) {
 
       // GMデータ取得（schedule_eventsとscenariosをJOIN）
       let gmQuery = supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select(`
           id,
           date,

--- a/src/pages/SalesManagement/hooks/useAnnualAnalysis.ts
+++ b/src/pages/SalesManagement/hooks/useAnnualAnalysis.ts
@@ -55,7 +55,7 @@ export function useAnnualAnalysis(
       let from = 0
       while (true) {
         let q = supabase
-          .from('schedule_events')
+          .from('schedule_events_staff_view')
           .select('id, date, category, venue_rental_fee')
           .gte('date', startDate)
           .lte('date', endDate)

--- a/src/pages/ScenarioDetailPage/hooks/useBookingActions.ts
+++ b/src/pages/ScenarioDetailPage/hooks/useBookingActions.ts
@@ -2,7 +2,7 @@ import { logger } from '@/utils/logger'
 import { showToast } from '@/utils/toast'
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { getCurrentParticipantsCount } from '@/lib/participantUtils'
+import { supabase } from '@/lib/supabase'
 import type { EventSchedule } from '../utils/types'
 
 interface UseBookingActionsProps {
@@ -68,9 +68,16 @@ export function useBookingActions({ events, onReload }: UseBookingActionsProps) 
     
     // 🚨 CRITICAL: リアルタイムで最新の空席状況をチェック
     // ページロード時のデータ(event.is_available)は古い可能性がある
+    // 注: reservations テーブルは RLS により顧客自身の行しか見えないため
+    //     schedule_events_public.current_participants（トリガーで常に最新）を使用する
     try {
-      const currentParticipants = await getCurrentParticipantsCount(event.event_id)
-      const maxParticipants = event.max_participants || 8
+      const { data: freshEventData } = await supabase
+        .from('schedule_events_public')
+        .select('current_participants, max_participants, capacity')
+        .eq('id', event.event_id)
+        .single()
+      const currentParticipants = freshEventData?.current_participants ?? event.current_participants
+      const maxParticipants = freshEventData?.max_participants || freshEventData?.capacity || event.max_participants || 8
       const availableSeats = maxParticipants - currentParticipants
 
       // 満席の場合でも予約確認画面に遷移（キャンセル待ち登録が可能）

--- a/src/pages/ScenarioDetailPage/hooks/useScenarioDetail.ts
+++ b/src/pages/ScenarioDetailPage/hooks/useScenarioDetail.ts
@@ -234,6 +234,8 @@ export function useScenarioDetail(scenarioId: string, organizationSlug?: string)
     enabled: !!scenarioId,
     staleTime: 2 * 60 * 1000, // 2分間はfreshとみなす（スケルトン表示なし）
     gcTime: 10 * 60 * 1000, // 10分間キャッシュ保持
+    // 空席状況はリアルタイム性が重要なため、毎回マウント時に必ずバックグラウンド再取得
+    refetchOnMount: 'always',
   })
 
   return {

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -180,7 +180,7 @@ export function ScheduleManager() {
       
       // まず対象のイベントを取得（シナリオの定員情報も含む、現在の組織のみ）
       const { data: events, error: fetchError } = await supabase
-        .from('schedule_events')
+        .from('schedule_events_staff_view')
         .select('id, scenario, max_participants, capacity, current_participants, date, start_time, scenario_id, scenario_master_id, store_id, gms, scenario_masters:scenario_master_id(player_count_max)')
         .eq('organization_id', orgId)
         .gte('date', startDate)

--- a/src/pages/static/GuidePage.tsx
+++ b/src/pages/static/GuidePage.tsx
@@ -1348,6 +1348,11 @@ export function GuidePage() {
                 <p className="font-medium text-gray-900 mb-1">Q. リクエスト送信後の流れは？</p>
                 <p className="text-gray-600 leading-relaxed">店舗側で候補日を確認し、日程を確定します。確定すると<strong>メールとグループ内の両方に通知</strong>が届きます。</p>
               </div>
+              <div>
+                <p className="font-medium text-gray-900 mb-1">Q. 作成した貸切グループを削除したい</p>
+                <p className="text-gray-600 leading-relaxed mb-1.5">グループページ右上の<strong>歯車アイコン</strong>を押して設定を開き、「グループを削除する」から削除できます。</p>
+                <p className="text-gray-600 leading-relaxed">ただし削除できるのは<strong>日程リクエストを送信する前</strong>のグループのみです。すでにリクエストを送信した場合は、お問い合わせフォームまたはメールにて「招待コード」と「削除希望」の旨をご連絡ください。</p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -900,10 +900,11 @@ export interface PrivateGroup {
   created_at: string
   updated_at: string
   // JOIN時の拡張フィールド
-  scenario_masters?: { 
+  scenario_masters?: {
     id: string
     title: string
     key_visual_url: string | null
+    survey_enabled?: boolean
     characters?: Array<{
       name: string
       gender?: string

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -79,6 +79,9 @@ verify_jwt = false
 [functions.send-waitlist-registration-confirmation]
 verify_jwt = false
 
+[functions.notify-gm-private-booking-confirmed]
+verify_jwt = false
+
 [functions.notify-waitlist]
 verify_jwt = false
 

--- a/supabase/functions/notify-gm-private-booking-confirmed/index.ts
+++ b/supabase/functions/notify-gm-private-booking-confirmed/index.ts
@@ -147,8 +147,8 @@ serve(async (req) => {
   }
 
   try {
-    // 認証チェック
-    const authResult = await verifyAuth(req)
+    // 認証チェック（フロントエンドからの publishable key 対応）
+    const authResult = await verifyAuth(req, undefined, { allowAnonymous: true })
     if (!authResult.success) {
       return errorResponse(authResult.error!, authResult.statusCode!, corsHeaders)
     }

--- a/supabase/migrations/20260414150000_fix_create_private_booking_request_auth_check.sql
+++ b/supabase/migrations/20260414150000_fix_create_private_booking_request_auth_check.sql
@@ -1,9 +1,18 @@
--- =============================================================================
--- create_private_booking_request: 貸切予約リクエストを作成
--- 正規ソース: supabase/rpcs/create_private_booking_request.sql
--- =============================================================================
+-- ====================================================================
+-- セキュリティ修正: create_private_booking_request の認証チェック追加
+--
+-- 問題1: p_customer_id が auth.uid() と照合されていないため、
+--        authenticated ユーザーが他人の customer_id で予約リクエストを作成できた。
+--
+-- 問題2: anon も EXECUTE 可能（PostgreSQL デフォルトで public に付与）
+--
+-- 修正:
+--   - auth.uid() IS NULL なら拒否（anon 禁止）
+--   - p_customer_id != auth.uid() なら拒否（なりすまし禁止）
+--   - REVOKE EXECUTE FROM public / GRANT TO authenticated
+-- ====================================================================
 
-CREATE OR REPLACE FUNCTION create_private_booking_request(
+CREATE OR REPLACE FUNCTION public.create_private_booking_request(
   p_scenario_id UUID,
   p_customer_id UUID,
   p_customer_name TEXT,
@@ -56,13 +65,13 @@ BEGIN
   END IF;
 
   -- シナリオ情報を取得（organization_scenariosから）
-  SELECT 
+  SELECT
     COALESCE(os.override_title, sm.title),
     COALESCE(os.duration, sm.official_duration),
     os.participation_fee,
     os.organization_id,
     os.scenario_master_id
-  INTO 
+  INTO
     v_scenario_title,
     v_duration,
     v_participation_fee,
@@ -72,14 +81,14 @@ BEGIN
   JOIN scenario_masters sm ON os.scenario_master_id = sm.id
   WHERE os.id = p_scenario_id
      OR os.scenario_master_id = p_scenario_id;
-  
+
   -- organization_scenarios で見つからない場合は scenarios_v2 ビューから取得
   IF v_scenario_title IS NULL THEN
     SELECT title, duration, participation_fee
     INTO v_scenario_title, v_duration, v_participation_fee
     FROM scenarios_v2
     WHERE id = p_scenario_id;
-    
+
     v_scenario_master_id := p_scenario_id;
   END IF;
 
@@ -89,7 +98,7 @@ BEGIN
     INTO v_scenario_title, v_duration
     FROM scenario_masters
     WHERE id = p_scenario_id;
-    
+
     v_scenario_master_id := p_scenario_id;
   END IF;
 
@@ -116,7 +125,7 @@ BEGIN
        OR os.scenario_master_id = v_scenario_master_id
     LIMIT 1;
   END IF;
-  
+
   IF v_org_id IS NULL THEN
     RAISE EXCEPTION 'Organization not found for scenario' USING ERRCODE = 'P0026';
   END IF;
@@ -128,8 +137,6 @@ BEGIN
 
   -- =========================================================================
   -- サーバー側空き判定: 全候補×全希望店舗で衝突チェック
-  -- 少なくとも1つの候補が1つの店舗で空いていれば通す。
-  -- 全候補が全店舗で既存公演と衝突する場合のみ拒否する。
   -- =========================================================================
   v_requested_store_count := jsonb_array_length(
     COALESCE(p_candidate_datetimes->'requestedStores', '[]'::jsonb)
@@ -153,7 +160,6 @@ BEGIN
       LOOP
         v_store_uuid := v_store_id_text::UUID;
 
-        -- 60分バッファ込みで衝突がなければ空きあり
         IF NOT EXISTS (
           SELECT 1 FROM schedule_events se
           WHERE se.store_id = v_store_uuid
@@ -180,7 +186,6 @@ BEGIN
         USING ERRCODE = 'P0030';
     END IF;
   END IF;
-  -- =========================================================================
 
   -- 料金計算
   v_total_price := p_participant_count * v_participation_fee;
@@ -188,8 +193,8 @@ BEGIN
   -- 最初の候補日時を取得
   v_first_candidate := p_candidate_datetimes->'candidates'->0;
   v_requested_datetime := (
-    (v_first_candidate->>'date') || 'T' || 
-    COALESCE(v_first_candidate->>'startTime', '10:00') || 
+    (v_first_candidate->>'date') || 'T' ||
+    COALESCE(v_first_candidate->>'startTime', '10:00') ||
     '+09:00'
   )::TIMESTAMPTZ;
 
@@ -246,8 +251,7 @@ BEGIN
     WHERE id = p_private_group_id;
   END IF;
 
-  -- GM確認レコードを作成（担当GMがいる場合のみ）
-  -- staff_scenario_assignments から担当GMを取得
+  -- GM確認レコードを作成
   FOR v_gm_id IN
     SELECT ssa.staff_id
     FROM staff_scenario_assignments ssa
@@ -277,3 +281,10 @@ $$;
 -- anon は実行不可、authenticated のみ
 REVOKE EXECUTE ON FUNCTION public.create_private_booking_request(UUID, UUID, TEXT, TEXT, TEXT, INTEGER, JSONB, TEXT, TEXT, UUID) FROM public;
 GRANT EXECUTE ON FUNCTION public.create_private_booking_request(UUID, UUID, TEXT, TEXT, TEXT, INTEGER, JSONB, TEXT, TEXT, UUID) TO authenticated;
+
+DO $$
+BEGIN
+  RAISE NOTICE '🔒 セキュリティ修正完了:';
+  RAISE NOTICE '  - create_private_booking_request: auth.uid() チェックを追加';
+  RAISE NOTICE '  - anon の EXECUTE 権限を剥奪';
+END $$;

--- a/supabase/migrations/20260414160000_restrict_authenticated_schedule_events_columns.sql
+++ b/supabase/migrations/20260414160000_restrict_authenticated_schedule_events_columns.sql
@@ -1,0 +1,65 @@
+-- ====================================================================
+-- セキュリティ修正: authenticated ロールの schedule_events カラム制限
+--
+-- 問題: anon への制限（20260412100000）と同様に、
+--       authenticated（ログイン済みの全ユーザー＝スタッフ・顧客・anon以外）が
+--       schedule_events の非公開カラム（GM情報・財務情報・内部メモ等）を
+--       PostgREST 経由で直接参照できる状態だった。
+--       anon と authenticated は別 PostgreSQL ロールであるため、
+--       anon への REVOKE では authenticated は保護されていなかった。
+--
+-- 修正方針:
+--   1. authenticated にも anon と同様のカラムレベル制限を適用
+--   2. スタッフ向けに schedule_events_staff_view ビューを作成
+--      - WHERE is_staff_or_admin() により非スタッフには0件を返す
+--      - スタッフは全カラムにアクセス可能
+--   3. 全スタッフ向けクエリは schedule_events_staff_view を使用するよう
+--      フロントエンドを更新（同コミットで実施）
+--
+-- 非公開カラム（顧客・一般ユーザーから隠すべき情報）:
+--   - gms, gm_roles（スタッフ情報）
+--   - venue_rental_fee, total_revenue, gm_cost, license_cost（財務）
+--   - notes, reservation_notes, cancellation_reason（内部メモ）
+--   - reservation_id, reservation_name, is_reservation_name_overwritten（予約紐付け）
+--   - is_tentative（内部ワークフロー）
+-- ====================================================================
+
+-- ============================================================
+-- 1. authenticated ロールへのカラム制限（anon と同等）
+-- ============================================================
+REVOKE SELECT ON public.schedule_events FROM authenticated;
+GRANT SELECT (
+  id, date, venue, scenario, start_time, end_time,
+  category, is_cancelled, scenario_id, store_id,
+  start_at, end_at, published, capacity, status,
+  max_participants, reservation_deadline_hours,
+  is_reservation_enabled, current_participants, time_slot,
+  organization_id, participant_count,
+  is_private_request, organization_scenario_id,
+  is_recruitment_extended, is_private_booking,
+  is_extended, extended_at,
+  cancelled_at, scenario_master_id,
+  created_at, updated_at
+) ON public.schedule_events TO authenticated;
+
+-- ============================================================
+-- 2. スタッフ専用ビュー: 全カラムを参照可能
+--    is_staff_or_admin() = false のユーザーには0件を返す
+-- ============================================================
+DROP VIEW IF EXISTS public.schedule_events_staff_view;
+CREATE VIEW public.schedule_events_staff_view AS
+  SELECT * FROM public.schedule_events
+  WHERE public.is_staff_or_admin();
+
+-- authenticated に SELECT 権限を付与（非スタッフは WHERE で0件）
+GRANT SELECT ON public.schedule_events_staff_view TO authenticated;
+
+-- ============================================================
+-- 3. 確認ログ
+-- ============================================================
+DO $$
+BEGIN
+  RAISE NOTICE '🔒 セキュリティ修正完了:';
+  RAISE NOTICE '  - schedule_events: authenticated の非公開カラムへのアクセスを制限';
+  RAISE NOTICE '  - schedule_events_staff_view: スタッフ専用ビューを作成（is_staff_or_admin() チェック付き）';
+END $$;

--- a/supabase/migrations/20260414170000_fix_recalc_participants_include_checked_in.sql
+++ b/supabase/migrations/20260414170000_fix_recalc_participants_include_checked_in.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- バグ修正: recalc_current_participants_for_event に checked_in を追加
+-- =============================================================================
+--
+-- 問題:
+--   recalc_current_participants_for_event() が status IN ('pending', 'confirmed', 'gm_confirmed')
+--   のみを集計しており、checked_in が除外されていた。
+--
+--   結果として、参加者がチェックイン（checked_in）すると current_participants が減少し、
+--   「満席なのに空き席あり」と誤表示される。
+--   → 別の顧客が予約できてしまう（スタッフ目線で「満席なのに申し込みが来る」）。
+--
+--   ※ create_reservation_with_lock_v2 の在庫チェックは 20260414100000 で checked_in を追加済みだが、
+--     INSERT 後に呼び出す recalc_current_participants_for_event() が正しくないため、
+--     current_participants が過小な値のまま残り、次のリクエスト時の RPC チェックも狂う。
+--
+-- 修正:
+--   1. recalc_current_participants_for_event に 'checked_in' を追加
+--   2. schedule_events.current_participants を正しい値に一括再計算（既存データ修復）
+--
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.recalc_current_participants_for_event(p_event_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+SET row_security = off
+AS $$
+BEGIN
+  UPDATE schedule_events se
+  SET current_participants = COALESCE((
+    SELECT SUM(r.participant_count)
+    FROM reservations r
+    WHERE r.schedule_event_id = se.id
+      AND r.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in')
+  ), 0)
+  WHERE se.id = p_event_id;
+END;
+$$;
+
+-- 既存の全公演の current_participants を正しい値に一括再計算
+-- （過去に checked_in を除外していたためズレが生じている可能性がある）
+DO $$
+DECLARE
+  v_event_id UUID;
+BEGIN
+  FOR v_event_id IN
+    SELECT DISTINCT schedule_event_id
+    FROM reservations
+    WHERE status IN ('checked_in')
+      AND schedule_event_id IS NOT NULL
+  LOOP
+    PERFORM public.recalc_current_participants_for_event(v_event_id);
+  END LOOP;
+  RAISE NOTICE '✅ checked_in を含む current_participants を再計算しました';
+END $$;

--- a/supabase/migrations/20260414180000_restore_authenticated_schedule_events_select.sql
+++ b/supabase/migrations/20260414180000_restore_authenticated_schedule_events_select.sql
@@ -1,0 +1,26 @@
+-- ====================================================================
+-- 緊急修正: authenticated の schedule_events SELECT 権限を復元
+--
+-- 問題:
+--   20260414160000 で `REVOKE SELECT ON schedule_events FROM authenticated`
+--   を実施したが、PostgREST はテーブルレベルの SELECT 権限を必須とする。
+--   カラムレベル権限のみでは PostgREST 経由の SELECT がすべて 403 になる。
+--   → スタッフのスケジュール管理・公演保存・GM確認が全滅。
+--
+-- 修正方針:
+--   1. テーブルレベルの SELECT を authenticated に再付与
+--   2. カラムレベル制限を撤去（PostgREST と非互換のため）
+--   3. セキュリティは以下で担保する:
+--      - schedule_events_public ビュー: 顧客向けページ（機密カラム除外）
+--      - schedule_events_staff_view ビュー: スタッフ専用（is_staff_or_admin() チェック）
+--      - RLS ポリシー: 行レベルアクセス制御
+-- ====================================================================
+
+-- テーブルレベル SELECT を復元
+GRANT SELECT ON public.schedule_events TO authenticated;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ 修正完了: schedule_events SELECT 権限を authenticated に再付与';
+  RAISE NOTICE '  セキュリティ: schedule_events_public / schedule_events_staff_view で列フィルタを担保';
+END $$;


### PR DESCRIPTION
## 変更内容

- fix: 予約完了後のトップページ残り席数が古い値を表示する問題を修正
- fix: authenticated ロールの organization_scenarios_with_master SELECT 権限を修正
- fix: ゲストメンバー削除RPCとPIIテーブルの権限を修正
- fix: COMMENT ON FUNCTION のシグネチャを明示指定
- fix: 招待リンクアクセス時のプロフィール補完ゲートをスキップ
- fix: anon の private_group_members UPDATE/DELETE 権限を剥奪
- fix: 貸切タイムスロットのフラッシュと午後・夜の重複表示を修正
- fix: authenticated ロールの schedule_events カラムレベル権限分離とRPC認証強化
- fix: 貸切グループの空き判定バグと schedule_events 権限を修正
- docs: ガイドページに貸切グループ削除方法のFAQを追加
- fix: 事前配役アンケートをsurvey_enabledに統合し、非配役シナリオへの誤送信を修正
- fix: GM確定通知Edge Functionの401エラーを修正

## DBマイグレーション

本番DB適用済み（20260330・20260414系、計9ファイル）。