### PR TITLE
fix: モバイルUI改善・メモ・シフトキャッシュ化

### DIFF
--- a/src/components/schedule/ScheduleTable.tsx
+++ b/src/components/schedule/ScheduleTable.tsx
@@ -149,7 +149,7 @@ export function ScheduleTable({
   const { categoryConfig, getReservationBadgeClass } = displayConfig
 
   return (
-    <div className="overflow-x-auto -mx-2 sm:mx-0">
+    <div className="overflow-x-auto -mx-2 sm:mx-0" data-schedule-scroll>
       <Table className="table-fixed w-full border-collapse min-w-[534px] sm:min-w-[700px] md:min-w-[800px]">
         <colgroup>
           <col className="w-[32px] sm:w-[40px] md:w-[48px]" />

--- a/src/hooks/useMemoManager.ts
+++ b/src/hooks/useMemoManager.ts
@@ -1,6 +1,7 @@
 // メモの管理
 
-import { useState, useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { memoApi } from '@/lib/api'
 import { logger } from '@/utils/logger'
 import { getMemoKey } from '@/utils/scheduleUtils'
@@ -11,61 +12,82 @@ interface MemoData {
   memo_text?: string
 }
 
+export const memoKeys = {
+  month: (year: number, month: number) => ['memos', year, month] as const,
+}
+
+async function fetchMemosForMonth(year: number, month: number): Promise<Record<string, string>> {
+  const memoData = await memoApi.getByMonth(year, month)
+  const memoMap: Record<string, string> = {}
+  memoData.forEach((memo: MemoData) => {
+    const key = getMemoKey(memo.date, memo.venue_id)
+    memoMap[key] = memo.memo_text || ''
+  })
+  return memoMap
+}
+
 export function useMemoManager(currentDate: Date) {
-  const [memos, setMemos] = useState<Record<string, string>>({})
+  const queryClient = useQueryClient()
+  const year = currentDate.getFullYear()
+  const month = currentDate.getMonth() + 1
+  const storageKey = `memos_${year}_${month}`
+  const storageTs = `${storageKey}_ts`
 
-  // 初期データ読み込み（月が変わった時も実行）
-  useEffect(() => {
-    const loadMemos = async () => {
+  const { data: memos = {} } = useQuery({
+    queryKey: memoKeys.month(year, month),
+    queryFn: () => fetchMemosForMonth(year, month),
+    staleTime: 10 * 60 * 1000, // 10分間は再フェッチしない
+    gcTime: 60 * 60 * 1000,
+    // sessionStorage から初期値を復元 → 即表示
+    initialData: () => {
       try {
-        const year = currentDate.getFullYear()
-        const month = currentDate.getMonth() + 1
-        const memoData = await memoApi.getByMonth(year, month)
-        
-        // メモデータを状態に変換（venue_id をキーとして使用）
-        const memoMap: Record<string, string> = {}
-        
-        memoData.forEach((memo: MemoData) => {
-          const key = getMemoKey(memo.date, memo.venue_id)
-          memoMap[key] = memo.memo_text || ''
-        })
-        
-        setMemos(memoMap)
-      } catch (error) {
-        logger.error('メモ読み込みエラー:', error)
+        const cached = sessionStorage.getItem(storageKey)
+        return cached ? JSON.parse(cached) : undefined
+      } catch {
+        return undefined
       }
-    }
+    },
+    initialDataUpdatedAt: () => {
+      try {
+        const ts = sessionStorage.getItem(storageTs)
+        return ts ? parseInt(ts) : 0
+      } catch {
+        return 0
+      }
+    },
+  })
 
-    loadMemos()
-  }, [currentDate])
+  // フェッチ完了後に sessionStorage に保存
+  useEffect(() => {
+    if (!memos || Object.keys(memos).length === 0) return
+    try {
+      sessionStorage.setItem(storageKey, JSON.stringify(memos))
+      sessionStorage.setItem(storageTs, String(Date.now()))
+    } catch { /* 容量超過など */ }
+  }, [memos, storageKey, storageTs])
 
-  // メモを保存
-  // venue には venue.id（店舗ID）が渡される
-  const handleSaveMemo = async (date: string, venueId: string, memo: string) => {
+  const handleSaveMemo = useCallback(async (date: string, venueId: string, memo: string) => {
     const key = getMemoKey(date, venueId)
-    setMemos(prev => ({
-      ...prev,
-      [key]: memo
-    }))
+
+    // 楽観的更新（即座にUIに反映）
+    queryClient.setQueryData<Record<string, string>>(
+      memoKeys.month(year, month),
+      prev => ({ ...(prev ?? {}), [key]: memo })
+    )
 
     try {
       await memoApi.save(date, venueId, memo)
       logger.log('メモ保存成功:', { date, venueId, memo })
     } catch (error) {
       logger.error('メモ保存エラー:', error)
+      // 失敗時はキャッシュを無効化して再フェッチ
+      queryClient.invalidateQueries({ queryKey: memoKeys.month(year, month) })
     }
-  }
+  }, [queryClient, year, month])
 
-  // メモを取得（venueId で検索）
-  const getMemo = (date: string, venueId: string) => {
-    const key = getMemoKey(date, venueId)
-    return memos[key] || ''
-  }
+  const getMemo = useCallback((date: string, venueId: string) => {
+    return memos[getMemoKey(date, venueId)] || ''
+  }, [memos])
 
-  return {
-    memos,
-    handleSaveMemo,
-    getMemo
-  }
+  return { memos, handleSaveMemo, getMemo }
 }
-

--- a/src/hooks/useShiftData.ts
+++ b/src/hooks/useShiftData.ts
@@ -24,11 +24,12 @@ export function useShiftData(
   const storageKey = `shifts_${year}_${month}`
   const storageTs = `${storageKey}_ts`
 
-  // 過去の月はシフトデータ不要（誰が出勤可能だったかは今更不要）
+  // 直近3ヶ月の過去 + 今月 + 未来月のみシフトデータを取得
+  // 3ヶ月以上前はシフト参照の必要性が低くスキップ
   const today = new Date()
-  const isCurrentOrFuture =
-    year > today.getFullYear() ||
-    (year === today.getFullYear() && month >= today.getMonth() + 1)
+  const threeMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 3, 1)
+  const displayedMonth = new Date(year, month - 1, 1)
+  const isCurrentOrFuture = displayedMonth >= threeMonthsAgo
 
   // 生シフトデータを React Query で取得・キャッシュ
   // staff の準備を待たずに並列でフェッチ開始

--- a/src/hooks/useShiftData.ts
+++ b/src/hooks/useShiftData.ts
@@ -24,24 +24,15 @@ export function useShiftData(
   const storageKey = `shifts_${year}_${month}`
   const storageTs = `${storageKey}_ts`
 
-  // 直近3ヶ月の過去 + 今月 + 未来月のみシフトデータを取得
-  // 3ヶ月以上前はシフト参照の必要性が低くスキップ
-  const today = new Date()
-  const threeMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 3, 1)
-  const displayedMonth = new Date(year, month - 1, 1)
-  const isCurrentOrFuture = displayedMonth >= threeMonthsAgo
-
   // 生シフトデータを React Query で取得・キャッシュ
   // staff の準備を待たずに並列でフェッチ開始
   const { data: rawShifts = [] } = useQuery({
     queryKey: shiftKeys.month(year, month),
     queryFn: () => shiftApi.getAllStaffShifts(year, month),
-    enabled: isCurrentOrFuture, // 過去月はフェッチしない
     staleTime: 5 * 60 * 1000,  // 5分間は再フェッチしない
     gcTime: 60 * 60 * 1000,
     // sessionStorage から初期値を復元 → 即表示
     initialData: () => {
-      if (!isCurrentOrFuture) return {}
       try {
         const cached = sessionStorage.getItem(storageKey)
         return cached ? JSON.parse(cached) : undefined

--- a/src/hooks/useShiftData.ts
+++ b/src/hooks/useShiftData.ts
@@ -24,15 +24,23 @@ export function useShiftData(
   const storageKey = `shifts_${year}_${month}`
   const storageTs = `${storageKey}_ts`
 
+  // 過去の月はシフトデータ不要（誰が出勤可能だったかは今更不要）
+  const today = new Date()
+  const isCurrentOrFuture =
+    year > today.getFullYear() ||
+    (year === today.getFullYear() && month >= today.getMonth() + 1)
+
   // 生シフトデータを React Query で取得・キャッシュ
   // staff の準備を待たずに並列でフェッチ開始
   const { data: rawShifts = [] } = useQuery({
     queryKey: shiftKeys.month(year, month),
     queryFn: () => shiftApi.getAllStaffShifts(year, month),
+    enabled: isCurrentOrFuture, // 過去月はフェッチしない
     staleTime: 5 * 60 * 1000,  // 5分間は再フェッチしない
     gcTime: 60 * 60 * 1000,
     // sessionStorage から初期値を復元 → 即表示
     initialData: () => {
+      if (!isCurrentOrFuture) return {}
       try {
         const cached = sessionStorage.getItem(storageKey)
         return cached ? JSON.parse(cached) : undefined

--- a/src/hooks/useShiftData.ts
+++ b/src/hooks/useShiftData.ts
@@ -1,96 +1,109 @@
 // スタッフシフトデータの管理
 
-import { useState, useEffect, useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { shiftApi } from '@/lib/shiftApi'
 import type { Staff } from '@/types'
 import { logger } from '@/utils/logger'
 
+export const shiftKeys = {
+  month: (year: number, month: number) => ['shifts', year, month] as const,
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useShiftData(
   currentDate: Date,
   staff: Staff[],
-  staffLoading: boolean
+  _staffLoading: boolean // 後方互換のため引数は残すが使わない
 ) {
-  const [shiftData, setShiftData] = useState<Record<string, Array<Staff & { timeSlot: string }>>>({})
+  const year = currentDate.getFullYear()
+  const month = currentDate.getMonth() + 1
+  const storageKey = `shifts_${year}_${month}`
+  const storageTs = `${storageKey}_ts`
 
+  // 生シフトデータを React Query で取得・キャッシュ
+  // staff の準備を待たずに並列でフェッチ開始
+  const { data: rawShifts = [] } = useQuery({
+    queryKey: shiftKeys.month(year, month),
+    queryFn: () => shiftApi.getAllStaffShifts(year, month),
+    staleTime: 5 * 60 * 1000,  // 5分間は再フェッチしない
+    gcTime: 60 * 60 * 1000,
+    // sessionStorage から初期値を復元 → 即表示
+    initialData: () => {
+      try {
+        const cached = sessionStorage.getItem(storageKey)
+        return cached ? JSON.parse(cached) : undefined
+      } catch {
+        return undefined
+      }
+    },
+    initialDataUpdatedAt: () => {
+      try {
+        const ts = sessionStorage.getItem(storageTs)
+        return ts ? parseInt(ts) : 0
+      } catch {
+        return 0
+      }
+    },
+  })
+
+  // フェッチ完了後に sessionStorage に保存
+  useEffect(() => {
+    if (!rawShifts || rawShifts.length === 0) return
+    try {
+      sessionStorage.setItem(storageKey, JSON.stringify(rawShifts))
+      sessionStorage.setItem(storageTs, String(Date.now()))
+    } catch { /* 容量超過など */ }
+  }, [rawShifts, storageKey, storageTs])
+
+  // スタッフ ID マップ（高速検索用）
   const staffById = useMemo(() => {
     const m = new Map<string, Staff>()
-    for (const s of staff) {
-      m.set(s.id, s)
-    }
+    for (const s of staff) m.set(s.id, s)
     return m
   }, [staff])
 
-  useEffect(() => {
-    const loadShiftData = async () => {
-      try {
-        // staffが読み込まれるまで待つ
-        if (staffLoading || !staff || staff.length === 0) return
-        
-        const year = currentDate.getFullYear()
-        const month = currentDate.getMonth() + 1
-        
-        // 全スタッフのシフトを取得
-        const shifts = await shiftApi.getAllStaffShifts(year, month)
-        
-        logger.log(`📅 シフトデータ取得: ${year}年${month}月 - ${shifts.length}件`)
-        
-        // 日付とタイムスロットごとにスタッフを整理
-        const shiftMap: Record<string, Array<Staff & { timeSlot: string }>> = {}
-        
-        // マッチングできなかったstaff_idを追跡
-        const unmatchedStaffIds = new Set<string>()
-        
-        for (const shift of shifts) {
-          // staffステートから完全なスタッフデータ（special_scenariosを含む）を取得
-          const fullStaffData = staffById.get(shift.staff_id)
-          if (!fullStaffData) {
-            unmatchedStaffIds.add(shift.staff_id)
-            continue
-          }
-          
-          const dateKey = shift.date
-          
-          // 各タイムスロットをチェック
-          if (shift.morning || shift.all_day) {
-            const key = `${dateKey}-morning`
-            if (!shiftMap[key]) shiftMap[key] = []
-            shiftMap[key].push({ ...fullStaffData, timeSlot: 'morning' })
-          }
-          
-          if (shift.afternoon || shift.all_day) {
-            const key = `${dateKey}-afternoon`
-            if (!shiftMap[key]) shiftMap[key] = []
-            shiftMap[key].push({ ...fullStaffData, timeSlot: 'afternoon' })
-          }
-          
-          if (shift.evening || shift.all_day) {
-            const key = `${dateKey}-evening`
-            if (!shiftMap[key]) shiftMap[key] = []
-            shiftMap[key].push({ ...fullStaffData, timeSlot: 'evening' })
-          }
-        }
-        
-        // マッチングできなかったstaff_idをログ出力
-        if (unmatchedStaffIds.size > 0) {
-          logger.log(`⚠️ スタッフテーブルに存在しないstaff_id: ${unmatchedStaffIds.size}件`, Array.from(unmatchedStaffIds))
-        }
-        
-        // シフトデータのサマリーをログ出力
-        const uniqueStaffInShifts = new Set<string>()
-        Object.values(shiftMap).forEach(staffList => {
-          staffList.forEach(s => uniqueStaffInShifts.add(s.name))
-        })
-        logger.log(`📊 シフトマップ作成完了: ${Object.keys(shiftMap).length}スロット, ${uniqueStaffInShifts.size}名のスタッフ`, Array.from(uniqueStaffInShifts))
-        
-        setShiftData(shiftMap)
-      } catch (error) {
-        logger.error('Error loading shift data:', error)
+  // 生シフト + スタッフデータ → 日付×スロットのマップ
+  const shiftData = useMemo(() => {
+    if (!rawShifts.length || !staffById.size) return {}
+
+    const shiftMap: Record<string, Array<Staff & { timeSlot: string }>> = {}
+    const unmatchedIds = new Set<string>()
+
+    for (const shift of rawShifts) {
+      const fullStaff = staffById.get(shift.staff_id)
+      if (!fullStaff) {
+        unmatchedIds.add(shift.staff_id)
+        continue
+      }
+
+      const date = shift.date
+      if (shift.morning || shift.all_day) {
+        const key = `${date}-morning`
+        if (!shiftMap[key]) shiftMap[key] = []
+        shiftMap[key].push({ ...fullStaff, timeSlot: 'morning' })
+      }
+      if (shift.afternoon || shift.all_day) {
+        const key = `${date}-afternoon`
+        if (!shiftMap[key]) shiftMap[key] = []
+        shiftMap[key].push({ ...fullStaff, timeSlot: 'afternoon' })
+      }
+      if (shift.evening || shift.all_day) {
+        const key = `${date}-evening`
+        if (!shiftMap[key]) shiftMap[key] = []
+        shiftMap[key].push({ ...fullStaff, timeSlot: 'evening' })
       }
     }
-    
-    loadShiftData()
-  }, [currentDate, staff, staffLoading, staffById])
+
+    if (unmatchedIds.size > 0) {
+      logger.log(`⚠️ スタッフテーブルに存在しないstaff_id: ${unmatchedIds.size}件`)
+    }
+
+    return shiftMap
+  }, [rawShifts, staffById])
 
   return { shiftData }
 }
-

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -1,5 +1,5 @@
 // React
-import React, { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react'
+import React, { useState, useEffect, useMemo, useCallback, lazy, Suspense, useRef } from 'react'
 import { logger } from '@/utils/logger'
 import { getSafeErrorMessage } from '@/lib/apiErrorHandler'
 import { showToast } from '@/utils/toast'
@@ -140,6 +140,18 @@ export function ScheduleManager() {
   // 現在表示中の日付（スクロール追跡用）
   const [currentVisibleDate, setCurrentVisibleDate] = useState<string | null>(null)
   const [showDateBar, setShowDateBar] = useState(false)
+
+  // テーブル横スクロールとヘッダーを同期させるための ref
+  const colHeaderScrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const tableScroll = document.querySelector('[data-schedule-scroll]')
+    const header = colHeaderScrollRef.current
+    if (!tableScroll || !header) return
+    const onScroll = () => { header.scrollLeft = tableScroll.scrollLeft }
+    tableScroll.addEventListener('scroll', onScroll, { passive: true })
+    return () => tableScroll.removeEventListener('scroll', onScroll)
+  }, [])
   
   // スクロール時に現在表示されている日付を追跡
   const handleScroll = useCallback(() => {
@@ -1352,19 +1364,22 @@ export function ScheduleManager() {
         </div>
         
         {/* テーブルヘッダー行（操作行に統合してstickyに） */}
-        <div className="flex bg-muted border-t -mx-[10px] px-[10px]">
-          <div className="w-[32px] sm:w-[40px] md:w-[48px] shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
-            <span className="hidden sm:inline">日付</span>
-            <span className="sm:hidden">日</span>
+        {/* overflow-x-hidden + JS で横スクロールをテーブルに同期 → 列幅のズレを解消 */}
+        <div className="overflow-x-hidden border-t -mx-[10px]" ref={colHeaderScrollRef}>
+          <div className="flex bg-muted min-w-[534px] sm:min-w-[700px] md:min-w-[800px] px-[10px]">
+            <div className="w-[32px] sm:w-[40px] md:w-[48px] shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
+              <span className="hidden sm:inline">日付</span>
+              <span className="sm:hidden">日</span>
+            </div>
+            <div className="w-[24px] sm:w-[28px] md:w-[32px] shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
+              <span className="hidden sm:inline">会場</span>
+              <span className="sm:hidden">店</span>
+            </div>
+            <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午前</div>
+            <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午後</div>
+            <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">夜</div>
+            <div className="w-[160px] shrink-0 text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">メモ</div>
           </div>
-          <div className="w-[24px] sm:w-[28px] md:w-[32px] shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
-            <span className="hidden sm:inline">会場</span>
-            <span className="sm:hidden">店</span>
-          </div>
-          <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午前</div>
-          <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午後</div>
-          <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">夜</div>
-          <div className="w-[160px] shrink-0 text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">メモ</div>
         </div>
         
         {/* スティッキー日付バー（スクロール時に現在の日付を表示） */}

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -141,16 +141,60 @@ export function ScheduleManager() {
   const [currentVisibleDate, setCurrentVisibleDate] = useState<string | null>(null)
   const [showDateBar, setShowDateBar] = useState(false)
 
-  // テーブル横スクロールとヘッダーを同期させるための ref
+  // テーブル列ヘッダーの同期用 ref
   const colHeaderScrollRef = useRef<HTMLDivElement>(null)
+  const colHeaderInnerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const tableScroll = document.querySelector('[data-schedule-scroll]')
+    const tableScroll = document.querySelector('[data-schedule-scroll]') as HTMLElement | null
     const header = colHeaderScrollRef.current
     if (!tableScroll || !header) return
+
+    // 横スクロールを同期
     const onScroll = () => { header.scrollLeft = tableScroll.scrollLeft }
     tableScroll.addEventListener('scroll', onScroll, { passive: true })
-    return () => tableScroll.removeEventListener('scroll', onScroll)
+
+    // テーブルの実際の列幅をヘッダーに反映（ResizeObserver で追跡）
+    const syncColWidths = () => {
+      const table = tableScroll.querySelector('table')
+      const inner = colHeaderInnerRef.current
+      if (!table || !inner) return
+
+      // colgroup の col 要素から幅を取得
+      const cols = table.querySelectorAll('col')
+      if (!cols.length) return
+
+      // table の実際の BoundingRect で絶対幅を計算
+      const tableRect = table.getBoundingClientRect()
+      const totalWidth = tableRect.width
+      const headerRect = header.getBoundingClientRect()
+
+      inner.style.width = `${totalWidth}px`
+      inner.style.marginLeft = `${tableRect.left - headerRect.left}px`
+
+      // 各列の幅をヘッダー列に適用
+      const headerCols = inner.querySelectorAll<HTMLElement>('[data-col]')
+      const tableCells = table.querySelector('tbody tr')?.querySelectorAll('td') ??
+                         table.querySelector('thead tr')?.querySelectorAll('th')
+      if (!tableCells) return
+
+      headerCols.forEach((col, i) => {
+        const cell = tableCells[i]
+        if (cell) col.style.width = `${cell.getBoundingClientRect().width}px`
+      })
+    }
+
+    const ro = new ResizeObserver(syncColWidths)
+    ro.observe(tableScroll)
+
+    // テーブルの行が描画されるまで少し待つ
+    const timer = setTimeout(syncColWidths, 100)
+
+    return () => {
+      tableScroll.removeEventListener('scroll', onScroll)
+      ro.disconnect()
+      clearTimeout(timer)
+    }
   }, [])
   
   // スクロール時に現在表示されている日付を追跡
@@ -1364,21 +1408,21 @@ export function ScheduleManager() {
         </div>
         
         {/* テーブルヘッダー行（操作行に統合してstickyに） */}
-        {/* overflow-x-hidden + JS で横スクロールをテーブルに同期 → 列幅のズレを解消 */}
+        {/* JS でテーブル実測値を適用 → 列幅が常にピクセル単位で一致 */}
         <div className="overflow-x-hidden border-t -mx-[10px]" ref={colHeaderScrollRef}>
-          <div className="flex bg-muted min-w-[534px] sm:min-w-[700px] md:min-w-[800px] px-[10px]">
-            <div className="w-[32px] sm:w-[40px] md:w-[48px] shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
+          <div className="flex bg-muted" ref={colHeaderInnerRef}>
+            <div data-col className="shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
               <span className="hidden sm:inline">日付</span>
               <span className="sm:hidden">日</span>
             </div>
-            <div className="w-[24px] sm:w-[28px] md:w-[32px] shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
+            <div data-col className="shrink-0 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">
               <span className="hidden sm:inline">会場</span>
               <span className="sm:hidden">店</span>
             </div>
-            <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午前</div>
-            <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午後</div>
-            <div className="flex-1 border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">夜</div>
-            <div className="w-[160px] shrink-0 text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">メモ</div>
+            <div data-col className="border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午前</div>
+            <div data-col className="border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">午後</div>
+            <div data-col className="border-r text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">夜</div>
+            <div data-col className="shrink-0 text-[10px] sm:text-xs font-bold py-0.5 text-center leading-tight">メモ</div>
           </div>
         </div>
         

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -1143,12 +1143,24 @@ export function ScheduleManager() {
           
           {/* アクションボタン - スマホ用 */}
           <div className="sm:hidden flex items-center gap-1 ml-auto">
+            {/* フィルタートグルボタン */}
+            <button
+              onClick={() => setShowMobileFilters(v => !v)}
+              title="フィルター"
+              className={`h-9 w-9 flex items-center justify-center border rounded-lg transition-colors shrink-0 ${
+                showMobileFilters
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'border-input bg-background hover:bg-accent'
+              }`}
+            >
+              <SlidersHorizontal className="h-4 w-4" />
+            </button>
             {isAdminOrLicenseAdmin && (
               <>
                 <button
                   onClick={handleCleanupBadDemoReservations}
                   disabled={isCleaningDemo}
-                  title="誤デモ予約の修正（テストプレイ削除・GMテスト参加費修正）"
+                  title="誤デモ予約の修正"
                   className="h-9 w-9 flex items-center justify-center border border-input rounded-lg bg-background hover:bg-accent transition-colors shrink-0 disabled:opacity-50"
                 >
                   {isCleaningDemo ? (
@@ -1238,6 +1250,88 @@ export function ScheduleManager() {
             )}
           </div>
         </div>
+
+        {/* モバイル用フィルターパネル */}
+        {showMobileFilters && (
+          <div className="sm:hidden border-t border-input divide-y divide-input">
+            {gmList.length > 0 && (
+              <MultiSelect
+                options={(() => {
+                  const shiftData = scheduleTableProps.dataProvider.shiftData || {}
+                  const staffWithShift = new Set<string>()
+                  Object.values(shiftData).forEach((staffList: Staff[]) => {
+                    staffList.forEach(s => staffWithShift.add(s.id))
+                  })
+                  return [...gmList]
+                    .sort((a, b) => {
+                      const aHas = staffWithShift.has(a.id)
+                      const bHas = staffWithShift.has(b.id)
+                      if (aHas && !bHas) return -1
+                      if (!aHas && bHas) return 1
+                      return (a.display_name || a.name).localeCompare(b.display_name || b.name, 'ja')
+                    })
+                    .map(staff => ({
+                      id: staff.id,
+                      name: staff.display_name || staff.name,
+                      displayInfo: staffWithShift.has(staff.id) ? (
+                        <span className="text-[9px] text-green-600">●</span>
+                      ) : undefined,
+                    }))
+                })()}
+                selectedValues={selectedGMs}
+                onSelectionChange={setSelectedGMs}
+                placeholder="スタッフで絞り込み"
+                closeOnSelect={false}
+                useIdAsValue={true}
+                className="h-10 w-full border-0 rounded-none shadow-none"
+              />
+            )}
+            {scheduleTableProps.viewConfig.stores.length > 0 && (
+              <StoreMultiSelect
+                stores={scheduleTableProps.viewConfig.stores}
+                selectedStoreIds={selectedStores}
+                onStoreIdsChange={setSelectedStores}
+                hideLabel={true}
+                placeholder="店舗で絞り込み"
+                className="h-10 w-full border-0 rounded-none shadow-none"
+              />
+            )}
+            {scenarioOptions.length > 0 && (
+              <MultiSelect
+                options={scenarioOptions}
+                selectedValues={selectedScenarioIds}
+                onSelectionChange={(values) => setSelectedScenarioIds(values.slice(-1))}
+                placeholder="シナリオで絞り込み"
+                searchPlaceholder="シナリオ検索..."
+                closeOnSelect={true}
+                useIdAsValue={true}
+                className="h-10 w-full border-0 rounded-none shadow-none"
+              />
+            )}
+            <MultiSelect
+              options={categoryOptions}
+              selectedValues={selectedCategories}
+              onSelectionChange={setSelectedCategories}
+              placeholder="カテゴリで絞り込み"
+              closeOnSelect={false}
+              useIdAsValue={true}
+              className="h-10 w-full border-0 rounded-none shadow-none"
+            />
+            {(selectedGMs.length > 0 || selectedStores.length > 0 || selectedScenarioIds.length > 0 || selectedCategories.length > 0) && (
+              <button
+                onClick={() => {
+                  setSelectedGMs([])
+                  setSelectedStores([])
+                  setSelectedScenarioIds([])
+                  setSelectedCategories([])
+                }}
+                className="w-full h-9 text-sm text-muted-foreground hover:bg-accent transition-colors"
+              >
+                フィルターをクリア
+              </button>
+            )}
+          </div>
+        )}
 
         {/* カテゴリ + GM統計（統合バー） */}
         <div className="py-0.5 border-t border-muted/50">


### PR DESCRIPTION
## 追加変更（前回PRのフォローアップ）

### バグ修正
- モバイルでの列ヘッダーとテーブル列のズレを修正（JS実測値で同期）
- フィルターがモバイルで使えない問題を修正（スライダーボタンで展開）

### パフォーマンス改善
- メモ列を React Query + sessionStorage キャッシュ化（即時表示）
- シフトデータを React Query + sessionStorage キャッシュ化（staffLoading 待機を廃止し並列フェッチ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)