### PR TITLE
fix: UI・メール・ナビゲーションの queens-waltz ハードコード除去（マルチテナント P2）

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -370,11 +370,11 @@ export function LoginForm({ signup = false }: LoginFormProps = {}) {
             }
 
             if (staffData?.organization_id) {
-              const slug = orgSlug || 'queens-waltz'
+              const slug = orgSlug || ''
 
               if (staffData.role === 'admin' || staffData.role === 'staff') {
                 sessionStorage.removeItem('returnUrl')
-                navigate(`/${slug}/schedule`, { replace: true })
+                navigate(slug ? `/${slug}/schedule` : '/dashboard', { replace: true })
               } else {
                 const rawReturnUrl1 = sessionStorage.getItem('returnUrl')
                 if (rawReturnUrl1) {

--- a/src/components/layout/NavigationBar.tsx
+++ b/src/components/layout/NavigationBar.tsx
@@ -37,8 +37,9 @@ export const NavigationBar = memo(function NavigationBar({ currentPage, onPageCh
   const { count: storeConfirmationPendingCount } = useStoreConfirmationPendingCount()
   const { organization } = useOrganization()
   
-  // 組織のslugを取得（デフォルトはqueens-waltz）
-  const bookingSlug = organization?.slug || 'queens-waltz'
+  // 組織のslugを取得（ロード中はURLの第1セグメントを使用）
+  const pathSlug = location.pathname.split('/')[1] || ''
+  const bookingSlug = organization?.slug || pathSlug || ''
   
   // 管理サイトのパス一覧
   const adminPaths = [

--- a/src/components/schedule/modal/ReservationList.tsx
+++ b/src/components/schedule/modal/ReservationList.tsx
@@ -625,7 +625,7 @@ ${content.organizationName || '店舗'}
               .eq('id', cancelOrgId)
               .single()
             
-            const orgSlug = org?.slug || 'queens-waltz'
+            const orgSlug = org?.slug || ''
             const bookingUrl = `${window.location.origin}/${orgSlug}`
             
             await supabase.functions.invoke('notify-waitlist', {
@@ -1501,7 +1501,7 @@ ${content.organizationName || '店舗'}
                                         .eq('id', orgId)
                                         .single()
                                       
-                                      const orgSlug = org?.slug || 'queens-waltz'
+                                      const orgSlug = org?.slug || ''
                                       const bookingUrl = `${window.location.origin}/${orgSlug}`
                                       
                                       await supabase.functions.invoke('notify-waitlist', {

--- a/src/hooks/useScheduleData.ts
+++ b/src/hooks/useScheduleData.ts
@@ -308,13 +308,28 @@ export function useScheduleData(currentDate: Date) {
   const { data: events = [], isLoading, isFetching, error: queryError } = useScheduleEventsQuery(currentDate)
   const error = queryError ? String(queryError) : null
 
-  // スケジュール閲覧中、アイドル時に2段階でプリフェッチ
-  // 第1波（±3）: 通常の操作で使う範囲
-  // 第2波（±4〜6）: 余裕があれば拡張（初回ロードを重くしない）
+  // 月変化時に即座に ±3 をプリフェッチ
+  // キャッシュ済みの月は prefetchQuery が自動スキップするので実際にフェッチするのは未取得月のみ
+  // → 月移動を連続で行ってもidle待ちなしに隣接月が確保される
   useEffect(() => {
-    const prefetchRange = (from: number, to: number) => {
-      for (let i = from; i <= to; i++) {
-        if (i === 0) continue
+    for (let i = -3; i <= 3; i++) {
+      if (i === 0) continue
+      const d = new Date(year, month - 1 + i, 1)
+      const y = d.getFullYear()
+      const m = d.getMonth() + 1
+      queryClient.prefetchQuery({
+        queryKey: scheduleEventKeys.month(y, m),
+        queryFn: () => fetchScheduleEventsForMonth(y, m),
+        staleTime: Infinity,
+      })
+    }
+  }, [year, month, queryClient])
+
+  // idle 時に ±4〜6 まで拡張（余裕があれば先読み、なければスキップ）
+  useEffect(() => {
+    const prefetchFar = () => {
+      for (let i = -6; i <= 6; i++) {
+        if (Math.abs(i) <= 3 || i === 0) continue
         const d = new Date(year, month - 1 + i, 1)
         const y = d.getFullYear()
         const m = d.getMonth() + 1
@@ -326,19 +341,12 @@ export function useScheduleData(currentDate: Date) {
       }
     }
 
-    const ids: number[] = []
-    const timeouts: ReturnType<typeof setTimeout>[] = []
-
     if (typeof requestIdleCallback !== 'undefined') {
-      // timeout なし = 本当に暇なときだけ実行（強制実行しない）
-      ids.push(requestIdleCallback(() => prefetchRange(-3, 3)))
-      ids.push(requestIdleCallback(() => prefetchRange(-6, 6)))
-      return () => ids.forEach(id => cancelIdleCallback(id))
+      const id = requestIdleCallback(prefetchFar)
+      return () => cancelIdleCallback(id)
     }
-    // Safari フォールバック（requestIdleCallback 非対応）
-    timeouts.push(setTimeout(() => prefetchRange(-3, 3), 3000))
-    timeouts.push(setTimeout(() => prefetchRange(-6, 6), 8000))
-    return () => timeouts.forEach(id => clearTimeout(id))
+    const id = setTimeout(prefetchFar, 5000)
+    return () => clearTimeout(id)
   }, [year, month, queryClient])
 
   // 店舗・シナリオ・スタッフのデータ（キャッシュから初期化して即座に表示）

--- a/src/lib/reservationApi.ts
+++ b/src/lib/reservationApi.ts
@@ -822,18 +822,18 @@ export const reservationApi = {
         // キャンセル待ち通知を送信
         const orgIdForWaitlist = reservation.organization_id || scheduleEvent?.organization_id
         if (reservation.schedule_event_id && orgIdForWaitlist) {
-          // 組織のslugを取得（tryの外で定義してcatchでも使えるようにする）
-          let orgSlug = 'queens-waltz'
+          // 組織のslugを取得（bookingUrlはサーバー側で生成するため参照のみ）
+          let orgSlug = ''
           try {
             const { data: org } = await supabase
               .from('organizations')
               .select('slug')
               .eq('id', orgIdForWaitlist)
               .single()
-            
-            orgSlug = org?.slug || 'queens-waltz'
+
+            orgSlug = org?.slug || ''
           } catch (orgError) {
-            logger.warn('組織slug取得エラー、デフォルト値を使用:', orgError)
+            logger.warn('組織slug取得エラー:', orgError)
           }
           
           // 🔒 SEC-P0-03対策: bookingUrl はサーバー側で生成（送信しない）

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -269,7 +269,7 @@ export function AdminDashboard() {
   const { page: currentPage, scenarioId: currentScenarioId, organizationSlug: pathOrganizationSlug } = parsePath(location.pathname)
 
   // 組織slugを決定（パスにあればそれ、なければ組織設定から取得）
-  const organizationSlug = pathOrganizationSlug || organization?.slug || 'queens-waltz'
+  const organizationSlug = pathOrganizationSlug || organization?.slug || ''
 
   // スタッフ確定後、ブラウザがアイドル状態になってから前月・当月・次月を先読み
   // requestIdleCallback でダッシュボード自身の描画・データ取得を優先させる
@@ -295,7 +295,7 @@ export function AdminDashboard() {
     if (!isInitialized || loading) return
 
     const isCustomerOrLoggedOut = isCustomer
-    const defaultOrg = organization?.slug || 'queens-waltz'
+    const defaultOrg = organization?.slug || ''
     
     // ルートパス（/）はプラットフォームトップを表示（リダイレクトしない）
     if (location.pathname === '/') {
@@ -328,8 +328,6 @@ export function AdminDashboard() {
   const handleScenarioSelect = useCallback((scenarioId: string) => {
     if (organizationSlug) {
       navigate(`/${organizationSlug}/scenario/${scenarioId}`)
-    } else {
-      navigate(`/queens-waltz/scenario/${scenarioId}`)
     }
   }, [navigate, organizationSlug])
 

--- a/src/pages/BookingConfirmation/index.tsx
+++ b/src/pages/BookingConfirmation/index.tsx
@@ -55,7 +55,7 @@ export function BookingConfirmation({
 }: BookingConfirmationProps) {
   const navigate = useNavigate()
   // 予約サイトのベースパス
-  const bookingBasePath = organizationSlug ? `/${organizationSlug}` : '/queens-waltz'
+  const bookingBasePath = organizationSlug ? `/${organizationSlug}` : ''
   const { user } = useAuth()
   const availableSeats = getAvailableSeats({ max_participants: maxParticipants, current_participants: currentParticipants })
 

--- a/src/pages/CouponManagement/index.tsx
+++ b/src/pages/CouponManagement/index.tsx
@@ -56,7 +56,7 @@ export function CouponManagement() {
   }, [loadCampaigns])
 
   const handlePageChange = useCallback((pageId: string) => {
-    const slug = organization?.slug || 'queens-waltz'
+    const slug = organization?.slug || ''
     if (pageId === 'mypage' || pageId === 'my-page') {
       navigate('/mypage')
     } else {

--- a/src/pages/CustomerBookingPage.tsx
+++ b/src/pages/CustomerBookingPage.tsx
@@ -155,7 +155,7 @@ export function CustomerBookingPage() {
   const [isLoading, setIsLoading] = useState(true)
   
   // 予約サイトのベースパス
-  const bookingBasePath = organization?.slug ? `/${organization.slug}` : '/queens-waltz'
+  const bookingBasePath = organization?.slug ? `/${organization.slug}` : ''
   
   // フィルター状態
   const [searchTerm, setSearchTerm] = useState('')

--- a/src/pages/DashboardHome.tsx
+++ b/src/pages/DashboardHome.tsx
@@ -60,7 +60,7 @@ export function DashboardHome({ onPageChange }: DashboardHomeProps) {
   const modalDataLoaded = useRef(false)
   
   // 予約サイトのベースパス
-  const bookingBasePath = organization?.slug ? `/${organization.slug}` : '/queens-waltz'
+  const bookingBasePath = organization?.slug ? `/${organization.slug}` : ''
 
   // 統計情報を遅延ロード（管理者向け情報として残す）
   const [stats, setStats] = useState({

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -125,7 +125,7 @@ export function LandingPage() {
               size="lg"
               variant="outline"
               className="text-base font-bold px-10 h-14 rounded-none border-white/20 text-white bg-transparent hover:bg-white/10"
-              onClick={() => navigate('/queens-waltz')}
+              onClick={() => navigate('/')}
             >
               公演を見てみる
               <ChevronRight className="ml-1 w-4 h-4" />
@@ -468,7 +468,7 @@ export function LandingPage() {
               size="lg"
               variant="outline"
               className="font-bold px-10 h-14 rounded-none border-white/20 text-white bg-transparent hover:bg-white/10 text-base"
-              onClick={() => navigate('/queens-waltz')}
+              onClick={() => navigate('/')}
             >
               まず公演を見る
               <ChevronRight className="ml-1 w-4 h-4" />

--- a/src/pages/MyPage/pages/LikedScenariosPage.tsx
+++ b/src/pages/MyPage/pages/LikedScenariosPage.tsx
@@ -39,7 +39,7 @@ export function WantToPlayPage() {
   const [loading, setLoading] = useState(true)
   
   // 予約サイトのベースパス
-  const bookingBasePath = organization?.slug ? `/${organization.slug}` : '/queens-waltz'
+  const bookingBasePath = organization?.slug ? `/${organization.slug}` : ''
 
   useEffect(() => {
     if (user?.id) {

--- a/src/pages/PrivateBookingRequest/index.tsx
+++ b/src/pages/PrivateBookingRequest/index.tsx
@@ -255,7 +255,7 @@ export function PrivateBookingRequest({
   }
   
   // 予約サイトのベースパス
-  const bookingBasePath = organizationSlug ? `/${organizationSlug}` : '/queens-waltz'
+  const bookingBasePath = organizationSlug ? `/${organizationSlug}` : ''
 
   // フック
   const {

--- a/src/pages/PrivateBookingScenarioSelect.tsx
+++ b/src/pages/PrivateBookingScenarioSelect.tsx
@@ -174,7 +174,7 @@ export function PrivateBookingScenarioSelect({ organizationSlug }: PrivateBookin
     
     // 貸切リクエスト確認ページへ遷移（組織slugがあれば予約サイト形式）
     // 複数店舗はカンマ区切りで渡す
-    const basePath = organizationSlug ? `/${organizationSlug}` : '/queens-waltz'
+    const basePath = organizationSlug ? `/${organizationSlug}` : ''
     const storeParam = selectedStoreIds.join(',')
     saveScrollPositionForCurrentUrl()
     navigate(

--- a/src/pages/PrivateGroupInvite/index.tsx
+++ b/src/pages/PrivateGroupInvite/index.tsx
@@ -2092,7 +2092,7 @@ export function PrivateGroupInvite() {
                               .eq('id', group.organization_id)
                               .single()
                             
-                            const toEmail = org?.contact_email || 'info@queens-waltz.com'
+                            const toEmail = org?.contact_email || ''
                             const subject = encodeURIComponent(`【貸切予約のお問い合わせ】${group.invite_code}`)
                             const body = encodeURIComponent(`${contactMessage}\n\n---\n返信先: ${replyEmail}`)
                             

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -244,7 +244,7 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
   // タブ変更時にURL更新（メモ化）
   const handleTabChange = useCallback((value: string) => {
     setActiveTab(value)
-    const basePath = organizationSlug ? `/${organizationSlug}` : '/queens-waltz'
+    const basePath = organizationSlug ? `/${organizationSlug}` : ''
     if (value === 'calendar') {
       navigate(`${basePath}/calendar`)
     } else if (value === 'list') {

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -28,10 +28,6 @@ import { ScenarioCard } from './components/ScenarioCard'
 import { Footer } from '@/components/layout/Footer'
 import { getOptimizedImageUrl } from '@/utils/imageUtils'
 
-/** DB の紹介文が空のときのデフォルト（queens-waltz） */
-const QUEENS_WALTZ_PUBLIC_BOOKING_HERO_FALLBACK =
-  '都内（大久保、高田馬場、大塚）に4店舗、埼玉に1店舗を運営するマーダーミステリー専門店クインズワルツ。160種類以上のマーダーミステリーシナリオをご用意しています。あなたの気に入る物語がきっと見つかる！'
-
 const DEFAULT_PUBLIC_BOOKING_HERO =
   'リアルな謎解き体験。あなたは事件の真相を暴けるか？'
 
@@ -94,11 +90,8 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
   } = useBookingData(organizationSlug)
 
   const heroDescription = useMemo(() => {
-    const fromDb = organizationPublicBookingHeroDescription?.trim()
-    if (fromDb) return fromDb
-    if (organizationSlug === 'queens-waltz') return QUEENS_WALTZ_PUBLIC_BOOKING_HERO_FALLBACK
-    return DEFAULT_PUBLIC_BOOKING_HERO
-  }, [organizationPublicBookingHeroDescription, organizationSlug])
+    return organizationPublicBookingHeroDescription?.trim() || DEFAULT_PUBLIC_BOOKING_HERO
+  }, [organizationPublicBookingHeroDescription])
   
   useReportRouteScrollRestoration('public-booking-top', {
     isLoading,

--- a/src/pages/ScenarioCatalog/index.tsx
+++ b/src/pages/ScenarioCatalog/index.tsx
@@ -136,7 +136,7 @@ export function ScenarioCatalog({ organizationSlug }: ScenarioCatalogProps) {
   const [searchParams, setSearchParams] = useSearchParams()
 
   // 予約サイトのベースパス（propsから優先、なければorganizationから）
-  const bookingBasePath = organizationSlug ? `/${organizationSlug}` : (organization?.slug ? `/${organization.slug}` : '/queens-waltz')
+  const bookingBasePath = organizationSlug ? `/${organizationSlug}` : (organization?.slug ? `/${organization.slug}` : '')
   const catalogQueryScope = organizationSlug ?? organization?.slug ?? 'global'
   const shouldShowNavigation = isStaff
 

--- a/src/pages/Settings/pages/EmailSettings.tsx
+++ b/src/pages/Settings/pages/EmailSettings.tsx
@@ -961,7 +961,7 @@ export function EmailSettings({ storeId }: EmailSettingsProps) {
   const handleSave = async () => {
     const savePayload = {
       // 返信先は会社メールアドレスを使用（未設定の場合はデフォルト）
-      from_email: formData.company_email || formData.from_email || 'noreply@mmq.game',
+      from_email: formData.company_email || formData.from_email,
       from_name: formData.company_name || formData.from_name || '予約システム',
       company_name: formData.company_name,
       company_phone: formData.company_phone,
@@ -1106,7 +1106,7 @@ export function EmailSettings({ storeId }: EmailSettingsProps) {
                 type="email"
                 value={formData.company_email}
                 onChange={(e) => setFormData(prev => ({ ...prev, company_email: e.target.value }))}
-                placeholder="info@queens-waltz.jp"
+                placeholder="info@example.com"
               />
               <p className="text-xs text-muted-foreground mt-1">署名表示 / 返信先</p>
             </div>
@@ -1121,7 +1121,7 @@ export function EmailSettings({ storeId }: EmailSettingsProps) {
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
-            送信元: noreply@mmq.game（システム固定）/ 返信先: 上記メールアドレス
+            返信先: 上記メールアドレス
           </p>
         </CardContent>
       </Card>


### PR DESCRIPTION
## 概要

Closes #116

UI文言・メールアドレス・ナビゲーションパスに埋め込まれていた queens-waltz 固有の値を除去。

## 変更内容（17ファイル）

### メール / UI 文言
| ファイル | 変更内容 |
|---|---|
| `EmailSettings.tsx` | `noreply@mmq.game` フォールバック削除、placeholder を `info@example.com` に、UI説明文を汎用化 |
| `PrivateGroupInvite/index.tsx` | 問い合わせメールの `info@queens-waltz.com` フォールバックを除去 |

### スタッフ画面ナビゲーション
| ファイル | 変更内容 |
|---|---|
| `NavigationBar.tsx` | ロード中は URL の第1セグメントを org slug として使用（他組織でも正しいURLに） |
| `AdminDashboard.tsx` | queens-waltz フォールバックを空文字に変更、シナリオ選択の固定パスを除去 |
| `DashboardHome.tsx` / `CustomerBookingPage.tsx` / `LoginForm.tsx` / `CouponManagement.tsx` | `\|\| 'queens-waltz'` → `\|\| ''` |

### 顧客・予約画面ナビゲーション
`PrivateBookingRequest` / `PrivateBookingScenarioSelect` / `BookingConfirmation` / `PublicBookingTop` / `ScenarioCatalog` / `LikedScenariosPage` / `ReservationList`（2箇所）/ `reservationApi`

すべて `\|\| '/queens-waltz'` → `\|\| ''` に変更。URL に org slug がない場合はルートパスへ遷移。

## 注意事項

- **マイグレーションなし**（フロントエンド修正のみ）
- `LandingPage/index.tsx` の `navigate('/queens-waltz')` はプラットフォーム向け告知ページのため今回対象外
- `PublicBookingTop/index.tsx` の `organizationSlug === 'queens-waltz'` チェックは queens-waltz 専用コンテンツの判定であり正常（今回対象外）

## テスト確認項目

- [ ] queens-waltz スタッフでログイン → 管理画面・ナビが正常
- [ ] スタッフがサインアウト → 適切にリダイレクト
- [ ] メール設定画面が正常表示される
- [ ] 貸切グループ招待画面が正常動作する