### PR TITLE
fix: 貸切予約承認後にスケジュール履歴を記録する (#82)

### DIFF
--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -15,6 +15,7 @@ import type { PrivateBookingRequest } from './usePrivateBookingData'
 import type { RpcApprovePrivateBookingParams } from '@/lib/rpcTypes'
 import { updatePrivateGroupStatus } from '@/lib/privateGroupStatus'
 import { sendEmail } from '@/lib/emailApi'
+import { createEventHistory } from '@/lib/api/eventHistoryApi'
 
 interface UseBookingApprovalProps {
   onSuccess: () => void
@@ -220,6 +221,34 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
       }
 
       logger.log('貸切承認RPC成功:', { requestId, scheduleEventId })
+
+      // 承認で作成されたスケジュールイベントを履歴に記録
+      if (scheduleEventId && organizationId) {
+        const gmIds = requiredGm >= 2 && selectedSubGmId
+          ? [selectedGMId, selectedSubGmId]
+          : [selectedGMId]
+        await createEventHistory(
+          scheduleEventId as string,
+          organizationId,
+          'create',
+          null,
+          {
+            scenario: cleanScenarioTitle,
+            date: selectedDateYmd,
+            store_id: selectedStoreId,
+            start_time: selectedCandidate.startTime,
+            end_time: selectedEndTime,
+            gms: gmIds,
+            reservation_name: selectedRequest?.customer_name || '',
+          },
+          {
+            date: selectedDateYmd,
+            storeId: selectedStoreId,
+            timeSlot: selectedCandidate.timeSlot || null,
+          },
+          { notes: '貸切予約承認により作成' }
+        )
+      }
 
       // 通知・メールは DB に実際に作成された公演日（schedule_events.date）を優先（クライアント保持の候補とズレないようにする）
       let notifyEventDate = selectedDateYmd


### PR DESCRIPTION
## 概要

貸切予約を承認したあと、スケジュールページ・貸切管理ページの「履歴」タブに承認が残らない問題を修正。

## 原因

`approve_private_booking` RPC でスケジュールイベントが作成されていたが、  
その後 `createEventHistory()` が呼ばれておらず `schedule_event_history` テーブルに記録されていなかった。

## 修正内容

`useBookingApproval.ts` の RPC 成功後に `createEventHistory()` を追加。

- action_type: `create`
- 記録内容: シナリオ名・日付・店舗・開始/終了時刻・GM・予約者名
- notes: `'貸切予約承認により作成'`

## テスト

- 貸切リクエストを承認 → スケジュールページの該当セルの履歴タブに「作成」エントリが表示されることを確認
- 承認者名が履歴に記録されることを確認

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)