### PR TITLE
fix: SlotMemoInput の不要な eslint-disable コメント削除

### DIFF
--- a/src/components/schedule/SlotMemoInput.tsx
+++ b/src/components/schedule/SlotMemoInput.tsx
@@ -149,7 +149,6 @@ export function SlotMemoInput({ date, storeId, timeSlot }: SlotMemoInputProps) {
     if (organizationId) {
       void migrateLocalStorageSlotMemos(organizationId)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organizationId])
 
   // マウント時に DB からメモを取得


### PR DESCRIPTION
## Summary

- `SlotMemoInput.tsx` の不要な `eslint-disable react-hooks/exhaustive-deps` コメントを削除
- CI の `--report-unused-disable-directives` エラーを解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)