### PR TITLE
fix: AboutPage のサービス開始年を「2026年3月」に修正

### DIFF
--- a/src/pages/static/AboutPage.tsx
+++ b/src/pages/static/AboutPage.tsx
@@ -62,7 +62,7 @@ export function AboutPage() {
                   サービス開始
                 </th>
                 <td className="px-6 py-4 text-sm text-gray-700">
-                  2024年
+                  2026年3月
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
Closes #69

## 変更内容
- `src/pages/static/AboutPage.tsx` のサービス開始年を `2024年` → `2026年3月` に修正