### PR TITLE
fix: invite-staff・scheduleApi の organization_id ハードコード除去（マルチテナント P1）

### DIFF
--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -1243,7 +1243,7 @@ export const scheduleApi = {
             
             const demoReservation = {
               schedule_event_id: event.id,
-              organization_id: event.organization_id || 'a0000000-0000-0000-0000-000000000001',
+              organization_id: event.organization_id,
               title: event.scenario || scenarioMaster?.title || '',
               scenario_master_id: event.scenario_master_id,
               store_id: event.store_id || null,

--- a/src/lib/staffInviteApi.ts
+++ b/src/lib/staffInviteApi.ts
@@ -5,6 +5,7 @@ import { logger } from '@/utils/logger'
 export interface InviteStaffRequest {
   email: string
   name: string
+  organization_id?: string
   phone?: string
   line_name?: string
   x_account?: string

--- a/src/pages/StaffManagement/hooks/useStaffInvitation.ts
+++ b/src/pages/StaffManagement/hooks/useStaffInvitation.ts
@@ -6,6 +6,7 @@ import { inviteStaff, type InviteStaffRequest } from '@/lib/staffInviteApi'
 import { staffKeys } from './useStaffQuery'
 import type { Staff } from '@/types'
 import { logger } from '@/utils/logger'
+import { getCurrentOrganizationId } from '@/lib/organization'
 import { getSafeErrorMessage } from '@/lib/apiErrorHandler'
 import { showToast } from '@/utils/toast'
 
@@ -48,9 +49,11 @@ export function useStaffInvitation({ onSuccess, onError }: UseStaffInvitationPro
     event.preventDefault()
 
     const formData = new FormData(event.currentTarget)
+    const organizationId = await getCurrentOrganizationId()
     const request: InviteStaffRequest = {
       email: formData.get('email') as string,
       name: formData.get('name') as string,
+      organization_id: organizationId ?? undefined,
       phone: formData.get('phone') as string || undefined,
       line_name: formData.get('line_name') as string || undefined,
       x_account: formData.get('x_account') as string || undefined,
@@ -298,6 +301,7 @@ export function useStaffInvitation({ onSuccess, onError }: UseStaffInvitationPro
       const request: InviteStaffRequest = {
         email: staff.email,
         name: staff.name,
+        organization_id: staff.organization_id ?? undefined,
         phone: staff.phone,
         line_name: staff.line_name,
         x_account: staff.x_account,

--- a/supabase/functions/invite-staff/index.ts
+++ b/supabase/functions/invite-staff/index.ts
@@ -125,9 +125,15 @@ serve(async (req) => {
       callerOrganizationId = callerUserOrg?.organization_id || null
     }
 
-    // リクエストで指定された organization_id が呼び出し元の組織と一致するか検証
-    const DEFAULT_ORG_ID = 'a0000000-0000-0000-0000-000000000001'
-    const requestedOrganizationId = payload.organization_id || DEFAULT_ORG_ID
+    // organization_id を決定: リクエスト優先、なければ呼び出し元の組織を使用
+    const requestedOrganizationId = payload.organization_id || callerOrganizationId
+
+    if (!requestedOrganizationId) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'organization_id が特定できません。管理者に連絡してください。' }),
+        { status: 400, headers: corsHeaders }
+      )
+    }
 
     if (callerOrganizationId && callerOrganizationId !== requestedOrganizationId) {
       console.warn('⚠️ 組織ID不一致: 呼び出し元=%s, リクエスト=%s', callerOrganizationId, requestedOrganizationId)


### PR DESCRIPTION
## 概要

Closes #115

スタッフ招待とスケジュールAPIで `organization_id` がクインズワルツ固定になっていた問題を修正。

## 変更内容

### フロントエンド

**`src/lib/staffInviteApi.ts`**
- `InviteStaffRequest` に `organization_id?: string` を追加

**`src/pages/StaffManagement/hooks/useStaffInvitation.ts`**
- `handleInviteStaff`: `getCurrentOrganizationId()` でログインユーザーの org_id を取得して渡す
- `handleReinviteStaff`: `staff.organization_id` をそのまま渡す

**`src/lib/api/scheduleApi.ts`**
- デモ予約作成時の `|| 'a0000000-...'` フォールバックを除去（event.organization_id をそのまま使用）

### Edge Function

**`supabase/functions/invite-staff/index.ts`**
- `DEFAULT_ORG_ID`（queens-waltz固定値）を削除
- `payload.organization_id` が未指定の場合、呼び出し元ユーザーの `callerOrganizationId` を使用
- どちらも取得できない場合は 400 エラーを返す

## 注意事項

- **Edge Function のデプロイが必要**（staging 確認後に `supabase functions deploy invite-staff`）
- `OrganizationManagement/OrganizationInviteDialog.tsx` は元々 `organization_id` を渡していたため変更なし
- マイグレーションなし

## テスト確認項目

- [ ] スタッフ管理画面から新規スタッフを招待できる（org_id が正しく設定される）
- [ ] 招待メールの再送信が動作する
- [ ] 別組織へのクロス招待が 403 エラーになる