### PR TITLE
perf: スケジュールプリフェッチを2段階化・idle強制実行を廃止

### DIFF
--- a/src/hooks/useScheduleData.ts
+++ b/src/hooks/useScheduleData.ts
@@ -308,12 +308,13 @@ export function useScheduleData(currentDate: Date) {
   const { data: events = [], isLoading, isFetching, error: queryError } = useScheduleEventsQuery(currentDate)
   const error = queryError ? String(queryError) : null
 
-  // スケジュール閲覧中、ブラウザがアイドルになったら前後3ヶ月を先読み
-  // requestIdleCallback で UI への影響ゼロ
+  // スケジュール閲覧中、アイドル時に2段階でプリフェッチ
+  // 第1波（±3）: 通常の操作で使う範囲
+  // 第2波（±4〜6）: 余裕があれば拡張（初回ロードを重くしない）
   useEffect(() => {
-    const run = () => {
-      for (let i = -6; i <= 6; i++) {
-        if (i === 0) continue // 当月は useScheduleEventsQuery が担当
+    const prefetchRange = (from: number, to: number) => {
+      for (let i = from; i <= to; i++) {
+        if (i === 0) continue
         const d = new Date(year, month - 1 + i, 1)
         const y = d.getFullYear()
         const m = d.getMonth() + 1
@@ -324,12 +325,20 @@ export function useScheduleData(currentDate: Date) {
         })
       }
     }
+
+    const ids: number[] = []
+    const timeouts: ReturnType<typeof setTimeout>[] = []
+
     if (typeof requestIdleCallback !== 'undefined') {
-      const id = requestIdleCallback(run, { timeout: 5000 })
-      return () => cancelIdleCallback(id)
+      // timeout なし = 本当に暇なときだけ実行（強制実行しない）
+      ids.push(requestIdleCallback(() => prefetchRange(-3, 3)))
+      ids.push(requestIdleCallback(() => prefetchRange(-6, 6)))
+      return () => ids.forEach(id => cancelIdleCallback(id))
     }
-    const id = setTimeout(run, 2000)
-    return () => clearTimeout(id)
+    // Safari フォールバック（requestIdleCallback 非対応）
+    timeouts.push(setTimeout(() => prefetchRange(-3, 3), 3000))
+    timeouts.push(setTimeout(() => prefetchRange(-6, 6), 8000))
+    return () => timeouts.forEach(id => clearTimeout(id))
   }, [year, month, queryClient])
 
   // 店舗・シナリオ・スタッフのデータ（キャッシュから初期化して即座に表示）

--- a/src/hooks/useScheduleData.ts
+++ b/src/hooks/useScheduleData.ts
@@ -312,7 +312,7 @@ export function useScheduleData(currentDate: Date) {
   // requestIdleCallback で UI への影響ゼロ
   useEffect(() => {
     const run = () => {
-      for (let i = -3; i <= 3; i++) {
+      for (let i = -6; i <= 6; i++) {
         if (i === 0) continue // 当月は useScheduleEventsQuery が担当
         const d = new Date(year, month - 1 + i, 1)
         const y = d.getFullYear()


### PR DESCRIPTION
## 変更内容

### プリフェッチ改善
- ±3 → ±6ヶ月に拡張（1ヶ月ずつ進んでも7ヶ月先まで即表示）
- 2段階実行: 第1波±3 / 第2波±4〜6（初回ロードを重くしない）
- `timeout` 削除: 真のidle時のみ実行（操作中に強制実行しない）

### Before
```
idle または5秒後に強制実行 → 操作中でも発火していた
```

### After
```
本当にブラウザが暇なときだけ実行
Safariは 3秒/8秒後にフォールバック
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)