### PR TITLE
fix: スケジュール画面が表示されない不具合を修正（ビュー定義の復元）

### DIFF
--- a/supabase/migrations/20260503120000_fix_restore_org_scenarios_view_full_columns.sql
+++ b/supabase/migrations/20260503120000_fix_restore_org_scenarios_view_full_columns.sql
@@ -1,0 +1,131 @@
+-- organization_scenarios_with_master ビューを正しい定義に戻す
+--
+-- 問題: 20260430000000_fix_organization_scenarios_view_id.sql が古い定義（20260415以前）で
+--       DROP→CREATE したため、以下が失われた:
+--         - private_booking_time_slots / private_booking_blocked_slots カラム
+--         - booking_start_date / booking_end_date / individual_notice_template
+--         - character_assignment_method
+--         - external_license_amount / external_gm_test_license_amount
+--         - fc_receive_license_amount / fc_receive_gm_test_license_amount
+--         - fc_author_license_amount / fc_author_gm_test_license_amount
+--         - GRANT SELECT（authenticated / anon）
+--
+--       scenarioApi.getAll() がこれらのカラムを SELECT に含むため
+--       PostgREST がエラーを返し、スケジュール画面が全く表示されなくなった。
+--
+-- 修正: 20260416040000_add_external_amounts_to_org_scenarios_view.sql と同一の
+--       完全な定義で再作成し、GRANT も再付与する。
+
+DROP VIEW IF EXISTS public.organization_scenarios_with_master;
+
+CREATE VIEW public.organization_scenarios_with_master AS
+SELECT
+  os.scenario_master_id AS id,
+  os.id AS org_scenario_id,
+  os.organization_id,
+  os.scenario_master_id,
+  os.slug,
+  os.org_status AS status,
+  os.org_status,
+  COALESCE(os.override_title, sm.title) AS title,
+  COALESCE(os.override_author, sm.author) AS author,
+  COALESCE(os.report_display_name, sm.report_display_name, COALESCE(os.override_author, sm.author)) AS report_display_name,
+  sm.author_email,
+  sm.author_id,
+  COALESCE(os.custom_key_visual_url, sm.key_visual_url) AS key_visual_url,
+  COALESCE(os.custom_description, sm.description) AS description,
+  COALESCE(os.custom_synopsis, sm.synopsis) AS synopsis,
+  COALESCE(os.custom_caution, sm.caution) AS caution,
+  COALESCE(os.override_player_count_min, sm.player_count_min) AS player_count_min,
+  COALESCE(os.override_player_count_max, sm.player_count_max) AS player_count_max,
+  os.male_count,
+  os.female_count,
+  os.other_count,
+  COALESCE(os.duration, sm.official_duration) AS duration,
+  os.weekend_duration,
+  COALESCE(os.override_genre, sm.genre) AS genre,
+  COALESCE(os.override_difficulty, sm.difficulty) AS difficulty,
+  COALESCE(os.override_has_pre_reading, sm.has_pre_reading) AS has_pre_reading,
+  sm.release_date,
+  sm.official_site_url,
+  sm.required_items AS required_props,
+  os.participation_fee,
+  os.gm_test_participation_fee,
+  os.participation_costs,
+  os.flexible_pricing,
+  os.use_flexible_pricing,
+  os.license_amount,
+  os.gm_test_license_amount,
+  os.franchise_license_amount,
+  os.franchise_gm_test_license_amount,
+  os.external_license_amount,
+  os.external_gm_test_license_amount,
+  os.fc_receive_license_amount,
+  os.fc_receive_gm_test_license_amount,
+  os.fc_author_license_amount,
+  os.fc_author_gm_test_license_amount,
+  os.gm_costs,
+  os.gm_count,
+  os.gm_assignments,
+  COALESCE((
+    SELECT array_agg(st.name ORDER BY st.name)
+    FROM staff_scenario_assignments ssa
+    JOIN staff st ON st.id = ssa.staff_id
+    WHERE ssa.scenario_master_id = os.scenario_master_id
+      AND ssa.organization_id = os.organization_id
+      AND (ssa.can_main_gm = true OR ssa.can_sub_gm = true)
+  ), ARRAY[]::text[]) AS available_gms,
+  COALESCE((
+    SELECT array_agg(st.name ORDER BY st.name)
+    FROM staff_scenario_assignments ssa
+    JOIN staff st ON st.id = ssa.staff_id
+    WHERE ssa.scenario_master_id = os.scenario_master_id
+      AND ssa.organization_id = os.organization_id
+      AND ssa.is_experienced = true
+      AND COALESCE(ssa.can_main_gm, false) = false
+      AND COALESCE(ssa.can_sub_gm, false) = false
+  ), ARRAY[]::text[]) AS experienced_staff,
+  os.available_stores,
+  os.production_cost,
+  os.production_costs,
+  os.depreciation_per_performance,
+  os.extra_preparation_time,
+  (
+    SELECT count(*)::integer
+    FROM schedule_events se
+    WHERE se.scenario_master_id = os.scenario_master_id
+      AND se.organization_id = os.organization_id
+      AND se.date <= CURRENT_DATE
+      AND se.is_cancelled IS NOT TRUE
+      AND se.category <> 'offsite'::text
+  ) AS play_count,
+  os.notes,
+  os.created_at,
+  os.updated_at,
+  sm.master_status,
+  os.pricing_patterns,
+  true AS is_shared,
+  COALESCE(os.scenario_type, 'normal'::text) AS scenario_type,
+  0::numeric AS rating,
+  COALESCE(os.kit_count, 1) AS kit_count,
+  '[]'::jsonb AS license_rewards,
+  COALESCE(os.is_recommended, false) AS is_recommended,
+  os.survey_url,
+  COALESCE(os.survey_enabled, false) AS survey_enabled,
+  COALESCE(os.survey_deadline_days, 1) AS survey_deadline_days,
+  COALESCE(os.characters, '[]'::jsonb) AS characters,
+  os.pre_reading_notice_message,
+  os.booking_start_date,
+  os.booking_end_date,
+  os.individual_notice_template,
+  COALESCE(os.character_assignment_method, 'survey'::text) AS character_assignment_method,
+  COALESCE(os.private_booking_time_slots, ARRAY[]::text[]) AS private_booking_time_slots,
+  COALESCE(os.private_booking_blocked_slots, ARRAY[]::text[]) AS private_booking_blocked_slots
+FROM organization_scenarios os
+JOIN scenario_masters sm ON sm.id = os.scenario_master_id;
+
+-- DROP+CREATE でGRANTが消えるため再付与
+GRANT SELECT ON public.organization_scenarios_with_master TO authenticated;
+GRANT SELECT ON public.organization_scenarios_with_master TO anon;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## 原因

`20260430000000` マイグレーションで `organization_scenarios_with_master` ビューを DROP→CREATE した際、`20260416040000` で追加された以下のカラムが欠落し、GRANT も失われた。

**欠落したカラム:**
- `private_booking_time_slots` / `private_booking_blocked_slots`
- `booking_start_date` / `booking_end_date`
- `external_license_amount` 系・`fc_*_license_amount` 系 計6カラム
- `individual_notice_template` / `character_assignment_method`

**欠落したGRANT:**
- `GRANT SELECT TO authenticated`
- `GRANT SELECT TO anon`

`scenarioApi.getAll()` がこれらのカラムを SELECT に含み、PostgREST がカラム不在エラーを返す → `if (error) throw error` → スケジュール画面が全く表示されなくなった。

## 修正

`20260416040000` の完全な定義でビューを再作成し、GRANT を再付与。

## 確認事項
- [ ] スケジュール画面にイベントが表示されること
- [ ] シナリオ一覧が表示されること