### PR TITLE
fix: ゲストアカウントに事前アンケートが表示されない問題を修正

### DIFF
--- a/src/pages/PrivateGroupInvite/components/SurveyResponseForm.tsx
+++ b/src/pages/PrivateGroupInvite/components/SurveyResponseForm.tsx
@@ -16,8 +16,6 @@ import type { SurveyQuestion } from '@/types'
 interface SurveyResponseFormProps {
   groupId: string
   memberId: string
-  scenarioId: string
-  organizationId: string
   performanceDate?: string
   characters?: Array<{ id: string; name: string; gender?: string }>
   hideCharacterSelection?: boolean
@@ -30,8 +28,6 @@ interface FormResponse {
 export function SurveyResponseForm({
   groupId,
   memberId,
-  scenarioId,
-  organizationId,
   performanceDate,
   characters = [],
   hideCharacterSelection = false,
@@ -48,116 +44,67 @@ export function SurveyResponseForm({
 
   useEffect(() => {
     const loadSurveyData = async () => {
-      logger.log('📋 SurveyForm: loading', { groupId, memberId, scenarioId, organizationId })
-      
-      if (!scenarioId || !organizationId) {
-        logger.log('📋 SurveyForm: missing scenarioId or organizationId', { 
-          scenarioId, 
-          organizationId,
-          groupId,
-          memberId 
-        })
-        setSurveyStatus('not_found')
-        setLoading(false)
-        return
-      }
+      logger.log('📋 SurveyForm: loading', { groupId, memberId })
 
       try {
-        // organization_scenariosからorg_scenario_idとdeadline_days、キャラクター情報を取得
-        // まずscenario_master_idで検索
-        let { data: orgScenario } = await supabase
-          .from('organization_scenarios')
-          .select('id, survey_enabled, survey_deadline_days, characters')
-          .eq('scenario_master_id', scenarioId)
-          .eq('organization_id', organizationId)
-          .maybeSingle()
+        const { data, error } = await supabase.rpc('get_survey_data_for_member', {
+          p_group_id: groupId,
+          p_member_id: memberId,
+        })
 
-        logger.log('📋 SurveyForm: first query result', { orgScenario, scenarioId, organizationId })
+        logger.log('📋 SurveyForm: rpc result', { data, error })
 
-        // 見つからなければidで検索（scenarioIdがorganization_scenario.idの場合）
-        if (!orgScenario) {
-          const { data: orgScenarioById, error: byIdError } = await supabase
-            .from('organization_scenarios')
-            .select('id, survey_enabled, survey_deadline_days, characters')
-            .eq('id', scenarioId)
-            .maybeSingle()
-          orgScenario = orgScenarioById
-          logger.log('📋 SurveyForm: second query result (by id)', { orgScenarioById, byIdError })
-        }
-        
-        logger.log('📋 SurveyForm: final orgScenario', { orgScenario, scenarioId })
-
-        if (!orgScenario) {
-          logger.log('📋 SurveyForm: orgScenario not found', { scenarioId, organizationId })
+        if (error) {
+          logger.error('📋 SurveyForm: rpc error', error)
           setSurveyStatus('not_found')
           setLoading(false)
           return
         }
-        
-        if (!orgScenario.survey_enabled) {
-          logger.log('📋 SurveyForm: survey not enabled', { orgScenarioId: orgScenario.id, survey_enabled: orgScenario.survey_enabled })
+
+        if (!data || data.error) {
+          logger.log('📋 SurveyForm: not found', { data })
+          setSurveyStatus('not_found')
+          setLoading(false)
+          return
+        }
+
+        if (!data.survey_enabled) {
+          logger.log('📋 SurveyForm: survey disabled')
           setSurveyStatus('disabled')
           setLoading(false)
           return
         }
 
         // 期限を計算
-        if (performanceDate && orgScenario.survey_deadline_days !== undefined) {
+        if (performanceDate && data.survey_deadline_days != null) {
           const perfDate = new Date(performanceDate + 'T00:00:00+09:00')
-          perfDate.setDate(perfDate.getDate() - orgScenario.survey_deadline_days)
+          perfDate.setDate(perfDate.getDate() - data.survey_deadline_days)
           perfDate.setHours(23, 59, 59, 999)
           setDeadlineDate(perfDate)
         } else {
           setDeadlineDate(null)
         }
 
-        // キャラクター情報を設定（propsより優先）
-        // NPCは希望キャラクター選択から除外
-        if (orgScenario.characters && Array.isArray(orgScenario.characters)) {
-          const charData = orgScenario.characters
-            .filter((c: any) => !c.is_npc)  // NPCを除外
-            .map((c: any) => ({
-              id: c.id,
-              name: c.name,
-              gender: c.gender,
-            }))
-          // 外部から渡されたcharactersが空の場合のみ上書き
-          if (characters.length === 0) {
-            setLocalCharacters(charData)
-          }
+        // キャラクター情報を設定（NPCを除外、propsが空の場合のみ上書き）
+        if (Array.isArray(data.characters) && characters.length === 0) {
+          const charData = data.characters
+            .filter((c: any) => !c.is_npc)
+            .map((c: any) => ({ id: c.id, name: c.name, gender: c.gender }))
+          setLocalCharacters(charData)
         }
 
-        // 質問を取得
-        const { data: questionsData, error: questionsError } = await supabase
-          .from('org_scenario_survey_questions')
-          .select(
-            'id, org_scenario_id, question_text, question_type, options, is_required, order_num, created_at, updated_at'
-          )
-          .eq('org_scenario_id', orgScenario.id)
-          .order('order_num', { ascending: true })
-
-        logger.log('📋 SurveyForm: questions', { questionsData, questionsError, orgScenarioId: orgScenario.id })
-
-        if (questionsData && questionsData.length > 0) {
+        const questionsData: SurveyQuestion[] = Array.isArray(data.questions) ? data.questions : []
+        if (questionsData.length > 0) {
           setQuestions(questionsData)
           setSurveyStatus('ready')
         } else {
           setSurveyStatus('no_questions')
         }
 
-        // 既存の回答を取得
-        const { data: existingResponse, error: existingError } = await supabase
-          .from('private_group_survey_responses')
-          .select('id, responses')
-          .eq('group_id', groupId)
-          .eq('member_id', memberId)
-          .maybeSingle()
-
-        logger.log('📋 SurveyForm: existing response', { existingResponse, existingError, groupId, memberId })
-
-        if (existingResponse) {
-          setExistingResponseId(existingResponse.id)
-          setResponses(existingResponse.responses || {})
+        // 既存の回答を設定
+        if (data.existing_response_id) {
+          setExistingResponseId(data.existing_response_id)
+          setResponses(data.existing_responses || {})
           setSubmitted(true)
         }
       } catch (err) {
@@ -169,7 +116,7 @@ export function SurveyResponseForm({
     }
 
     loadSurveyData()
-  }, [groupId, memberId, scenarioId, organizationId, performanceDate])
+  }, [groupId, memberId, performanceDate])
 
   const handleTextChange = useCallback((questionId: string, value: string) => {
     setResponses(prev => ({ ...prev, [questionId]: value }))
@@ -202,38 +149,20 @@ export function SurveyResponseForm({
 
     setSubmitting(true)
     try {
-      const responsesToSave = responses
+      const { data: responseId, error } = await supabase.rpc('upsert_survey_response_for_member', {
+        p_group_id: groupId,
+        p_member_id: memberId,
+        p_responses: responses,
+      })
 
-      if (existingResponseId) {
-        // 更新
-        const { error } = await supabase
-          .from('private_group_survey_responses')
-          .update({ responses: responsesToSave, updated_at: new Date().toISOString() })
-          .eq('id', existingResponseId)
-
-        if (error) throw error
-        toast.success('回答を更新しました')
-      } else {
-        // 新規作成
-        logger.log('📋 SurveyForm: saving new response', { groupId, memberId, responses })
-        const { data, error } = await supabase
-          .from('private_group_survey_responses')
-          .insert({
-            group_id: groupId,
-            member_id: memberId,
-            responses: responsesToSave,
-          })
-          .select('id')
-          .single()
-
-        if (error) {
-          logger.error('📋 SurveyForm: insert error', error)
-          throw error
-        }
-        logger.log('📋 SurveyForm: saved with id', data.id)
-        setExistingResponseId(data.id)
-        toast.success('回答を送信しました')
+      if (error) {
+        logger.error('📋 SurveyForm: upsert error', error)
+        throw error
       }
+
+      logger.log('📋 SurveyForm: saved with id', responseId)
+      setExistingResponseId(responseId)
+      toast.success(existingResponseId ? '回答を更新しました' : '回答を送信しました')
       setSubmitted(true)
     } catch (err) {
       logger.error('アンケート送信エラー:', err)

--- a/src/pages/PrivateGroupInvite/index.tsx
+++ b/src/pages/PrivateGroupInvite/index.tsx
@@ -3445,8 +3445,6 @@ export function PrivateGroupInvite() {
               <SurveyResponseForm
                 groupId={group.id}
                 memberId={existingMemberId}
-                scenarioId={group.scenario_master_id}
-                organizationId={group.organization_id}
                 performanceDate={group.candidate_dates?.find(cd => cd.order_num === 1)?.date}
                 characters={(group as any).scenario_characters || []}
               />

--- a/src/pages/PrivateGroupManage/components/GroupChat.tsx
+++ b/src/pages/PrivateGroupManage/components/GroupChat.tsx
@@ -1454,17 +1454,10 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
                   <Loader2 className="w-6 h-6 animate-spin mx-auto mb-2" />
                   <p className="text-sm">メンバー情報を読み込み中...</p>
                 </div>
-              ) : !scenarioId || !organizationId ? (
-                <div className="text-center py-8 text-muted-foreground">
-                  <AlertCircle className="w-6 h-6 mx-auto mb-2 text-amber-500" />
-                  <p className="text-sm">アンケート情報を取得できませんでした</p>
-                </div>
               ) : (
                 <SurveyResponseForm
                   groupId={groupId}
                   memberId={currentMemberId}
-                  scenarioId={scenarioId}
-                  organizationId={organizationId}
                   performanceDate={performanceDate}
                 />
               )}

--- a/supabase/migrations/20260515000000_add_survey_rpcs_for_guests.sql
+++ b/supabase/migrations/20260515000000_add_survey_rpcs_for_guests.sql
@@ -1,0 +1,172 @@
+-- ====================================================================
+-- ゲストメンバー向けアンケートRPC追加
+--
+-- 問題: organization_scenarios / org_scenario_survey_questions /
+--       private_group_survey_responses は全て auth.uid() IS NOT NULL
+--       を必要とするRLSポリシーが設定されているため、Supabase未認証の
+--       ゲストメンバーがアンケートを閲覧・回答できない。
+--
+-- 解決: SECURITY DEFINER RPC を経由してデータを返す。
+--       p_member_id が p_group_id に属することを検証してからアクセスする。
+-- ====================================================================
+
+-- ====================================================================
+-- 1. get_survey_data_for_member — アンケートデータ取得（ゲスト対応）
+-- ====================================================================
+CREATE OR REPLACE FUNCTION public.get_survey_data_for_member(
+  p_group_id UUID,
+  p_member_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_group RECORD;
+  v_org_scenario RECORD;
+  v_questions JSONB;
+  v_existing_response RECORD;
+  v_member_exists BOOLEAN;
+BEGIN
+  -- メンバーがグループに属しているか検証
+  SELECT EXISTS(
+    SELECT 1 FROM private_group_members
+    WHERE id = p_member_id
+      AND group_id = p_group_id
+      AND status = 'joined'
+  ) INTO v_member_exists;
+
+  IF NOT v_member_exists THEN
+    RAISE EXCEPTION 'Member does not belong to this group';
+  END IF;
+
+  -- グループのシナリオ情報を取得
+  SELECT scenario_master_id, organization_id
+  INTO v_group
+  FROM private_groups
+  WHERE id = p_group_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error', 'group_not_found');
+  END IF;
+
+  -- organization_scenarios を scenario_master_id で検索
+  SELECT id, survey_enabled, survey_deadline_days, characters
+  INTO v_org_scenario
+  FROM organization_scenarios
+  WHERE scenario_master_id = v_group.scenario_master_id
+    AND organization_id = v_group.organization_id
+  LIMIT 1;
+
+  -- 見つからなければ id で直接検索（scenario_master_id が org_scenario.id の場合）
+  IF NOT FOUND THEN
+    SELECT id, survey_enabled, survey_deadline_days, characters
+    INTO v_org_scenario
+    FROM organization_scenarios
+    WHERE id = v_group.scenario_master_id
+    LIMIT 1;
+  END IF;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error', 'scenario_not_found');
+  END IF;
+
+  IF NOT COALESCE(v_org_scenario.survey_enabled, false) THEN
+    RETURN jsonb_build_object('survey_enabled', false);
+  END IF;
+
+  -- 質問を取得（order_num 順）
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', q.id,
+      'org_scenario_id', q.org_scenario_id,
+      'question_text', q.question_text,
+      'question_type', q.question_type,
+      'options', q.options,
+      'is_required', q.is_required,
+      'order_num', q.order_num,
+      'created_at', q.created_at,
+      'updated_at', q.updated_at
+    ) ORDER BY q.order_num
+  )
+  INTO v_questions
+  FROM org_scenario_survey_questions q
+  WHERE q.org_scenario_id = v_org_scenario.id;
+
+  -- 既存の回答を取得
+  SELECT id, responses
+  INTO v_existing_response
+  FROM private_group_survey_responses
+  WHERE group_id = p_group_id
+    AND member_id = p_member_id;
+
+  RETURN jsonb_build_object(
+    'survey_enabled', true,
+    'org_scenario_id', v_org_scenario.id,
+    'survey_deadline_days', v_org_scenario.survey_deadline_days,
+    'characters', COALESCE(v_org_scenario.characters, '[]'::jsonb),
+    'questions', COALESCE(v_questions, '[]'::jsonb),
+    'existing_response_id', v_existing_response.id,
+    'existing_responses', v_existing_response.responses
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_survey_data_for_member IS 'ゲスト含むグループメンバーのアンケートデータを返すRPC。member_idがgroup_idに属することを検証する。';
+
+GRANT EXECUTE ON FUNCTION public.get_survey_data_for_member(UUID, UUID) TO anon;
+GRANT EXECUTE ON FUNCTION public.get_survey_data_for_member(UUID, UUID) TO authenticated;
+
+-- ====================================================================
+-- 2. upsert_survey_response_for_member — アンケート回答の保存（ゲスト対応）
+-- ====================================================================
+CREATE OR REPLACE FUNCTION public.upsert_survey_response_for_member(
+  p_group_id UUID,
+  p_member_id UUID,
+  p_responses JSONB
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_member_exists BOOLEAN;
+  v_response_id UUID;
+BEGIN
+  -- メンバーがグループに属しているか検証
+  SELECT EXISTS(
+    SELECT 1 FROM private_group_members
+    WHERE id = p_member_id
+      AND group_id = p_group_id
+      AND status = 'joined'
+  ) INTO v_member_exists;
+
+  IF NOT v_member_exists THEN
+    RAISE EXCEPTION 'Member does not belong to this group';
+  END IF;
+
+  -- UNIQUE(group_id, member_id) を利用してUPSERT
+  INSERT INTO private_group_survey_responses (group_id, member_id, responses)
+  VALUES (p_group_id, p_member_id, p_responses)
+  ON CONFLICT (group_id, member_id) DO UPDATE
+    SET responses = EXCLUDED.responses,
+        updated_at = NOW()
+  RETURNING id INTO v_response_id;
+
+  RETURN v_response_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_survey_response_for_member IS 'ゲスト含むグループメンバーのアンケート回答をUPSERTするRPC。member_idがgroup_idに属することを検証する。';
+
+GRANT EXECUTE ON FUNCTION public.upsert_survey_response_for_member(UUID, UUID, JSONB) TO anon;
+GRANT EXECUTE ON FUNCTION public.upsert_survey_response_for_member(UUID, UUID, JSONB) TO authenticated;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ マイグレーション完了: ゲスト向けアンケートRPC追加';
+  RAISE NOTICE '  - get_survey_data_for_member: アンケートデータ取得（anon/authenticated）';
+  RAISE NOTICE '  - upsert_survey_response_for_member: アンケート回答保存（anon/authenticated）';
+END $$;


### PR DESCRIPTION
## 問題

MMQ未登録のゲストアカウントでグループに参加したメンバーに、日程確定後も事前アンケートが表示されない。

## 原因

2026-03-21 のセキュリティ強化マイグレーションで、以下のテーブルが `auth.uid() IS NOT NULL` を必須とするRLSポリシーに変更された：

- `organization_scenarios`（アンケート設定）
- `org_scenario_survey_questions`（質問一覧）
- `private_group_survey_responses`（回答の読み書き）

ゲストはSupabase未認証（`auth.uid() = NULL`）なのでこれらへのクエリが全て失敗し、`SurveyResponseForm` がアンケートを表示できなかった。

## 修正内容

### DBマイグレーション（`20260515000000_add_survey_rpcs_for_guests.sql`）

SECURITY DEFINER RPCを2つ追加：

- **`get_survey_data_for_member(group_id, member_id)`**  
  アンケート設定・質問・既存回答をまとめて返す。`anon` ロールに EXECUTE 付与。
  
- **`upsert_survey_response_for_member(group_id, member_id, responses)`**  
  アンケート回答を保存（INSERT or UPDATE）。`anon` ロールに EXECUTE 付与。

両RPCとも「`member_id` が `group_id` に属すること」をRPC内部で検証するため情報漏洩なし。

### フロントエンド

- `SurveyResponseForm.tsx`：直接テーブルクエリ3本 → 上記RPCに置き換え
- `scenarioId`・`organizationId` propsを削除（RPCがgroupIdから内部解決するため不要）
- `index.tsx`・`GroupChat.tsx`：不要になったpropsの渡しを削除

## テスト手順

1. ステージングDBにマイグレーションを適用（`npm run db:push:staging`）
2. ゲストアカウントで招待URLにアクセス → 参加
3. グループの日程を確定（status: confirmed）
4. アンケートが表示されることを確認
5. 回答を送信・更新できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)