### PR TITLE
fix: claude-issue-handler に gh pr create と npm typecheck の権限を追加

### DIFF
--- a/.github/workflows/claude-issue-handler.yml
+++ b/.github/workflows/claude-issue-handler.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*),Bash(gh pr create:*),Bash(npm run typecheck:*),Bash(npm run build:fast:*)"
           direct_prompt: |
             GitHub Issue #${{ github.event.issue.number }} が作成されました。
 


### PR DESCRIPTION
## 変更内容
Claude が Issue 対応後に自動で PR を作成できるよう、`allowed_tools` に以下を追加：
- `Bash(gh pr create:*)` — PR の自動作成
- `Bash(npm run typecheck:*)` — 型チェック
- `Bash(npm run build:fast:*)` — ビルド確認