### PR TITLE
fix: GM確定通知の ReferenceError 修正・失敗時に管理者警告 (#74 #73)

### DIFF
--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -16,6 +16,7 @@ import type { RpcApprovePrivateBookingParams } from '@/lib/rpcTypes'
 import { updatePrivateGroupStatus } from '@/lib/privateGroupStatus'
 import { sendEmail } from '@/lib/emailApi'
 import { createEventHistory } from '@/lib/api/eventHistoryApi'
+import { showToast } from '@/utils/toast'
 
 function addMinutesToTime(time: string, minutes: number): string {
   const [h, m] = time.split(':').map(Number)
@@ -403,11 +404,16 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
                 error: notifyFnError,
                 errorDetails: JSON.stringify(notifyFnError, null, 2)
               })
+              showToast.warning(`${row.name} への確定通知の送信に失敗しました。手動でご連絡ください。`)
             } else {
               logger.log('GM確定通知リクエスト完了:', {
                 gmName: row.name,
                 results: notifyResult?.results || 'no_details'
               })
+              // Discord が全方法で失敗していた場合も警告
+              if (notifyResult?.results?.discord === 'failed') {
+                showToast.warning(`${row.name} へのDiscord通知が失敗しました。メール通知または手動連絡をご確認ください。`)
+              }
             }
           }
           

--- a/supabase/functions/notify-gm-private-booking-confirmed/index.ts
+++ b/supabase/functions/notify-gm-private-booking-confirmed/index.ts
@@ -160,6 +160,8 @@ serve(async (req) => {
     const formattedTime = `${formatScheduleClockJst(data.startTime)}〜${formatScheduleClockJst(data.endTime)}`
 
     // Discord通知（個人チャンネル → DM → 組織の貸切用チャンネル＋メンション の順）
+    // discordSent は try ブロック外で宣言し、結果集計時に参照できるようにする
+    let discordSent = false
     try {
       const discordSettings = await getDiscordSettings(supabase, data.organizationId)
       const botToken = discordSettings?.botToken || Deno.env.get('DISCORD_BOT_TOKEN')
@@ -183,7 +185,6 @@ serve(async (req) => {
           timestamp: new Date().toISOString(),
         }
 
-        let discordSent = false
         const discordAttempts: { method: string, success: boolean, details?: string }[] = []
 
         // 個人チャンネル試行


### PR DESCRIPTION
## 概要

貸切公演確定通知が断続的に届かない問題（#74, #73）を修正。

## 根本原因

`notify-gm-private-booking-confirmed` Edge Function の **変数スコープバグ**。

```typescript
try {
  let discordSent = false  // ← try ブロック内で let 宣言
  // ... Discord通知処理 ...
} catch (e) { ... }

// ↓ ブロック外で参照 → 常に ReferenceError が発生し 500 を返していた
const notificationResults = {
  discord: discordSent ? 'sent' : 'failed',
}
```

Discord・メール通知自体は送信されていたが、その後 ReferenceError で関数が 500 を返すため、クライアント側はエラーとして扱っていた。

## 修正内容

### Edge Function
- `let discordSent = false` を `try` ブロック**外**に移動

### クライアント (`useBookingApproval.ts`)
- 通知失敗時（Edge Function エラー / Discord 全方法失敗）に `showToast.warning` で管理者へ警告表示
- 承認処理自体は従来どおり成功扱いで継続

## テスト確認

- 貸切承認後、GM へ Discord/メール通知が届くことを確認
- 通知設定が未構成の場合に警告トーストが表示されることを確認

Closes #74
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)