### PR TITLE
fix: 公演中止判定の cron を cron-job.org に移行（GitHub Actions 遅延対策）

### DIFF
--- a/.github/workflows/check-performance-day-before.yml
+++ b/.github/workflows/check-performance-day-before.yml
@@ -1,8 +1,9 @@
 name: 公演中止判定（前日チェック）
 
 on:
-  schedule:
-    - cron: '30 14 * * *'  # 23:30 JST (14:59 UTCまで29分の余裕を確保)
+  # スケジュール実行は cron-job.org に移行したため無効化
+  # schedule:
+  #   - cron: '30 14 * * *'
   workflow_dispatch:        # GitHub UI からの手動実行（失敗時の再実行用）
 
 jobs:

--- a/.github/workflows/check-performance-four-hours.yml
+++ b/.github/workflows/check-performance-four-hours.yml
@@ -1,8 +1,9 @@
 name: 公演中止判定（4時間前チェック）
 
 on:
-  schedule:
-    - cron: '0,15,30,45 * * * *'   # 15分ごと UTC（GitHub Actions遅延対策）
+  # スケジュール実行は cron-job.org に移行したため無効化
+  # schedule:
+  #   - cron: '0,15,30,45 * * * *'
   workflow_dispatch:       # GitHub UI からの手動実行（失敗時の再実行用）
 
 jobs:

--- a/src/pages/PrivateBookingManagement/components/PrivateGroupAnnouncementHistoryDialog.tsx
+++ b/src/pages/PrivateBookingManagement/components/PrivateGroupAnnouncementHistoryDialog.tsx
@@ -162,6 +162,7 @@ function SystemMessageCard({ payload, createdAt, senderName }: SystemMsgProps) {
 
   // 却下
   if (action === 'booking_rejected') {
+    const rejectionReason = typeof payload.rejectionReason === 'string' ? payload.rejectionReason : ''
     return (
       <div className="flex justify-center my-3">
         <div className="bg-red-50 border border-red-200 rounded-lg p-3 w-full max-w-sm">
@@ -175,6 +176,11 @@ function SystemMessageCard({ payload, createdAt, senderName }: SystemMsgProps) {
             </div>
           </div>
           {body && <p className="text-xs text-gray-600 mt-2">{body}</p>}
+          {rejectionReason && (
+            <div className="mt-2 bg-white rounded border border-red-100 px-2 py-1.5">
+              <p className="text-xs text-gray-700 whitespace-pre-wrap">{rejectionReason}</p>
+            </div>
+          )}
         </div>
       </div>
     )

--- a/src/pages/PrivateGroupManage/components/GroupChat.tsx
+++ b/src/pages/PrivateGroupManage/components/GroupChat.tsx
@@ -31,6 +31,7 @@ interface SystemMessage {
   title?: string
   body?: string
   note?: string
+  rejectionReason?: string
   // 個別お知らせ用
   target_member_id?: string
   target_member_name?: string
@@ -869,6 +870,11 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
                           <p className="text-xs text-gray-600 mt-2">
                             {systemMsg.body || '店舗の都合がつかず、ご希望の日程でのご予約をお受けすることができませんでした。お手数ですが、別の候補日を選択のうえ再度お申し込みください。'}
                           </p>
+                          {systemMsg.rejectionReason && (
+                            <div className="mt-2 bg-white rounded border border-red-100 px-3 py-2">
+                              <p className="text-xs text-gray-700 whitespace-pre-wrap">{systemMsg.rejectionReason}</p>
+                            </div>
+                          )}
                         </div>
                       </div>
                     )

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -104,3 +104,7 @@ verify_jwt = false
 # Discord 貸切予約通知（DBトリガー / 管理画面からの再送、どちらも関数内でロール確認）
 [functions.notify-private-booking-discord]
 verify_jwt = false
+
+# 公演中止判定（cron-job.org / GitHub Actions から x-cron-secret で認証）
+[functions.check-performance-cancellation]
+verify_jwt = false

--- a/supabase/migrations/20260514000000_add_unique_constraint_cancellation_logs.sql
+++ b/supabase/migrations/20260514000000_add_unique_constraint_cancellation_logs.sql
@@ -1,0 +1,5 @@
+-- performance_cancellation_logs の二重処理防止
+-- cron-job.org から15分ごとに呼び出されるため、同一イベントへの重複実行を防ぐ
+ALTER TABLE public.performance_cancellation_logs
+  ADD CONSTRAINT performance_cancellation_logs_event_check_type_unique
+  UNIQUE (schedule_event_id, check_type);


### PR DESCRIPTION
## 背景
GitHub Actions のスケジュール実行が最大2時間遅延する問題が頻発し、お客様への通知が大幅に遅れる事案が発生した。

## 変更内容
- **cron-job.org に移行**: 専用スケジューラーのため遅延がほぼなく、失敗時もメール通知される
- **GitHub Actions のスケジュール無効化**: `workflow_dispatch`（手動実行）は残す
- **`check-performance-cancellation` を config.toml に追加**: `verify_jwt = false` で cron-job.org からの認証を通す
- **UNIQUE 制約追加**: `performance_cancellation_logs (schedule_event_id, check_type)` に UNIQUE 制約を追加し、15分ごと実行での二重処理を防止

## cron-job.org 設定済み
- 前日判定: 毎日 23:59 JST
- 4時間前判定: 15分ごと

## 確認事項
- [ ] staging マージ後、マイグレーション適用を確認
- [ ] 本番マージ後、`yyy` で本番デプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)