### PR TITLE
fix: claude-issue-handler に git checkout 権限を追加

### DIFF
--- a/.github/workflows/claude-issue-handler.yml
+++ b/.github/workflows/claude-issue-handler.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*),Bash(gh pr create:*),Bash(npm run typecheck:*),Bash(npm run build:fast:*)"
+          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,Bash(git add:*),Bash(git checkout:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*),Bash(gh pr create:*),Bash(npm run typecheck:*),Bash(npm run build:fast:*)"
           direct_prompt: |
             GitHub Issue #${{ github.event.issue.number }} が作成されました。
 


### PR DESCRIPTION
## 概要

Issue ハンドラーワークフローで Claude がブランチを作成できず `CLAUDE_SUCCESS: false` で終了していた問題を修正します。

## 原因

`allowed_tools` に `Bash(git checkout:*)` が含まれておらず、`git checkout -b fix/issue-N` の実行が拒否されていた。

## 変更

`.github/workflows/claude-issue-handler.yml` の `allowed_tools` に `Bash(git checkout:*)` を追加。

## 影響

Issue #86 以降のハンドラーが正常にブランチを作成してPRを出せるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)