### PR TITLE
feat: スケジュールCSVエクスポート機能

### DIFF
--- a/src/lib/api/salesApi.ts
+++ b/src/lib/api/salesApi.ts
@@ -511,6 +511,127 @@ export const salesApi = {
     }
 
     return { events, reservations: allReservations }
-  }
+  },
+
+  // スケジュールCSVエクスポート用データを取得
+  async getScheduleExportData(startDate: string, endDate: string) {
+    const orgId = await getCurrentOrganizationId()
+
+    let eventsQuery = supabase
+      .from('schedule_events_staff_view')
+      .select('id, date, start_time, end_time, store_id, venue, scenario, category, gms, capacity, max_participants, venue_rental_fee, is_cancelled, organization_id')
+      .gte('date', startDate)
+      .lte('date', endDate)
+      .eq('is_cancelled', false)
+      .order('date', { ascending: true })
+      .order('start_time', { ascending: true })
+
+    if (orgId) {
+      eventsQuery = eventsQuery.eq('organization_id', orgId)
+    }
+
+    const { data: events, error } = await eventsQuery
+    if (error) throw error
+    if (!events || events.length === 0) return []
+
+    // スタッフ名セットを取得（スタッフ参加判定用）
+    let staffQuery = supabase.from('staff').select('name')
+    if (orgId) staffQuery = staffQuery.eq('organization_id', orgId)
+    const { data: staffData } = await staffQuery
+    const staffNames = new Set(staffData?.map(s => s.name) || [])
+
+    // 店舗一覧を取得
+    const { data: stores } = await supabase
+      .from('stores')
+      .select('id, name, short_name')
+    const storeMap = new Map(stores?.map(s => [s.id, s]) || [])
+
+    // 全予約を一括取得（バッチ処理）
+    const eventIds = events.map(e => e.id)
+    const BATCH_SIZE = 100
+    const allReservations: Array<{
+      schedule_event_id: string
+      participant_count: number | null
+      participant_names: string[] | null
+      payment_method: string | null
+      final_price: number | null
+    }> = []
+
+    for (let i = 0; i < eventIds.length; i += BATCH_SIZE) {
+      const batchIds = eventIds.slice(i, i + BATCH_SIZE)
+      let resQuery = supabase
+        .from('reservations')
+        .select('schedule_event_id, participant_count, participant_names, payment_method, final_price')
+        .in('schedule_event_id', batchIds)
+        .in('status', ['confirmed', 'pending', 'gm_confirmed', 'checked_in'])
+
+      if (orgId) resQuery = resQuery.eq('organization_id', orgId)
+
+      const { data: batch } = await resQuery
+      if (batch) allReservations.push(...batch)
+    }
+
+    // イベントIDごとに予約をグループ化
+    const reservationsByEvent = new Map<string, typeof allReservations>()
+    allReservations.forEach(r => {
+      const existing = reservationsByEvent.get(r.schedule_event_id) || []
+      existing.push(r)
+      reservationsByEvent.set(r.schedule_event_id, existing)
+    })
+
+    return events.map(event => {
+      const reservations = reservationsByEvent.get(event.id) || []
+      const isVenueRental = event.category === 'venue_rental' || event.category === 'venue_rental_free'
+      const store = storeMap.get(event.store_id ?? '')
+
+      let totalParticipants = 0
+      let staffParticipants = 0
+      let regularParticipants = 0
+      let onsiteAmount = 0
+      let onlineAmount = 0
+      let staffAmount = 0
+
+      if (isVenueRental) {
+        onsiteAmount = event.category === 'venue_rental_free' ? 0 : (event.venue_rental_fee || 12000)
+      } else {
+        reservations.forEach(r => {
+          const count = r.participant_count || 0
+          totalParticipants += count
+
+          const names = r.participant_names || []
+          const isStaff = r.payment_method === 'staff' || names.some((n: string) => staffNames.has(n))
+
+          if (isStaff) {
+            staffParticipants += count
+          } else {
+            regularParticipants += count
+            const price = r.final_price || 0
+            if (r.payment_method === 'onsite') onsiteAmount += price
+            else if (r.payment_method === 'online') onlineAmount += price
+            else staffAmount += price
+          }
+        })
+      }
+
+      const totalRevenue = onsiteAmount + onlineAmount
+
+      return {
+        date: event.date,
+        start_time: event.start_time,
+        end_time: event.end_time,
+        store_name: store?.short_name || store?.name || event.venue || '',
+        scenario: event.scenario || '',
+        category: event.category,
+        gms: Array.isArray(event.gms) ? (event.gms as string[]).join('・') : String(event.gms || ''),
+        capacity: event.max_participants || event.capacity || 0,
+        total_participants: totalParticipants,
+        regular_participants: regularParticipants,
+        staff_participants: staffParticipants,
+        onsite_amount: onsiteAmount,
+        online_amount: onlineAmount,
+        total_revenue: totalRevenue,
+      }
+    })
+  },
 }
 

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -5,7 +5,7 @@ import { getSafeErrorMessage } from '@/lib/apiErrorHandler'
 import { showToast } from '@/utils/toast'
 
 // API
-import { staffApi, scheduleApi } from '@/lib/api'
+import { staffApi, scheduleApi, salesApi } from '@/lib/api'
 import { supabase } from '@/lib/supabase'
 import { getCurrentOrganizationId, QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
 
@@ -54,12 +54,13 @@ const HistoryModal = lazy(() => import('@/components/schedule/modal/HistoryModal
 const KitManagementDialog = lazy(() => import('./components/KitManagementDialog').then(m => ({ default: m.KitManagementDialog })))
 
 // Icons
-import { Ban, Edit, RotateCcw, Trash2, Plus, CalendarDays, Upload, FileText, EyeOff, Eye, SlidersHorizontal, ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Clock, Package, Calendar, Users, Wrench } from 'lucide-react'
+import { Ban, Edit, RotateCcw, Trash2, Plus, CalendarDays, Upload, FileText, EyeOff, Eye, SlidersHorizontal, ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Clock, Package, Calendar, Users, Wrench, Download } from 'lucide-react'
 
 // Utils
 import { getJapaneseHoliday } from '@/utils/japaneseHolidays'
 import { RESERVATION_SOURCE } from '@/lib/constants'
 import { recalculateCurrentParticipants } from '@/lib/participantUtils'
+import { exportScheduleToCSV } from './utils/exportSchedule'
 
 // Types
 export type { ScheduleEvent } from '@/types/schedule'
@@ -116,6 +117,7 @@ export function ScheduleManager() {
   // その他の状態
   const [isImportModalOpen, setIsImportModalOpen] = useState(false)
   const [isKitManagementOpen, setIsKitManagementOpen] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
   const [isFillingSeats, setIsFillingSeats] = useState(false)
   const [isFixingData, setIsFixingData] = useState(false)
   const [isCleaningDemo, setIsCleaningDemo] = useState(false)
@@ -181,6 +183,26 @@ export function ScheduleManager() {
   }, [currentVisibleDate, monthDays])
   
   const currentHoliday = currentVisibleDate ? getJapaneseHoliday(currentVisibleDate) : null
+
+  // スケジュールCSVエクスポート
+  const handleExportCSV = async () => {
+    const year = currentDate.getFullYear()
+    const month = currentDate.getMonth() + 1
+    const startDate = `${year}-${String(month).padStart(2, '0')}-01`
+    const lastDay = new Date(year, month, 0).getDate()
+    const endDate = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+    const yearMonth = `${year}${String(month).padStart(2, '0')}`
+
+    setIsExporting(true)
+    try {
+      const rows = await salesApi.getScheduleExportData(startDate, endDate)
+      exportScheduleToCSV(rows, yearMonth)
+    } catch (e) {
+      showToast.error('CSVエクスポートに失敗しました')
+    } finally {
+      setIsExporting(false)
+    }
+  }
 
   // 中止以外を満席にする処理（参加者数を定員に合わせる）
   const handleFillAllSeats = async () => {
@@ -1159,6 +1181,18 @@ export function ScheduleManager() {
               className="h-9 w-9 flex items-center justify-center hover:bg-accent transition-colors border-r border-input"
             >
               <Package className="h-4 w-4" />
+            </button>
+            <button
+              onClick={handleExportCSV}
+              disabled={isExporting}
+              title={`${currentDate.getFullYear()}年${currentDate.getMonth() + 1}月のスケジュールをCSVエクスポート`}
+              className="h-9 w-9 flex items-center justify-center hover:bg-accent transition-colors border-r border-input disabled:opacity-50"
+            >
+              {isExporting ? (
+                <span className="animate-spin h-4 w-4 border-2 border-primary border-t-transparent rounded-full" />
+              ) : (
+                <Download className="h-4 w-4" />
+              )}
             </button>
             <button
               onClick={() => setIsImportModalOpen(true)}

--- a/src/pages/ScheduleManager/utils/exportSchedule.ts
+++ b/src/pages/ScheduleManager/utils/exportSchedule.ts
@@ -1,0 +1,79 @@
+import { saveAs } from 'file-saver'
+
+const CATEGORY_LABELS: Record<string, string> = {
+  open: 'オープン公演',
+  private: '貸切公演',
+  gmtest: 'GMテスト',
+  testplay: 'テストプレイ',
+  offsite: '出張公演',
+  venue_rental: '場所貸し',
+  venue_rental_free: '場所貸し(無料)',
+  package: 'パッケージ',
+  mtg: 'MTG',
+  memo: 'メモ',
+}
+
+type ExportRow = {
+  date: string
+  start_time: string
+  end_time: string
+  store_name: string
+  scenario: string
+  category: string
+  gms: string
+  capacity: number
+  total_participants: number
+  regular_participants: number
+  staff_participants: number
+  onsite_amount: number
+  online_amount: number
+  total_revenue: number
+}
+
+export function exportScheduleToCSV(rows: ExportRow[], yearMonth: string) {
+  const headers = [
+    '日付',
+    '開始時間',
+    '終了時間',
+    '会場',
+    'シナリオ',
+    'カテゴリ',
+    'GM',
+    '定員',
+    '参加者数合計',
+    '一般参加者数',
+    'スタッフ参加者数',
+    '予想現地決済額',
+    'オンライン決済済み額',
+    '売上合計',
+  ]
+
+  const dataRows = rows.map(r => [
+    r.date,
+    r.start_time?.slice(0, 5) ?? '',
+    r.end_time?.slice(0, 5) ?? '',
+    r.store_name,
+    r.scenario,
+    CATEGORY_LABELS[r.category] ?? r.category,
+    r.gms,
+    r.capacity,
+    r.total_participants,
+    r.regular_participants,
+    r.staff_participants,
+    r.onsite_amount,
+    r.online_amount,
+    r.total_revenue,
+  ])
+
+  const csvContent = [headers, ...dataRows]
+    .map(row => row.map(cell => {
+      const s = String(cell ?? '')
+      return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
+    }).join(','))
+    .join('\n')
+
+  // BOM付きUTF-8でExcelが文字化けしないようにする
+  const bom = '﻿'
+  const blob = new Blob([bom + csvContent], { type: 'text/csv;charset=utf-8;' })
+  saveAs(blob, `スケジュール_${yearMonth}.csv`)
+}


### PR DESCRIPTION
## Summary
- スケジュールページのツールバーにダウンロード（↓）ボタンを追加
- 現在表示中の月のスケジュールを `スケジュール_YYYYMM.csv` でダウンロード
- CSV列: 日付・時間・会場・シナリオ・カテゴリ・GM・定員・参加者数合計・一般参加者数・スタッフ参加者数・予想現地決済額・オンライン決済済み額・売上合計

## Test plan
- [ ] スケジュールページのツールバーに↓ボタンが表示される
- [ ] ボタンクリックで当月スケジュールのCSVがダウンロードされる
- [ ] スタッフ参加者が `スタッフ参加者数` 列にカウントされ売上から除外される
- [ ] `予想現地決済額` が onsite payment_method 合計と一致する
- [ ] 場所貸し公演は `venue_rental_fee` が予想現地決済額に入る

🤖 Generated with [Claude Code](https://claude.com/claude-code)