### PR TITLE
fix: グループ削除を SECURITY DEFINER RPC に置き換え（#86）

### DIFF
--- a/src/pages/PrivateGroupInvite/index.tsx
+++ b/src/pages/PrivateGroupInvite/index.tsx
@@ -773,44 +773,14 @@ export function PrivateGroupInvite() {
     }
   }
 
-  // グループ削除（主催者かつgatheringまたはcancelledステータスのみ）
   const handleDeleteGroup = async () => {
     if (!group || !isOrganizer || (group.status !== 'gathering' && group.status !== 'cancelled')) return
-    
+
     setIsDeleting(true)
     try {
-      // メンバーを全員削除
-      const { error: membersError } = await supabase
-        .from('private_group_members')
-        .delete()
-        .eq('group_id', group.id)
-      
-      if (membersError) throw membersError
-      
-      // 候補日を全て削除
-      const { error: datesError } = await supabase
-        .from('private_group_candidate_dates')
-        .delete()
-        .eq('group_id', group.id)
-      
-      if (datesError) throw datesError
-      
-      // メッセージを削除
-      const { error: messagesError } = await supabase
-        .from('private_group_messages')
-        .delete()
-        .eq('group_id', group.id)
-      
-      if (messagesError) throw messagesError
-      
-      // グループを削除
-      const { error: groupDeleteError } = await supabase
-        .from('private_groups')
-        .delete()
-        .eq('id', group.id)
-      
-      if (groupDeleteError) throw groupDeleteError
-      
+      const { error } = await supabase.rpc('delete_private_group', { p_group_id: group.id })
+      if (error) throw error
+
       toast.success('グループを削除しました')
       navigate('/mypage')
     } catch (err: any) {

--- a/supabase/migrations/20260507010000_add_delete_private_group_rpc.sql
+++ b/supabase/migrations/20260507010000_add_delete_private_group_rpc.sql
@@ -1,0 +1,52 @@
+-- 主催者がグループを削除するRPC
+-- 複数テーブルへの RLS 依存チェーンを避けるため SECURITY DEFINER で一括削除
+
+CREATE OR REPLACE FUNCTION public.delete_private_group(
+  p_group_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+SET row_security = off
+AS $$
+DECLARE
+  v_group RECORD;
+  v_caller_id UUID;
+BEGIN
+  v_caller_id := auth.uid();
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'ログインが必要です' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT id, organizer_id, status
+  INTO v_group
+  FROM private_groups
+  WHERE id = p_group_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'グループが見つかりません' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_group.organizer_id != v_caller_id THEN
+    RAISE EXCEPTION '削除できるのは主催者のみです' USING ERRCODE = 'P0010';
+  END IF;
+
+  IF v_group.status NOT IN ('gathering', 'cancelled') THEN
+    RAISE EXCEPTION '削除できるのは予約申請前または キャンセル済みのグループのみです' USING ERRCODE = 'P0003';
+  END IF;
+
+  -- 依存テーブルを順番に削除（CASCADE があるが明示的に削除して確実に）
+  DELETE FROM private_group_date_responses WHERE group_id = p_group_id;
+  DELETE FROM private_group_candidate_dates WHERE group_id = p_group_id;
+  DELETE FROM private_group_messages WHERE group_id = p_group_id;
+  DELETE FROM private_group_members WHERE group_id = p_group_id;
+  DELETE FROM private_groups WHERE id = p_group_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.delete_private_group(UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.delete_private_group IS
+'主催者がグループを削除する（gathering/cancelled のみ）。SECURITY DEFINER で RLS をバイパスし一括削除。';


### PR DESCRIPTION
## 概要

予約申請前のグループが削除できない不具合を修正します。

Closes #86

## 原因

`handleDeleteGroup()` が `private_group_members` → `private_group_candidate_dates` → `private_group_messages` → `private_groups` を個別に DELETE していたが、それぞれのテーブルの RLS ポリシーの USING 句が相互参照しており、削除順序やテーブル間の依存関係で失敗していた。

特に `private_group_messages.member_id` は `ON DELETE SET NULL`（migration 20260311200000 で変更済み）のため、メンバー削除後もメッセージが残り、その削除でポリシーが通らないケースがあった。

## 修正内容

- **`delete_private_group` RPC**（SECURITY DEFINER）を新規作成
  - 呼び出し元が organizer_id と一致するかチェック
  - status が `gathering` または `cancelled` のみ許可
  - 依存テーブルを正しい順序で一括削除
- フロントエンドの `handleDeleteGroup()` をこの RPC 呼び出し1行に簡略化

## DBマイグレーション

`npm run db:push` でステージングDBに適用が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)