### PR TITLE
fix: queens-waltz ハードコードフォールバックを除去（マルチテナント P0）

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -481,7 +481,7 @@ function AppRoutes() {
       ]
       if (adminPaths.some((path) => location.pathname.startsWith(path))) {
         const slug = getOrganizationSlugFromPath()
-        navigate(`/${slug}`, { replace: true })
+        navigate(slug ? `/${slug}` : '/', { replace: true })
         return (
           <Suspense fallback={adminDashboardSuspenseFallback}>
             <AdminDashboard />

--- a/src/components/modals/ScenarioEditDialogV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2.tsx
@@ -190,7 +190,7 @@ export function ScenarioEditDialogV2({ isOpen, onClose, scenarioId, onSaved, onS
       }
       // ローカル等: users.organization が取れない・一覧の organization_id が遅延する場合のフォールバック
       if (!slugForPublic.trim()) {
-        slugForPublic = getOrganizationSlugFromPath()
+        slugForPublic = getOrganizationSlugFromPath() ?? ''
       }
       if (!cancelled) {
         setPublicBookingOrgSlug(slugForPublic.trim())

--- a/src/components/schedule/ImportScheduleModal.tsx
+++ b/src/components/schedule/ImportScheduleModal.tsx
@@ -12,7 +12,6 @@ import { memoApi } from '@/lib/api/memoApi'
 import { staffApi } from '@/lib/api/staffApi'
 import { scenarioApi } from '@/lib/api/scenarioApi'
 import { useOrganization } from '@/hooks/useOrganization'
-import { QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
 import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
 import { logger } from '@/utils/logger'
 import { getTimeSlot } from '@/utils/scheduleUtils'
@@ -234,7 +233,7 @@ const GM_ROLE_OPTIONS = [
 export function ImportScheduleModal({ isOpen, onClose, currentDisplayDate, onImportComplete }: ImportScheduleModalProps) {
   // 組織IDを動的に取得（マルチテナント対応）
   const { organizationId } = useOrganization()
-  const ORGANIZATION_ID = organizationId || QUEENS_WALTZ_ORG_ID
+  const ORGANIZATION_ID = organizationId
   
   const [scheduleText, setScheduleText] = useState('')
   const [isImporting, setIsImporting] = useState(false)

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -39,12 +39,27 @@ async function lookupStaffRole(
 }
 
 /**
- * 現在のURLからorganizationSlugを抽出するヘルパー関数
+ * サインアウト後のリダイレクト先パスを返す。
+ * 公開予約ページ（/org-slug/...）にいる場合はそのorgのトップへ、
+ * 管理画面や判定不能な場合はルート（/）へ。
  */
-function getOrganizationSlugFromUrl(): string {
-  const hash = window.location.hash.replace('#', '')
-  const bookingMatch = hash.match(/^booking\/([^/]+)/)
-  return bookingMatch ? bookingMatch[1] : 'queens-waltz'
+function getSignOutRedirectPath(): string {
+  const pathname = window.location.pathname
+  const match = pathname.match(/^\/([^/]+)/)
+  if (match) {
+    const adminPaths = [
+      'dashboard', 'stores', 'staff', 'scenarios', 'schedule',
+      'shift-submission', 'gm-availability', 'private-booking-management',
+      'reservations', 'accounts', 'sales', 'settings', 'manual',
+      'login', 'signup', 'reset-password', 'set-password', 'complete-profile',
+      'coupon-present', 'license-management', 'staff-profile', 'mypage', 'author',
+      'external-reports', 'accept-invitation', 'organization-register',
+    ]
+    if (!adminPaths.includes(match[1])) {
+      return `/${match[1]}`
+    }
+  }
+  return '/'
 }
 
 // パスワードリセット中フラグのキー（sessionStorage使用）
@@ -492,8 +507,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             setStaffCache(new Map())  // キャッシュもクリア
             setIsInitialized(true)
             // ページをリロードしてクリーンな状態にする（現在の組織を維持）
-            const slug = getOrganizationSlugFromUrl()
-            window.location.href = `/${slug}`
+            window.location.href = getSignOutRedirectPath()
             break
           case 'SIGNED_IN':
             // 他のタブでログインした場合、セッションをリフレッシュ
@@ -1073,8 +1087,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
       
       // 予約サイトにリダイレクト（現在の組織を維持）
-      const slug = getOrganizationSlugFromUrl()
-      window.location.href = `/${slug}`
+      window.location.href = getSignOutRedirectPath()
     } catch (error) {
       setLoading(false)
       isExplicitSignOutRef.current = false

--- a/src/hooks/useBlockedSlots.ts
+++ b/src/hooks/useBlockedSlots.ts
@@ -8,7 +8,7 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
-import { getCurrentOrganizationId, QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
+import { getCurrentOrganizationId } from '@/lib/organization'
 import { logger } from '@/utils/logger'
 
 // ブロックされたスロットのキー形式: "YYYY-MM-DD:storeId:timeSlot"
@@ -33,7 +33,8 @@ export function useBlockedSlots(): UseBlockedSlotsReturn {
   useEffect(() => {
     const load = async () => {
       try {
-        const orgId = (await getCurrentOrganizationId()) || QUEENS_WALTZ_ORG_ID
+        const orgId = await getCurrentOrganizationId()
+        if (!orgId) return
         const { data, error } = await supabase
           .from('schedule_blocked_slots')
           .select('date, store_id, time_slot')
@@ -87,7 +88,8 @@ export function useBlockedSlots(): UseBlockedSlotsReturn {
       setBlockedSlots(prev => new Set(prev).add(key))
 
       try {
-        const orgId = (await getCurrentOrganizationId()) || QUEENS_WALTZ_ORG_ID
+        const orgId = await getCurrentOrganizationId()
+        if (!orgId) { setBlockedSlots(prev => { const s = new Set(prev); s.delete(key); return s }); return }
         const { error } = await supabase
           .from('schedule_blocked_slots')
           .insert({ organization_id: orgId, date, store_id: storeId, time_slot: timeSlot })
@@ -114,7 +116,8 @@ export function useBlockedSlots(): UseBlockedSlotsReturn {
       setBlockedSlots(prev => { const s = new Set(prev); s.delete(key); return s })
 
       try {
-        const orgId = (await getCurrentOrganizationId()) || QUEENS_WALTZ_ORG_ID
+        const orgId = await getCurrentOrganizationId()
+        if (!orgId) { setBlockedSlots(prev => new Set(prev).add(key)); return }
         const { error } = await supabase
           .from('schedule_blocked_slots')
           .delete()

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,12 +1,19 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
-import { getCurrentOrganizationId } from '@/lib/organization'
+import { getCurrentOrganizationId, getOrganizationBySlug } from '@/lib/organization'
+import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
 import { sanitizeForPostgRestFilter } from '@/lib/utils'
 import { logger } from '@/utils/logger'
 
-// デフォルト組織ID（クインズワルツ）
-const DEFAULT_ORG_ID = 'a0000000-0000-0000-0000-000000000001'
+async function resolveCurrentOrgId(): Promise<string | null> {
+  const orgId = await getCurrentOrganizationId()
+  if (orgId) return orgId
+  const slug = getOrganizationSlugFromPath()
+  if (!slug) return null
+  const org = await getOrganizationBySlug(slug)
+  return org?.id ?? null
+}
 
 const FAVORITES_KEY = 'scenario_favorites'
 
@@ -79,8 +86,12 @@ export function useFavorites() {
         }
 
         // 顧客が存在しない場合、作成する（organization_id付き）
-        const orgId = await getCurrentOrganizationId() || DEFAULT_ORG_ID
-        
+        const orgId = await resolveCurrentOrgId()
+        if (!orgId) {
+          logger.warn('useFavorites: org_id が特定できないため顧客レコード作成をスキップ')
+          return
+        }
+
         const { data: newCustomer, error: insertError } = await supabase
           .from('customers')
           .insert({
@@ -190,7 +201,11 @@ export function useFavorites() {
           if (error) throw error
         } else {
           // お気に入りに追加（scenario_master_id を使用）
-          const orgId = await getCurrentOrganizationId() || DEFAULT_ORG_ID
+          const orgId = await resolveCurrentOrgId()
+          if (!orgId) {
+            logger.warn('useFavorites: org_id が特定できないためお気に入り登録をスキップ')
+            return
+          }
           const { error } = await supabase
             .from('scenario_likes')
             .insert({

--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -56,9 +56,13 @@ async function fetchOrganizationData(): Promise<{ organization: Organization | n
     return { organization: null, staff: null }
   }
 
+  if (!staffData.organization_id) {
+    logger.warn('useOrganization: staff.organization_id が未設定です', { userId: user.id })
+    return { organization: null, staff: staffData as Staff }
+  }
+
   // 組織情報を取得（DBのマイグレーションが古くてもコア列までフォールバック）
-  const orgId = staffData?.organization_id || QUEENS_WALTZ_ORG_ID
-  const orgData = await fetchOrganizationForStaffSession(orgId)
+  const orgData = await fetchOrganizationForStaffSession(staffData.organization_id)
 
   return {
     organization: orgData,

--- a/src/hooks/usePrivateGroup.ts
+++ b/src/hooks/usePrivateGroup.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '@/lib/supabase'
-import { getCurrentOrganizationId, QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
+import { getCurrentOrganizationId } from '@/lib/organization'
 import { logger } from '@/utils/logger'
 import { privateGroupTimeSlotToDb } from '@/lib/privateGroupTimeSlot'
 import {
@@ -228,7 +228,8 @@ export function usePrivateGroup() {
       const { data: { user } } = await supabase.auth.getUser()
       if (!user) throw new Error('ログインが必要です')
 
-      const organizationId = await getCurrentOrganizationId() || QUEENS_WALTZ_ORG_ID
+      const organizationId = await getCurrentOrganizationId()
+      if (!organizationId) throw new Error('組織情報が取得できません')
 
 
       let inviteCode = await generateInviteCode()

--- a/src/lib/publicBookingPath.ts
+++ b/src/lib/publicBookingPath.ts
@@ -1,9 +1,9 @@
 /**
  * 予約サイトの公開URL用 organization slug を、現在のパスから推測する。
- * 管理画面（/scenarios 等）では第1セグメントが組織slugでないため、デフォルトを返す。
+ * 管理画面（/scenarios 等）や SSR 環境では null を返す。
  */
-export function getOrganizationSlugFromPath(): string {
-  if (typeof window === 'undefined') return 'queens-waltz'
+export function getOrganizationSlugFromPath(): string | null {
+  if (typeof window === 'undefined') return null
   const pathname = window.location.pathname
   const match = pathname.match(/^\/([^/]+)/)
   if (match) {
@@ -50,5 +50,5 @@ export function getOrganizationSlugFromPath(): string {
       return match[1]
     }
   }
-  return 'queens-waltz'
+  return null
 }

--- a/src/pages/CompleteProfile.tsx
+++ b/src/pages/CompleteProfile.tsx
@@ -18,9 +18,8 @@ import { grantRegistrationCoupon } from '@/lib/api/couponApi'
 import { MYPAGE_THEME as THEME } from '@/lib/theme'
 import { Link, useNavigate } from 'react-router-dom'
 import { resendSignupConfirmationEmail } from '@/lib/authResendSignup'
-
-// デフォルト組織ID（クインズワルツ）
-const DEFAULT_ORG_ID = 'a0000000-0000-0000-0000-000000000001'
+import { getOrganizationBySlug } from '@/lib/organization'
+import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
 
 // 都道府県リスト
 const PREFECTURES = [
@@ -374,7 +373,17 @@ export function CompleteProfile() {
           ? existingUser.role
           : 'customer'
 
-      const organizationId = existingUser?.organization_id || DEFAULT_ORG_ID
+      let organizationId = existingUser?.organization_id ?? null
+      if (!organizationId) {
+        const slug = getOrganizationSlugFromPath()
+        if (slug) {
+          const org = await getOrganizationBySlug(slug)
+          organizationId = org?.id ?? null
+        }
+        if (!organizationId) {
+          logger.warn('CompleteProfile: org_id が特定できません（URLにorgスラッグがありません）')
+        }
+      }
       const { error: usersUpsertError } = await supabase
         .from('users')
         .upsert({

--- a/src/pages/MyPage/pages/SettingsPage.tsx
+++ b/src/pages/MyPage/pages/SettingsPage.tsx
@@ -20,7 +20,8 @@ import { getSafeErrorMessage } from '@/lib/apiErrorHandler'
 import { showToast } from '@/utils/toast'
 import { supabase } from '@/lib/supabase'
 import { useOrganization } from '@/hooks/useOrganization'
-import { QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
+import { getOrganizationBySlug } from '@/lib/organization'
+import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
 import { MYPAGE_THEME as THEME } from '@/lib/theme'
 import { RESERVATION_STATUSES_BLOCKING_WITHDRAWAL } from '@/lib/reservationWithdrawalGuard'
 import {
@@ -234,7 +235,14 @@ export function SettingsPage() {
         if (error) throw error
         showToast.success('プロフィールを更新しました')
       } else if (user?.id) {
-        const orgId = organizationId || QUEENS_WALTZ_ORG_ID
+        let orgId = organizationId
+        if (!orgId) {
+          const slug = getOrganizationSlugFromPath()
+          if (slug) {
+            const org = await getOrganizationBySlug(slug)
+            orgId = org?.id ?? null
+          }
+        }
         
         // user_id で自分のレコードを検索（RLSで確実に読み書き可能）
         const { data: existingCust } = await supabase

--- a/src/pages/PrivateBookingRequest/hooks/usePrivateBookingSubmit.ts
+++ b/src/pages/PrivateBookingRequest/hooks/usePrivateBookingSubmit.ts
@@ -1,6 +1,16 @@
 import { useState } from 'react'
 import { supabase } from '@/lib/supabase'
-import { getCurrentOrganizationId, QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
+import { getCurrentOrganizationId, getOrganizationBySlug } from '@/lib/organization'
+import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
+
+async function resolveOrgId(): Promise<string | null> {
+  const orgId = await getCurrentOrganizationId()
+  if (orgId) return orgId
+  const slug = getOrganizationSlugFromPath()
+  if (!slug) return null
+  const org = await getOrganizationBySlug(slug)
+  return org?.id ?? null
+}
 import { logger } from '@/utils/logger'
 import { hasNonEmptyCustomerPhone, MSG_CUSTOMER_PHONE_REQUIRED_FOR_BOOKING } from '@/lib/customerPhonePolicy'
 import { GLOBAL_SETTINGS_MSG_SELECT } from '@/lib/constants'
@@ -67,8 +77,9 @@ export function usePrivateBookingSubmit(props: UsePrivateBookingSubmitProps) {
     try {
       // 顧客レコードを取得または作成
       let customerId: string | null = null
-      const organizationId = await getCurrentOrganizationId() || QUEENS_WALTZ_ORG_ID
-      
+      const organizationId = await resolveOrgId()
+      if (!organizationId) throw new Error('組織情報が取得できません')
+
       try {
         const { data: existingCustomer } = await supabase
           .from('customers')
@@ -239,7 +250,7 @@ export function usePrivateBookingSubmit(props: UsePrivateBookingSubmitProps) {
             
             if (organizerMember) {
               // 設定からメッセージ文言を取得
-              const msgOrgId = await getCurrentOrganizationId() || QUEENS_WALTZ_ORG_ID
+              const msgOrgId = await resolveOrgId()
               const { data: msgSettings } = await supabase
                 .from('global_settings')
                 .select(GLOBAL_SETTINGS_MSG_SELECT.BOOKING_REQUESTED)
@@ -281,7 +292,7 @@ export function usePrivateBookingSubmit(props: UsePrivateBookingSubmitProps) {
             endTime: c.endTime
           }))
 
-          const orgId = await getCurrentOrganizationId() || QUEENS_WALTZ_ORG_ID
+          const orgId = await resolveOrgId()
           console.log('[貸切リクエスト] メール送信 invoke開始', { orgId, reservationId: parentReservationId })
           const { error: emailError, data: emailData } = await supabase.functions.invoke('send-private-booking-request-confirmation', {
             body: {

--- a/src/pages/PrivateGroupCreate/index.tsx
+++ b/src/pages/PrivateGroupCreate/index.tsx
@@ -15,7 +15,6 @@ import { usePrivateGroup } from '@/hooks/usePrivateGroup'
 import { supabase } from '@/lib/supabase'
 import {
   getCurrentOrganizationId,
-  QUEENS_WALTZ_ORG_ID,
   resolveOrganizationFromPathSegment,
 } from '@/lib/organization'
 import { scenarioApi } from '@/lib/api'
@@ -62,8 +61,9 @@ export function PrivateGroupCreate() {
           organizationId = orgData?.id || null
         }
         if (!organizationId) {
-          organizationId = await getCurrentOrganizationId() || QUEENS_WALTZ_ORG_ID
+          organizationId = await getCurrentOrganizationId()
         }
+        if (!organizationId) throw new Error('組織情報が取得できません')
 
         // scenarioId が UUID でない場合（slug）は、先に scenario_master_id を解決する
         const isUuidLike = /^[0-9a-f]{8}-/.test(scenarioId)

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -7,7 +7,7 @@ import { showToast } from '@/utils/toast'
 // API
 import { staffApi, scheduleApi, salesApi } from '@/lib/api'
 import { supabase } from '@/lib/supabase'
-import { getCurrentOrganizationId, QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
+import { getCurrentOrganizationId } from '@/lib/organization'
 
 // Custom Hooks
 import { useRouteScrollControls } from '@/contexts/RouteScrollRestorationContext'
@@ -282,8 +282,12 @@ export function ScheduleManager() {
       const endDate = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
       
       // 組織IDを最初に取得
-      const orgId = await getCurrentOrganizationId() || QUEENS_WALTZ_ORG_ID
-      
+      const orgId = await getCurrentOrganizationId()
+      if (!orgId) {
+        showToast.error('組織情報が取得できません')
+        return
+      }
+
       // まず対象のイベントを取得（シナリオの定員情報も含む、現在の組織のみ）
       // testplay / venue_rental / venue_rental_free / mtg は対象外
       const { data: events, error: fetchError } = await supabase
@@ -526,7 +530,12 @@ export function ScheduleManager() {
     let fixedCount = 0
 
     try {
-      const orgId = await getCurrentOrganizationId() || QUEENS_WALTZ_ORG_ID
+      const orgId = await getCurrentOrganizationId()
+      if (!orgId) {
+        showToast.error('組織情報が取得できません')
+        setIsCleaningDemo(false)
+        return
+      }
 
       // ─── ① テストプレイのデモ予約を削除 ───
       const { data: testplayEvents } = await supabase

--- a/supabase/functions/check-performance-cancellation/index.ts
+++ b/supabase/functions/check-performance-cancellation/index.ts
@@ -98,8 +98,9 @@ serve(async (req) => {
 
     // RPC関数を実行（RETURNS TABLEは配列を返すため[0]で取得）
     if (check_type === 'day_before') {
+      // p_target_date は DATE 型なので文字列のまま渡す（PostgreSQL が自動キャスト）
       const rpcParams = target_date ? { p_target_date: target_date } : {}
-      const { data, error } = await serviceClient.rpc('check_performances_day_before', rpcParams)
+      const { data, error } = await serviceClient.rpc('check_performances_day_before', rpcParams as Record<string, unknown>)
       if (error) throw error
       const row = Array.isArray(data) ? data[0] : data
       result = {

--- a/supabase/migrations/20260516000000_fix_day_before_add_target_date_param.sql
+++ b/supabase/migrations/20260516000000_fix_day_before_add_target_date_param.sql
@@ -1,0 +1,188 @@
+-- =============================================================================
+-- 前日中止判定RPC修正: p_target_date パラメータ追加 + NOT EXISTS ガード追加
+-- =============================================================================
+--
+-- 問題:
+--   1) cron-job.org が Edge Function に target_date を渡し、Edge Function が
+--      p_target_date として RPC に渡していたが、関数がパラメータを受け付けず
+--      "function does not exist" エラーで HTTP 400 → cron 失敗
+--   2) NOT EXISTS ガードがないため、同日内に複数回実行されると
+--      performance_cancellation_logs の UNIQUE 制約に違反してエラーになる危険
+--
+-- 修正:
+--   - p_target_date TEXT DEFAULT NULL を追加（NULL 時は JST NOW()+1 で計算）
+--   - day_before ログの NOT EXISTS チェックを追加（重複実行防止）
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION check_performances_day_before(
+  p_target_date TEXT DEFAULT NULL
+)
+RETURNS TABLE(
+  events_checked INTEGER,
+  events_confirmed INTEGER,
+  events_extended INTEGER,
+  events_cancelled INTEGER,
+  details JSONB
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+SET timezone TO 'Asia/Tokyo'
+AS $$
+DECLARE
+  v_events_checked INTEGER := 0;
+  v_events_confirmed INTEGER := 0;
+  v_events_extended INTEGER := 0;
+  v_events_cancelled INTEGER := 0;
+  v_details JSONB := '[]'::JSONB;
+  v_event RECORD;
+  v_current INTEGER;
+  v_reservation_count INTEGER;
+  v_unsynced_staff INTEGER;
+  v_max INTEGER;
+  v_half INTEGER;
+  v_result TEXT;
+  v_target_date_jst DATE;
+BEGIN
+  -- p_target_date が指定されていれば使用、なければ JST の明日を計算
+  IF p_target_date IS NOT NULL AND p_target_date != '' THEN
+    v_target_date_jst := p_target_date::DATE;
+  ELSE
+    v_target_date_jst := (timezone('Asia/Tokyo', NOW())::date + 1);
+  END IF;
+
+  RAISE NOTICE '前日チェック開始: 対象日=%', v_target_date_jst;
+
+  FOR v_event IN
+    SELECT
+      se.id,
+      se.date,
+      se.start_time,
+      se.scenario,
+      se.gm_roles,
+      COALESCE(
+        os.override_player_count_max,
+        sm.player_count_max,
+        sm2.player_count_max,
+        se.max_participants,
+        s.player_count_max,
+        8
+      ) AS max_participants,
+      se.organization_id,
+      se.gms,
+      se.store_id,
+      st.name AS store_name
+    FROM schedule_events se
+    LEFT JOIN organization_scenarios os ON se.organization_scenario_id = os.id
+    LEFT JOIN scenario_masters sm ON os.scenario_master_id = sm.id
+    LEFT JOIN scenario_masters sm2 ON se.scenario_master_id = sm2.id
+    LEFT JOIN scenarios s ON se.scenario_id = s.id
+    LEFT JOIN stores st ON se.store_id = st.id
+    WHERE se.date = v_target_date_jst
+      AND se.is_cancelled = FALSE
+      AND se.is_recruitment_extended IS NOT TRUE
+      AND se.category = 'open'
+      AND se.scenario IS NOT NULL
+      AND se.scenario != ''
+      -- 既に処理済みのイベントはスキップ（重複実行・UNIQUE制約違反防止）
+      AND NOT EXISTS (
+        SELECT 1 FROM performance_cancellation_logs pcl
+        WHERE pcl.schedule_event_id = se.id
+          AND pcl.check_type = 'day_before'
+      )
+    ORDER BY se.start_time
+  LOOP
+    v_events_checked := v_events_checked + 1;
+
+    SELECT COALESCE(SUM(r.participant_count), 0) INTO v_reservation_count
+    FROM reservations r
+    WHERE r.schedule_event_id = v_event.id
+      AND r.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in');
+
+    SELECT COUNT(*) INTO v_unsynced_staff
+    FROM (
+      SELECT key AS staff_name, value AS staff_role
+      FROM jsonb_each_text(COALESCE(v_event.gm_roles, '{}'::jsonb))
+    ) AS gm_staff
+    WHERE gm_staff.staff_role = 'staff'
+      AND NOT EXISTS (
+        SELECT 1 FROM reservations r2
+        WHERE r2.schedule_event_id = v_event.id
+          AND r2.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in')
+          AND r2.reservation_source = 'staff_entry'
+          AND gm_staff.staff_name = ANY(r2.participant_names)
+      );
+
+    v_current := v_reservation_count + v_unsynced_staff;
+    v_max := v_event.max_participants;
+    v_half := CEIL(v_max::NUMERIC / 2);
+
+    RAISE NOTICE 'イベント: id=%, scenario=%, participants=%, max=%, half=%',
+      v_event.id, v_event.scenario, v_current, v_max, v_half;
+
+    IF v_current >= v_max THEN
+      v_result := 'confirmed';
+      v_events_confirmed := v_events_confirmed + 1;
+    ELSIF v_current >= v_half THEN
+      v_result := 'extended';
+      v_events_extended := v_events_extended + 1;
+
+      UPDATE schedule_events
+      SET is_recruitment_extended = TRUE,
+          updated_at = NOW()
+      WHERE id = v_event.id;
+    ELSE
+      v_result := 'cancelled';
+      v_events_cancelled := v_events_cancelled + 1;
+
+      UPDATE schedule_events
+      SET is_cancelled = TRUE,
+          updated_at = NOW()
+      WHERE id = v_event.id;
+    END IF;
+
+    INSERT INTO performance_cancellation_logs (
+      schedule_event_id,
+      organization_id,
+      check_type,
+      current_participants,
+      max_participants,
+      result
+    ) VALUES (
+      v_event.id,
+      v_event.organization_id,
+      'day_before',
+      v_current,
+      v_max,
+      v_result
+    );
+
+    v_details := v_details || jsonb_build_array(jsonb_build_object(
+      'event_id', v_event.id,
+      'date', v_event.date,
+      'start_time', v_event.start_time,
+      'scenario', v_event.scenario,
+      'store_name', v_event.store_name,
+      'current_participants', v_current,
+      'max_participants', v_max,
+      'half_required', v_half,
+      'result', v_result,
+      'organization_id', v_event.organization_id,
+      'gms', to_jsonb(v_event.gms)
+    ));
+  END LOOP;
+
+  RAISE NOTICE '前日チェック完了: checked=%, confirmed=%, extended=%, cancelled=%',
+    v_events_checked, v_events_confirmed, v_events_extended, v_events_cancelled;
+
+  RETURN QUERY SELECT
+    v_events_checked,
+    v_events_confirmed,
+    v_events_extended,
+    v_events_cancelled,
+    v_details;
+END;
+$$;
+
+COMMENT ON FUNCTION check_performances_day_before(TEXT) IS
+'前日23:59に実行する公演中止判定。p_target_date(YYYY-MM-DD)省略時はJST翌日を対象とする。';

--- a/supabase/migrations/20260516010000_fix_day_before_drop_text_overload.sql
+++ b/supabase/migrations/20260516010000_fix_day_before_drop_text_overload.sql
@@ -1,0 +1,190 @@
+-- =============================================================================
+-- 前日中止判定RPC修正: text オーバーロードを削除し date 版に統一
+-- =============================================================================
+--
+-- 問題:
+--   20260516000000 で p_target_date TEXT DEFAULT NULL を追加したが、
+--   既存の p_target_date DATE 版と競合し PGRST203 エラーが発生。
+--
+-- 修正:
+--   - text 版を DROP
+--   - 単一の date 版として再定義（NOT EXISTS ガード・jsonb_build_array も含む）
+-- =============================================================================
+
+-- 競合する全バージョンを削除してから再作成
+DROP FUNCTION IF EXISTS public.check_performances_day_before(p_target_date text);
+DROP FUNCTION IF EXISTS public.check_performances_day_before();  -- 旧no-param版も削除
+
+-- date 版として統一（NOT EXISTS ガード込み）
+CREATE OR REPLACE FUNCTION check_performances_day_before(
+  p_target_date DATE DEFAULT NULL
+)
+RETURNS TABLE(
+  events_checked INTEGER,
+  events_confirmed INTEGER,
+  events_extended INTEGER,
+  events_cancelled INTEGER,
+  details JSONB
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+SET timezone TO 'Asia/Tokyo'
+AS $$
+DECLARE
+  v_events_checked INTEGER := 0;
+  v_events_confirmed INTEGER := 0;
+  v_events_extended INTEGER := 0;
+  v_events_cancelled INTEGER := 0;
+  v_details JSONB := '[]'::JSONB;
+  v_event RECORD;
+  v_current INTEGER;
+  v_reservation_count INTEGER;
+  v_unsynced_staff INTEGER;
+  v_max INTEGER;
+  v_half INTEGER;
+  v_result TEXT;
+  v_target_date_jst DATE;
+BEGIN
+  -- p_target_date が指定されていれば使用、なければ JST の明日を計算
+  IF p_target_date IS NOT NULL THEN
+    v_target_date_jst := p_target_date;
+  ELSE
+    v_target_date_jst := (timezone('Asia/Tokyo', NOW())::date + 1);
+  END IF;
+
+  RAISE NOTICE '前日チェック開始: 対象日=%', v_target_date_jst;
+
+  FOR v_event IN
+    SELECT
+      se.id,
+      se.date,
+      se.start_time,
+      se.scenario,
+      se.gm_roles,
+      COALESCE(
+        os.override_player_count_max,
+        sm.player_count_max,
+        sm2.player_count_max,
+        se.max_participants,
+        s.player_count_max,
+        8
+      ) AS max_participants,
+      se.organization_id,
+      se.gms,
+      se.store_id,
+      st.name AS store_name
+    FROM schedule_events se
+    LEFT JOIN organization_scenarios os ON se.organization_scenario_id = os.id
+    LEFT JOIN scenario_masters sm ON os.scenario_master_id = sm.id
+    LEFT JOIN scenario_masters sm2 ON se.scenario_master_id = sm2.id
+    LEFT JOIN scenarios s ON se.scenario_id = s.id
+    LEFT JOIN stores st ON se.store_id = st.id
+    WHERE se.date = v_target_date_jst
+      AND se.is_cancelled = FALSE
+      AND se.is_recruitment_extended IS NOT TRUE
+      AND se.category = 'open'
+      AND se.scenario IS NOT NULL
+      AND se.scenario != ''
+      -- 既に処理済みのイベントはスキップ（重複実行・UNIQUE制約違反防止）
+      AND NOT EXISTS (
+        SELECT 1 FROM performance_cancellation_logs pcl
+        WHERE pcl.schedule_event_id = se.id
+          AND pcl.check_type = 'day_before'
+      )
+    ORDER BY se.start_time
+  LOOP
+    v_events_checked := v_events_checked + 1;
+
+    SELECT COALESCE(SUM(r.participant_count), 0) INTO v_reservation_count
+    FROM reservations r
+    WHERE r.schedule_event_id = v_event.id
+      AND r.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in');
+
+    SELECT COUNT(*) INTO v_unsynced_staff
+    FROM (
+      SELECT key AS staff_name, value AS staff_role
+      FROM jsonb_each_text(COALESCE(v_event.gm_roles, '{}'::jsonb))
+    ) AS gm_staff
+    WHERE gm_staff.staff_role = 'staff'
+      AND NOT EXISTS (
+        SELECT 1 FROM reservations r2
+        WHERE r2.schedule_event_id = v_event.id
+          AND r2.status IN ('pending', 'confirmed', 'gm_confirmed', 'checked_in')
+          AND r2.reservation_source = 'staff_entry'
+          AND gm_staff.staff_name = ANY(r2.participant_names)
+      );
+
+    v_current := v_reservation_count + v_unsynced_staff;
+    v_max := v_event.max_participants;
+    v_half := CEIL(v_max::NUMERIC / 2);
+
+    RAISE NOTICE 'イベント: id=%, scenario=%, participants=%, max=%, half=%',
+      v_event.id, v_event.scenario, v_current, v_max, v_half;
+
+    IF v_current >= v_max THEN
+      v_result := 'confirmed';
+      v_events_confirmed := v_events_confirmed + 1;
+    ELSIF v_current >= v_half THEN
+      v_result := 'extended';
+      v_events_extended := v_events_extended + 1;
+
+      UPDATE schedule_events
+      SET is_recruitment_extended = TRUE,
+          updated_at = NOW()
+      WHERE id = v_event.id;
+    ELSE
+      v_result := 'cancelled';
+      v_events_cancelled := v_events_cancelled + 1;
+
+      UPDATE schedule_events
+      SET is_cancelled = TRUE,
+          updated_at = NOW()
+      WHERE id = v_event.id;
+    END IF;
+
+    INSERT INTO performance_cancellation_logs (
+      schedule_event_id,
+      organization_id,
+      check_type,
+      current_participants,
+      max_participants,
+      result
+    ) VALUES (
+      v_event.id,
+      v_event.organization_id,
+      'day_before',
+      v_current,
+      v_max,
+      v_result
+    );
+
+    v_details := v_details || jsonb_build_array(jsonb_build_object(
+      'event_id', v_event.id,
+      'date', v_event.date,
+      'start_time', v_event.start_time,
+      'scenario', v_event.scenario,
+      'store_name', v_event.store_name,
+      'current_participants', v_current,
+      'max_participants', v_max,
+      'half_required', v_half,
+      'result', v_result,
+      'organization_id', v_event.organization_id,
+      'gms', to_jsonb(v_event.gms)
+    ));
+  END LOOP;
+
+  RAISE NOTICE '前日チェック完了: checked=%, confirmed=%, extended=%, cancelled=%',
+    v_events_checked, v_events_confirmed, v_events_extended, v_events_cancelled;
+
+  RETURN QUERY SELECT
+    v_events_checked,
+    v_events_confirmed,
+    v_events_extended,
+    v_events_cancelled,
+    v_details;
+END;
+$$;
+
+COMMENT ON FUNCTION check_performances_day_before(DATE) IS
+'前日23:59に実行する公演中止判定。p_target_date(DATE)省略時はJST翌日を対象とする。';

--- a/supabase/migrations/20260516020000_drop_day_before_no_param.sql
+++ b/supabase/migrations/20260516020000_drop_day_before_no_param.sql
@@ -1,0 +1,3 @@
+-- check_performances_day_before() の引数なし版を削除
+-- date DEFAULT NULL 版のみに統一してオーバーロード解消
+DROP FUNCTION IF EXISTS public.check_performances_day_before();


### PR DESCRIPTION
## 概要

Closes #114

他組織がMMQを使用した場合に、フォールバック値がクインズワルツのデータを指してしまう問題を修正。

## 変更内容

### フロントエンド（フォールバック除去）

| ファイル | 変更内容 |
|---|---|
| `src/lib/publicBookingPath.ts` | 戻り値を `string → string \| null` に変更。管理画面・SSRでは null を返す |
| `src/contexts/AuthContext.tsx` | ハッシュ依存のslug取得を廃止。サインアウト後は現在のURLのorgへ、管理画面からは `/` へ |
| `src/AppRoot.tsx` | null slugの場合は `/` へリダイレクト |

### スタッフ向け（org_id取れない場合は早期リターン）

- `useOrganization.ts` — staff.organization_id が未設定時にQW IDを使わない
- `useBlockedSlots.ts` — 3箇所のフォールバックを除去
- `usePrivateGroup.ts` — フォールバック除去、エラーをthrow
- `PrivateGroupCreate/index.tsx` — フォールバック除去
- `ScheduleManager/index.tsx` — 2箇所、エラートースト表示
- `ImportScheduleModal.tsx` — useOrganization の値をそのまま使用

### 顧客向け（URL slugから組織を解決）

- `useFavorites.ts` — `getCurrentOrganizationId()` → URL slug → `getOrganizationBySlug()` の順で取得
- `CompleteProfile.tsx` — 同上
- `SettingsPage.tsx` — 同上
- `usePrivateBookingSubmit.ts` — 同上

## 注意事項

- **マイグレーションなし**（フロントエンド修正のみ）
- `QUEENS_WALTZ_ORG_ID` 定数は `useOrganization.ts` の `isQueensWaltz()` / `checkIsLicenseAdmin()` で引き続き使用（これはデータ書き込みではなく identity check のため問題なし）
- 既存のクインズワルツユーザーの動作は変わらない

## テスト確認項目

- [ ] クインズワルツスタッフでログイン → 管理画面が正常に動作する
- [ ] クインズワルツの公開予約ページからお気に入り登録できる
- [ ] サインアウト後に適切なURLへリダイレクトされる