### PR TITLE
fix: 貸切予約承認に60分インターバルチェックを追加（#81）

### DIFF
--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -16,6 +16,12 @@ import type { RpcApprovePrivateBookingParams } from '@/lib/rpcTypes'
 import { updatePrivateGroupStatus } from '@/lib/privateGroupStatus'
 import { sendEmail } from '@/lib/emailApi'
 
+function addMinutesToTime(time: string, minutes: number): string {
+  const [h, m] = time.split(':').map(Number)
+  const total = h * 60 + m + minutes
+  return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`
+}
+
 interface UseBookingApprovalProps {
   onSuccess: () => void
 }
@@ -124,12 +130,20 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
           const eventStart = event.start_time?.substring(0, 5) || ''
           const eventEnd = event.end_time?.substring(0, 5) || ''
 
-          // 時間帯が重複しているかチェック
+          // 直接重複チェック
           if (candidateStart < eventEnd && candidateEnd > eventStart) {
             setSubmitting(false)
-            return { 
-              success: false, 
-              error: `${selectedDateYmd} ${candidateStart}〜${candidateEnd} の時間帯には既に「${event.scenario}」(${eventStart}〜${eventEnd})が入っています。` 
+            return {
+              success: false,
+              error: `${selectedDateYmd} ${candidateStart}〜${candidateEnd} の時間帯には既に「${event.scenario}」(${eventStart}〜${eventEnd})が入っています。`,
+            }
+          }
+          // 60分インターバルチェック（設営・撤収時間）
+          if (candidateStart < addMinutesToTime(eventEnd, 60) && addMinutesToTime(candidateEnd, 60) > eventStart) {
+            setSubmitting(false)
+            return {
+              success: false,
+              error: `${selectedDateYmd} ${candidateStart}〜${candidateEnd} は「${event.scenario}」(${eventStart}〜${eventEnd})との間隔が60分未満です。設営・撤収時間を確保するため60分以上の間隔が必要です。`,
             }
           }
         }
@@ -203,6 +217,13 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
           return {
             success: false,
             error: 'メインGMとサブGMに同じ人は指定できません。別々のスタッフを選んでください。',
+          }
+        }
+        if (approveError.code === 'P0027') {
+          setSubmitting(false)
+          return {
+            success: false,
+            error: 'この時間帯は前後の公演と間隔が60分未満です。設営・撤収時間を確保するため60分以上の間隔が必要です。別の候補日時を選んでください。',
           }
         }
         if (approveError.code === 'P0018') {

--- a/src/pages/PrivateBookingManagement/hooks/useConflictCheck.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useConflictCheck.ts
@@ -14,6 +14,15 @@ const normalizeTimeSlot = (timeSlot: string): string => {
   return timeSlot
 }
 
+// "HH:MM" 形式の時刻に指定分を加算して "HH:MM" を返す
+function addMinutesToTime(time: string, minutes: number): string {
+  const [h, m] = time.split(':').map(Number)
+  const total = h * 60 + m + minutes
+  const hh = Math.floor(total / 60)
+  const mm = total % 60
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`
+}
+
 /**
  * 既存イベント情報
  */
@@ -184,10 +193,11 @@ export const useConflictCheck = () => {
         // 全店舗について競合をチェック（希望店舗だけでなく全店舗）
         for (const storeId of allStoreIdsWithEvents) {
           // 既存イベント（schedule_events + 確定済みreservations）から競合をチェック
-          const conflictEvents = existingEventsList.filter(event => 
-            event.storeId === storeId && 
+          // 60分インターバルを考慮した競合チェック（設営・撤収時間の確保）
+          const conflictEvents = existingEventsList.filter(event =>
+            event.storeId === storeId &&
             event.date === date &&
-            startTime < event.endTime && endTime > event.startTime
+            startTime < addMinutesToTime(event.endTime, 60) && addMinutesToTime(endTime, 60) > event.startTime
           )
 
           if (conflictEvents.length > 0) {

--- a/supabase/migrations/20260507000000_add_60min_interval_check_to_approve_booking.sql
+++ b/supabase/migrations/20260507000000_add_60min_interval_check_to_approve_booking.sql
@@ -1,0 +1,273 @@
+-- approve_private_booking に60分インターバルチェックを追加
+-- 同一店舗で60分以内の別公演がある場合は P0027 INTERVAL_TOO_SHORT を返す
+-- （設営・撤収時間を確保するための安全要件）
+
+DROP FUNCTION IF EXISTS public.approve_private_booking(UUID, DATE, TIME, TIME, UUID, UUID, JSONB, TEXT, TEXT, UUID);
+
+CREATE OR REPLACE FUNCTION approve_private_booking(
+  p_reservation_id UUID,
+  p_selected_date DATE,
+  p_selected_start_time TIME,
+  p_selected_end_time TIME,
+  p_selected_store_id UUID,
+  p_selected_gm_id UUID,
+  p_candidate_datetimes JSONB,
+  p_scenario_title TEXT,
+  p_customer_name TEXT,
+  p_selected_sub_gm_id UUID DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+SET row_security = off
+AS $$
+DECLARE
+  v_reservation RECORD;
+  v_org_id UUID;
+  v_caller_org_id UUID;
+  v_caller_staff_id UUID;
+  v_schedule_event_id UUID;
+  v_existing_event_id UUID;
+  v_gm_name TEXT;
+  v_sub_gm_name TEXT;
+  v_store_name TEXT;
+  v_updated_count INTEGER;
+  v_private_group_id UUID;
+  v_gms_array TEXT[];
+  v_gm_roles JSONB;
+  v_calendar_date DATE;
+  v_raw TEXT;
+BEGIN
+  SELECT *
+  INTO v_reservation
+  FROM reservations
+  WHERE id = p_reservation_id
+    AND status IN ('pending', 'pending_gm', 'gm_confirmed', 'pending_store', 'confirmed', 'cancelled')
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'RESERVATION_NOT_FOUND_OR_ALREADY_CONFIRMED' USING ERRCODE = 'P0018';
+  END IF;
+
+  v_org_id := v_reservation.organization_id;
+  v_private_group_id := v_reservation.private_group_id;
+  v_existing_event_id := v_reservation.schedule_event_id;
+
+  v_caller_org_id := get_user_organization_id();
+  IF NOT (is_org_admin() OR (v_caller_org_id IS NOT NULL AND v_caller_org_id = v_org_id)) THEN
+    RAISE EXCEPTION 'UNAUTHORIZED' USING ERRCODE = 'P0010';
+  END IF;
+
+  SELECT id INTO v_caller_staff_id
+  FROM staff
+  WHERE user_id = auth.uid()
+    AND organization_id = v_org_id;
+
+  SELECT name INTO v_gm_name
+  FROM staff
+  WHERE id = p_selected_gm_id
+    AND organization_id = v_org_id;
+
+  IF v_gm_name IS NULL THEN
+    RAISE EXCEPTION 'GM_NOT_FOUND' USING ERRCODE = 'P0022';
+  END IF;
+
+  v_sub_gm_name := NULL;
+  IF p_selected_sub_gm_id IS NOT NULL THEN
+    IF p_selected_sub_gm_id = p_selected_gm_id THEN
+      RAISE EXCEPTION 'SUB_GM_SAME_AS_MAIN' USING ERRCODE = 'P0026';
+    END IF;
+    SELECT name INTO v_sub_gm_name
+    FROM staff
+    WHERE id = p_selected_sub_gm_id
+      AND organization_id = v_org_id;
+    IF v_sub_gm_name IS NULL THEN
+      RAISE EXCEPTION 'SUB_GM_NOT_FOUND' USING ERRCODE = 'P0022';
+    END IF;
+  END IF;
+
+  SELECT name INTO v_store_name
+  FROM stores
+  WHERE id = p_selected_store_id
+    AND organization_id = v_org_id;
+
+  IF v_store_name IS NULL THEN
+    RAISE EXCEPTION 'STORE_NOT_FOUND' USING ERRCODE = 'P0023';
+  END IF;
+
+  -- 日本の公演カレンダー日（確定候補の date を優先。ISO は JST 暦日で解釈）
+  v_calendar_date := p_selected_date;
+  SELECT elem->>'date' INTO v_raw
+  FROM jsonb_array_elements(COALESCE(p_candidate_datetimes->'candidates', '[]'::jsonb)) AS elem
+  WHERE elem->>'status' = 'confirmed'
+  LIMIT 1;
+
+  IF v_raw IS NOT NULL AND btrim(v_raw) <> '' THEN
+    IF btrim(v_raw) ~ '^\d{4}-\d{2}-\d{2}$' THEN
+      v_calendar_date := btrim(v_raw)::date;
+    ELSE
+      BEGIN
+        v_calendar_date := ((btrim(v_raw))::timestamptz AT TIME ZONE 'Asia/Tokyo')::date;
+      EXCEPTION WHEN OTHERS THEN
+        v_calendar_date := p_selected_date;
+      END;
+    END IF;
+  END IF;
+
+  IF v_existing_event_id IS NOT NULL THEN
+    UPDATE schedule_events
+    SET is_cancelled = true,
+        updated_at = NOW()
+    WHERE id = v_existing_event_id;
+  END IF;
+
+  -- メインGMの競合チェック（直接重複）
+  PERFORM 1
+  FROM schedule_events
+  WHERE organization_id = v_org_id
+    AND date = v_calendar_date
+    AND is_cancelled = false
+    AND v_gm_name = ANY(gms)
+    AND start_time < p_selected_end_time
+    AND end_time > p_selected_start_time
+    AND id != COALESCE(v_existing_event_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  FOR UPDATE NOWAIT;
+
+  IF FOUND THEN
+    RAISE EXCEPTION 'GM_ALREADY_ASSIGNED' USING ERRCODE = 'P0025';
+  END IF;
+
+  -- サブGMの競合チェック（直接重複）
+  IF v_sub_gm_name IS NOT NULL THEN
+    PERFORM 1
+    FROM schedule_events
+    WHERE organization_id = v_org_id
+      AND date = v_calendar_date
+      AND is_cancelled = false
+      AND v_sub_gm_name = ANY(gms)
+      AND start_time < p_selected_end_time
+      AND end_time > p_selected_start_time
+      AND id != COALESCE(v_existing_event_id, '00000000-0000-0000-0000-000000000000'::uuid)
+    FOR UPDATE NOWAIT;
+
+    IF FOUND THEN
+      RAISE EXCEPTION 'GM_ALREADY_ASSIGNED' USING ERRCODE = 'P0025';
+    END IF;
+  END IF;
+
+  -- 店舗の直接重複チェック
+  PERFORM 1
+  FROM schedule_events
+  WHERE organization_id = v_org_id
+    AND date = v_calendar_date
+    AND store_id = p_selected_store_id
+    AND is_cancelled = false
+    AND start_time < p_selected_end_time
+    AND end_time > p_selected_start_time
+    AND id != COALESCE(v_existing_event_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  FOR UPDATE NOWAIT;
+
+  IF FOUND THEN
+    RAISE EXCEPTION 'SLOT_ALREADY_OCCUPIED' USING ERRCODE = 'P0019';
+  END IF;
+
+  -- 店舗の60分インターバルチェック（設営・撤収時間の確保）
+  PERFORM 1
+  FROM schedule_events
+  WHERE organization_id = v_org_id
+    AND date = v_calendar_date
+    AND store_id = p_selected_store_id
+    AND is_cancelled = false
+    AND start_time < p_selected_end_time + INTERVAL '60 minutes'
+    AND end_time > p_selected_start_time - INTERVAL '60 minutes'
+    AND id != COALESCE(v_existing_event_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  FOR UPDATE NOWAIT;
+
+  IF FOUND THEN
+    RAISE EXCEPTION 'INTERVAL_TOO_SHORT' USING ERRCODE = 'P0027';
+  END IF;
+
+  IF v_sub_gm_name IS NOT NULL THEN
+    v_gms_array := ARRAY[v_gm_name, v_sub_gm_name];
+    v_gm_roles := jsonb_build_object(v_gm_name, 'main', v_sub_gm_name, 'sub');
+  ELSE
+    v_gms_array := ARRAY[v_gm_name];
+    v_gm_roles := '{}'::jsonb;
+  END IF;
+
+  INSERT INTO schedule_events (
+    date,
+    venue,
+    scenario,
+    start_time,
+    end_time,
+    start_at,
+    end_at,
+    store_id,
+    gms,
+    gm_roles,
+    is_reservation_enabled,
+    status,
+    category,
+    organization_id,
+    reservation_id,
+    reservation_name,
+    is_reservation_name_overwritten
+  ) VALUES (
+    v_calendar_date,
+    v_store_name,
+    p_scenario_title,
+    p_selected_start_time,
+    p_selected_end_time,
+    (v_calendar_date + p_selected_start_time)::timestamptz,
+    (v_calendar_date + p_selected_end_time)::timestamptz,
+    p_selected_store_id,
+    v_gms_array,
+    v_gm_roles,
+    false,
+    'confirmed',
+    'private',
+    v_org_id,
+    p_reservation_id,
+    p_customer_name,
+    false
+  )
+  RETURNING id INTO v_schedule_event_id;
+
+  UPDATE reservations
+  SET
+    status = 'confirmed',
+    gm_staff = p_selected_gm_id,
+    store_id = p_selected_store_id,
+    schedule_event_id = v_schedule_event_id,
+    candidate_datetimes = COALESCE(p_candidate_datetimes, candidate_datetimes),
+    requested_datetime = (v_calendar_date::text || ' ' || p_selected_start_time::text)::TIMESTAMP WITH TIME ZONE,
+    duration = EXTRACT(EPOCH FROM (p_selected_end_time - p_selected_start_time)) / 60,
+    confirmed_by = COALESCE(v_caller_staff_id, confirmed_by),
+    updated_at = NOW()
+  WHERE id = p_reservation_id;
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  IF v_updated_count <> 1 THEN
+    RAISE EXCEPTION 'RESERVATION_UPDATE_FAILED' USING ERRCODE = 'P0024';
+  END IF;
+
+  IF v_private_group_id IS NOT NULL THEN
+    UPDATE private_groups
+    SET status = 'confirmed'
+    WHERE id = v_private_group_id;
+  END IF;
+
+  RETURN v_schedule_event_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION approve_private_booking(
+  UUID, DATE, TIME, TIME, UUID, UUID, JSONB, TEXT, TEXT, UUID
+) TO authenticated;
+
+COMMENT ON FUNCTION approve_private_booking(
+  UUID, DATE, TIME, TIME, UUID, UUID, JSONB, TEXT, TEXT, UUID
+) IS
+'貸切予約承認。確定候補の date を JST 暦で解釈して schedule_events.date に保存。同一店舗は60分インターバル必須（P0027）。';


### PR DESCRIPTION
## 概要

貸切予約承認フローにおいて、同一店舗での公演間隔が60分未満の場合に承認を拒否するチェックを追加します。

Closes #81

## 変更内容

- **DB（RPC）**: `approve_private_booking` に新しい60分インターバルチェックを追加
  - 直接重複チェック（P0019）の後に追加
  - 60分未満の場合は `INTERVAL_TOO_SHORT`（P0027）エラーを返す
  - マイグレーション: `20260507000000_add_60min_interval_check_to_approve_booking.sql`

- **クライアント事前チェック**（`useBookingApproval.ts`）:
  - 承認前に既存公演との60分インターバルを確認
  - P0027エラーのハンドリングと日本語エラーメッセージを追加

- **競合チェック表示**（`useConflictCheck.ts`）:
  - グループ一覧の競合表示にも60分バッファを適用
  - `addMinutesToTime` ヘルパー関数を追加

## 技術詳細

`create_private_booking_request` RPC はすでに60分インターバルチェックを実装していたが、`approve_private_booking` では直接重複のみをチェックしていた。この不整合を修正。

## DBマイグレーション

`npm run db:push` でステージングDBに適用が必要です。

## テスト手順

1. 同一店舗・同日に公演A（10:00〜12:00）が存在する状態で
2. 12:30〜14:00の貸切予約を承認しようとする
3. 「60分未満」エラーが表示されることを確認
4. 13:00〜15:00（60分以上の間隔）では承認できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)