### PR TITLE
fix: 公演中止判定の cron を cron-job.org に移行 & pg_cron シークレット修正

### DIFF
--- a/supabase/migrations/20260514000000_add_unique_constraint_cancellation_logs.sql
+++ b/supabase/migrations/20260514000000_add_unique_constraint_cancellation_logs.sql
@@ -1,5 +1,15 @@
 -- performance_cancellation_logs の二重処理防止
--- cron-job.org から15分ごとに呼び出されるため、同一イベントへの重複実行を防ぐ
+-- GitHub Actions 遅延による重複実行で既に重複データがあるため、先に削除してから制約を追加する
+
+-- 重複行を削除（同一 schedule_event_id + check_type の中で最古の行を残す）
+DELETE FROM public.performance_cancellation_logs
+WHERE id NOT IN (
+  SELECT DISTINCT ON (schedule_event_id, check_type) id
+  FROM public.performance_cancellation_logs
+  ORDER BY schedule_event_id, check_type, created_at ASC
+);
+
+-- UNIQUE 制約を追加
 ALTER TABLE public.performance_cancellation_logs
   ADD CONSTRAINT performance_cancellation_logs_event_check_type_unique
   UNIQUE (schedule_event_id, check_type);

--- a/supabase/migrations/20260514010000_fix_cron_jobs_remove_hardcoded_secrets.sql
+++ b/supabase/migrations/20260514010000_fix_cron_jobs_remove_hardcoded_secrets.sql
@@ -1,0 +1,47 @@
+-- cron ジョブのハードコードされたシークレットを app_config 参照に変更
+--
+-- 問題: retry-discord-notifications / process-booking-email-queue / process-waitlist-queue の
+--       x-cron-secret がハードコードされており、CRON_SECRET 変更時に 401 になる。
+-- 解決: app_config.trigger_secret を参照する方式に統一（DB トリガーと同じ値を使用）
+
+UPDATE cron.job
+SET command = $cmd$
+  SELECT net.http_post(
+    url := (SELECT value FROM public.app_config WHERE key = 'supabase_url') || '/functions/v1/retry-discord-notifications',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT value FROM public.app_config WHERE key = 'supabase_anon_key'),
+      'x-cron-secret', (SELECT value FROM public.app_config WHERE key = 'trigger_secret')
+    ),
+    body := '{}'::jsonb
+  ) AS request_id;
+$cmd$
+WHERE jobname = 'retry-discord-notifications';
+
+UPDATE cron.job
+SET command = $cmd$
+  SELECT net.http_post(
+    url := (SELECT value FROM public.app_config WHERE key = 'supabase_url') || '/functions/v1/process-booking-email-queue',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT value FROM public.app_config WHERE key = 'supabase_anon_key'),
+      'x-cron-secret', (SELECT value FROM public.app_config WHERE key = 'trigger_secret')
+    ),
+    body := '{}'::jsonb
+  ) AS request_id;
+$cmd$
+WHERE jobname = 'process-booking-email-queue';
+
+UPDATE cron.job
+SET command = $cmd$
+  SELECT net.http_post(
+    url := (SELECT value FROM public.app_config WHERE key = 'supabase_url') || '/functions/v1/process-waitlist-queue',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT value FROM public.app_config WHERE key = 'supabase_anon_key'),
+      'x-cron-secret', (SELECT value FROM public.app_config WHERE key = 'trigger_secret')
+    ),
+    body := '{}'::jsonb
+  ) AS request_id;
+$cmd$
+WHERE jobname = 'process-waitlist-queue';


### PR DESCRIPTION
## Summary

- **公演中止判定の cron を cron-job.org に移行**（GitHub Actions の最大2時間遅延対策）
  - GitHub Actions のスケジュール実行を無効化（workflow_dispatch は残す）
  - `check-performance-cancellation` に `verify_jwt = false` を追加
- **pg_cron ジョブのハードコードされたシークレットを修正**（Issue #99 の根本原因）
  - `retry-discord-notifications` / `process-booking-email-queue` / `process-waitlist-queue` の `x-cron-secret` を `app_config.trigger_secret` から動的に読む方式に統一
  - `CRON_SECRET` 変更時に 401 になる問題を解消
- `performance_cancellation_logs` に UNIQUE 制約を追加（二重処理防止）
- 却下通知の改善（却下理由の表示、メール送信の安定化）

## Test plan

- [ ] cron-job.org の前日判定・4時間前判定が正常に動作することを確認
- [ ] `retry-discord-notifications` が 200 を返すことを確認
- [ ] 貸切予約リクエスト受付時に GM への Discord 通知が自動送信されることを確認
- [ ] 却下通知メールに却下理由が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)