### PR TITLE
fix: キャンセルメールの customers.email null 対応

### DIFF
--- a/src/lib/reservationApi.ts
+++ b/src/lib/reservationApi.ts
@@ -744,7 +744,10 @@ export const reservationApi = {
 
     // キャンセル確認メールを送信
     const cancelMailCustomer = joinedCustomerFromReservation(reservation.customers)
-    if (reservation && cancelMailCustomer) {
+    // 貸切予約など customers.email が null の場合は reservation.customer_email をフォールバックとして使う
+    const cancelMailEmail = cancelMailCustomer?.email || (reservation as any).customer_email || null
+    const cancelMailName = cancelMailCustomer?.name || (reservation as any).customer_name || null
+    if (reservation && cancelMailEmail) {
       try {
         const scheduleEvent = Array.isArray(reservation.schedule_events) ? reservation.schedule_events[0] : reservation.schedule_events
         const storeName = scheduleEvent?.venue || '店舗不明'
@@ -762,8 +765,8 @@ export const reservationApi = {
             organizationId: orgIdForEmail,
             storeId: scheduleEvent?.store_id,
             reservationId: reservation.id,
-            customerEmail: cancelMailCustomer.email,
-            customerName: cancelMailCustomer.name,
+            customerEmail: cancelMailEmail,
+            customerName: cancelMailName,
             scenarioTitle: reservation.title || scheduleEvent?.scenario,
             eventDate: scheduleEvent?.date,
             startTime: scheduleEvent?.start_time,


### PR DESCRIPTION
## Summary
- 貸切予約など `customers.email` が null のケースで `send-cancellation-confirmation` が 400 を返していたバグを修正
- `cancelMailCustomer?.email` → `reservation.customer_email` の順でフォールバック
- どちらも null の場合のみメール送信をスキップ（従来どおり）

## 原因
`create_private_booking_request` RPC で作成された貸切予約は `customer_email` を reservations テーブルに直接保存するが、`customers` JOIN 経由の `.email` は null になるケースがある。`cancelMailCustomer` が非 null でも `.email` が null のため Edge Function が 400 を返していた。

## Test plan
- [ ] 貸切予約をキャンセルしてキャンセル確認メールが届くことを確認
- [ ] 通常予約のキャンセルも引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)