### PR TITLE
feat: React Query導入・ページ高速化・スケジュール安定表示

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -109,6 +109,7 @@ const BOOKING_SHELL_GLOBAL_FIRST_SEGMENT = new Set([
   'complete-profile',
   'coupon-present',
   'register',
+  'start',
   'about',
   'accept-invitation',
   'author-dashboard',
@@ -323,7 +324,7 @@ function AppRoutes() {
     // /complete-profile 自体はスキップ（無限ループ防止）
     const isCompleteProfilePage = location.pathname === '/complete-profile'
     // 認証フローページにいるログイン済み顧客はプロフィールゲート対象外（ループ防止）
-    const isAuthPage = ['/signup', '/login', '/register', '/reset-password', '/set-password'].includes(location.pathname)
+    const isAuthPage = ['/signup', '/login', '/register', '/start', '/reset-password', '/set-password'].includes(location.pathname)
     // 招待リンクはゲスト向けのため、ログイン済みでもプロフィールゲート対象外
     const isInvitePage = location.pathname.startsWith('/group/invite/')
 

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -14,7 +14,7 @@ import {
   CalendarDays, Users, BookOpen, TrendingUp, CalendarClock, Settings,
   ClipboardCheck, UserCog, Store, HelpCircle, Globe, LayoutDashboard,
   UserCircle, UserCheck, Ticket, FileCheck, Shield, Gift, FileText,
-  Mail, Building2, ChevronDown, ChevronRight, Menu, X,
+  Mail, Building2, ChevronDown, ChevronRight, Menu, X, Plus,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -33,7 +33,8 @@ type NavItem = {
   path: string
   roles: string[]
   badge?: number
-  subItems?: SubItem[]   // そのページにいる時だけ展開表示
+  subItems?: SubItem[]
+  sectionLabel?: string  // グループ内でこのアイテムの直前にセクションヘッダーを表示
 }
 
 type SidebarContentProps = {
@@ -134,7 +135,34 @@ export const AdminSidebar = memo(function AdminSidebar() {
       items: [
         { id: 'scenarios', label: 'シナリオ', icon: BookOpen, path: `/${slug}/scenarios`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'blog',      label: 'ブログ',   icon: FileText, path: `/${slug}/blog`,      roles: ['admin', 'license_admin'] },
-        { id: 'manual',    label: 'マニュアル', icon: HelpCircle, path: `/${slug}/manual`, roles: ['admin', 'staff', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'manual-category',
+      label: 'マニュアル',
+      icon: HelpCircle,
+      items: [
+        {
+          id: 'manual-common', label: '共通マニュアル', icon: HelpCircle,
+          path: `/${slug}/manual?tab=checkin`, roles: ['admin', 'staff', 'license_admin'],
+          subItems: [
+            { id: 'manual-checkin',            label: '受付・チェックイン',    path: `/${slug}/manual?tab=checkin` },
+            { id: 'manual-pre-reading-survey', label: '事前アンケート・配役',  path: `/${slug}/manual?tab=pre-reading-survey` },
+            { id: 'manual-coupon-reception',   label: 'クーポン受付対応',      path: `/${slug}/manual?tab=coupon-reception` },
+            { id: 'manual-coupon-types',       label: 'クーポン・チケット種類', path: `/${slug}/manual?tab=coupon-types` },
+          ],
+        },
+        {
+          id: 'manual-admin', label: '運営', icon: HelpCircle,
+          path: `/${slug}/manual?tab=reservation`, roles: ['admin', 'license_admin'],
+          subItems: [
+            { id: 'manual-reservation', label: '予約管理',             path: `/${slug}/manual?tab=reservation` },
+            { id: 'manual-staff-item',  label: 'スタッフ管理',         path: `/${slug}/manual?tab=staff` },
+            { id: 'manual-schedule',    label: 'シフト・スケジュール', path: `/${slug}/manual?tab=schedule` },
+            { id: 'manual-coupon',      label: 'クーポン管理',         path: `/${slug}/manual?tab=coupon` },
+          ],
+        },
+        { id: 'manual-new', label: '新規作成', icon: Plus, path: `/${slug}/manual?action=new`, roles: ['admin'] },
       ],
     },
     {
@@ -243,9 +271,16 @@ export const AdminSidebar = memo(function AdminSidebar() {
       )
     }
     const [basePath, query] = item.path.split('?')
+    const currentTab = new URLSearchParams(search).get('tab')
+    // subItems のいずれかのタブがアクティブなら親も active とみなす
+    if (item.subItems && pathname === basePath) {
+      if (item.subItems.some(sub => {
+        const [, subQuery] = sub.path.split('?')
+        return subQuery && new URLSearchParams(subQuery).get('tab') === currentTab
+      })) return true
+    }
     if (query) {
       const tabParam = new URLSearchParams(query).get('tab')
-      const currentTab = new URLSearchParams(search).get('tab')
       return pathname === basePath && currentTab === tabParam
     }
     return pathname === basePath || pathname.startsWith(basePath + '/')
@@ -390,6 +425,11 @@ function GroupPanel({
             : []
           return (
             <div key={item.id}>
+              {item.sectionLabel && (
+                <p className="text-[10px] font-semibold text-muted-foreground/60 px-3 pt-2 pb-0.5 uppercase tracking-wide">
+                  {item.sectionLabel}
+                </p>
+              )}
               <Link
                 to={item.path}
                 className={`relative flex items-center px-3 py-2 text-sm transition-all duration-150 ${

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -5,7 +5,7 @@
  * - モバイルはハンバーガー → ドロワー
  * - ロールベースでメニューをフィルタリング
  */
-import { useState, useMemo, useCallback, useEffect, memo } from 'react'
+import { useState, useLayoutEffect, useRef, useMemo, useCallback, useEffect, memo } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useOrganization, checkIsLicenseAdmin } from '@/hooks/useOrganization'
@@ -63,7 +63,7 @@ const ADMIN_PATH_SEGMENTS = [
   'reservations', 'accounts', 'sales', 'settings', 'manual',
   'staff-profile', 'license-management', 'coupons', 'blog',
   'organizations', 'external-reports', 'scenario-masters',
-  'license-reports', 'customer-management', 'user-management',
+  'license-reports', 'customer-management', 'user-management', 'scenario-matcher',
 ]
 
 export const AdminSidebar = memo(function AdminSidebar() {
@@ -123,15 +123,8 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: 'アカウント・顧客',
       icon: UserCog,
       items: [
-        {
-          id: 'accounts', label: 'アカウント', icon: UserCog,
-          path: `/${slug}/accounts`, roles: ['admin', 'license_admin'],
-          subItems: [
-            { id: 'users',     label: 'ユーザー', path: `/${slug}/accounts?tab=users` },
-            { id: 'customers', label: '顧客',     path: `/${slug}/accounts?tab=customers` },
-          ],
-        },
-        { id: 'coupons', label: 'クーポン', icon: Gift, path: `/${slug}/coupons`, roles: ['admin', 'license_admin'] },
+        { id: 'customers', label: '顧客', icon: UserCog, path: `/${slug}/accounts?tab=customers`, roles: ['admin', 'license_admin'] },
+        { id: 'coupons',   label: 'クーポン', icon: Gift, path: `/${slug}/coupons`, roles: ['admin', 'license_admin'] },
       ],
     },
     {
@@ -217,6 +210,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: 'MMQ運営',
       icon: Shield,
       items: [
+        { id: 'accounts', label: 'ユーザー管理', icon: UserCog, path: `/${slug}/accounts?tab=users`, roles: ['admin', 'license_admin'] },
         { id: 'organizations',     label: 'テナント管理',       icon: Building2, path: `/${slug}/organizations`,     roles: ['license_admin'] },
         { id: 'scenario-masters',  label: 'マスタ管理',         icon: Shield,    path: '/admin/scenario-masters',     roles: ['license_admin'] },
         { id: 'external-reports',  label: '外部公演報告',       icon: FileCheck, path: `/${slug}/external-reports`,  roles: ['license_admin'] },
@@ -241,14 +235,19 @@ export const AdminSidebar = memo(function AdminSidebar() {
 
   // アクティブ判定（ページレベル）
   const isActive = useCallback((item: NavItem) => {
-    const { pathname } = location
+    const { pathname, search } = location
     if (item.id === 'booking') {
       return pathname === `/${slug}` || (
         pathname.startsWith(`/${slug}/`) &&
         !ADMIN_PATH_SEGMENTS.some(seg => pathname.includes(`/${seg}`))
       )
     }
-    const basePath = item.path.split('?')[0]
+    const [basePath, query] = item.path.split('?')
+    if (query) {
+      const tabParam = new URLSearchParams(query).get('tab')
+      const currentTab = new URLSearchParams(search).get('tab')
+      return pathname === basePath && currentTab === tabParam
+    }
     return pathname === basePath || pathname.startsWith(basePath + '/')
   }, [location, slug])
 
@@ -354,11 +353,26 @@ function GroupPanel({
   userRole: string
   isLicAdmin: boolean
 }) {
-  // display:none→blockでCSSアニメーションが自動リスタートする仕様を利用
-  // 同グループ内ナビでは display が変わらないのでアニメーション再発なし
+  const divRef = useRef<HTMLDivElement>(null)
+  const prevIsOpenRef = useRef(isOpen) // マウント時の値で初期化
+
+  // isOpen が false→true になった瞬間だけ DOM 直接操作でアニメーションをリスタート
+  // React の style/class 再適用に依存しないため確実に動作する
+  useLayoutEffect(() => {
+    const wasOpen = prevIsOpenRef.current
+    prevIsOpenRef.current = isOpen
+    if (!group.label || !divRef.current) return
+    if (!wasOpen && isOpen) {
+      const el = divRef.current
+      el.style.animationName = 'none'
+      void el.getBoundingClientRect() // reflow を強制してアニメーションをリセット
+      el.style.animationName = ''
+    }
+  })
 
   return (
     <div
+      ref={divRef}
       className={group.label ? 'sidebar-items-enter' : ''}
       style={group.label ? { display: isOpen ? 'block' : 'none' } : undefined}
     >

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -306,10 +306,12 @@ export const AdminSidebar = memo(function AdminSidebar() {
           )}
 
           {/* グループアイテム */}
-          <div className={`overflow-hidden transition-all duration-200 ease-out ${
-            isGroupOpen(group) ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+          <div className={`overflow-hidden transition-[max-height,opacity] duration-300 ease-out ${
+            isGroupOpen(group) ? 'max-h-[600px] opacity-100' : 'max-h-0 opacity-0'
           }`}>
-            <div className="space-y-0.5 px-2 pb-1">
+            <div className={`space-y-0.5 px-2 pb-1 transition-transform duration-300 ease-out ${
+              isGroupOpen(group) ? 'translate-y-0' : '-translate-y-2'
+            }`}>
               {group.items.map(item => {
                 const active = isActive(item)
                 const showSubs = active && item.subItems && item.subItems.length > 0

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -86,14 +86,6 @@ export const AdminSidebar = memo(function AdminSidebar() {
       items: [
         { id: 'dashboard', label: 'ダッシュボード', icon: LayoutDashboard, path: `/${slug}/dashboard`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'booking', label: '予約サイト', icon: Globe, path: `/${slug}`, roles: ['admin', 'staff', 'license_admin'] },
-      ],
-    },
-    {
-      id: 'schedule',
-      label: 'スケジュール',
-      icon: CalendarDays,
-      defaultOpen: true,
-      items: [
         { id: 'schedule', label: 'スケジュール', icon: CalendarDays, path: `/${slug}/schedule`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'shift-submission', label: 'シフト提出', icon: CalendarClock, path: `/${slug}/shift-submission`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'gm-availability', label: 'GM確認', icon: UserCheck, path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'] },
@@ -204,10 +196,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
               onClick={() => toggleGroup(group.id)}
               className="w-full flex items-center justify-between px-3 py-1.5 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors"
             >
-              <div className="flex items-center gap-1.5">
-                {group.icon && <group.icon className="w-3.5 h-3.5" />}
-                {group.label}
-              </div>
+              <span>{group.label}</span>
               {openGroups[group.id]
                 ? <ChevronDown className="w-3 h-3" />
                 : <ChevronRight className="w-3 h-3" />
@@ -220,18 +209,16 @@ export const AdminSidebar = memo(function AdminSidebar() {
             <div className="space-y-0.5 px-2">
               {group.items.map(item => {
                 const active = isActive(item)
-                const Icon = item.icon
                 return (
                   <Link
                     key={item.id}
                     to={item.path}
-                    className={`relative flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors ${
+                    className={`relative flex items-center px-2 py-1.5 rounded-md text-sm transition-colors ${
                       active
                         ? 'bg-primary/10 text-primary font-medium'
                         : 'text-muted-foreground hover:bg-accent hover:text-foreground'
                     }`}
                   >
-                    <Icon className="w-4 h-4 flex-shrink-0" />
                     <span className="truncate">{item.label}</span>
                     {item.badge != null && item.badge > 0 && (
                       <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -395,23 +395,16 @@ function SidebarContent({
             </button>
           )}
 
-          {/* grid-rows アニメーション（外部コンポーネントなので transition が正常に動く） */}
           <div
             style={{
               display: 'grid',
               gridTemplateRows: isGroupOpen(group) ? '1fr' : '0fr',
-              opacity: isGroupOpen(group) ? 1 : 0,
-              transition: 'grid-template-rows 280ms ease-out, opacity 220ms ease-out',
+              transition: 'grid-template-rows 300ms ease-out',
             }}
           >
-            <div className="overflow-hidden">
-              <div
-                style={{
-                  transform: isGroupOpen(group) ? 'translateY(0)' : 'translateY(-6px)',
-                  transition: 'transform 280ms ease-out',
-                }}
-                className="space-y-0.5 px-2 pb-1"
-              >
+            {/* min-height:0 が必須 — これがないと 0fr まで縮まらない */}
+            <div style={{ minHeight: 0, overflow: 'hidden' }}>
+              <div className="space-y-0.5 px-2 pb-1">
                 {group.items.map(item => {
                   const active = isActive(item)
                   const showSubs = active && item.subItems && item.subItems.length > 0

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -5,7 +5,7 @@
  * - モバイルはハンバーガー → ドロワー
  * - ロールベースでメニューをフィルタリング
  */
-import { useState, useMemo, useCallback, useEffect, memo } from 'react'
+import { useState, useLayoutEffect, useRef, useMemo, useCallback, useEffect, memo } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useOrganization, checkIsLicenseAdmin } from '@/hooks/useOrganization'
@@ -362,7 +362,14 @@ function GroupPanel({
   userRole: string
   isLicAdmin: boolean
 }) {
-  const [animate, setAnimate] = useState(!!group.label)
+  const [animate, setAnimate] = useState(false)
+  const prevIsOpenRef = useRef(false)
+
+  // isOpen が false→true になった瞬間だけ animate=true にする
+  useLayoutEffect(() => {
+    if (isOpen && !prevIsOpenRef.current && group.label) setAnimate(true)
+    prevIsOpenRef.current = isOpen
+  })
 
   if (!isOpen) return null
 

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -64,6 +64,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
   const slug = organization?.slug || 'queens-waltz'
 
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [hoveredGroup, setHoveredGroup] = useState<string | null>(null)
   const navigate = useNavigate()
 
   // パス変更でモバイルドロワーを閉じる
@@ -264,11 +265,11 @@ export const AdminSidebar = memo(function AdminSidebar() {
 
   if (!user || user.role === 'customer' || !isAdminPage) return null
 
-  // カテゴリが開いているか（アクティブページが含まれる時だけ）
+  // カテゴリが開いているか（アクティブ or ホバー中）
   const isGroupOpen = useCallback((group: typeof visibleGroups[0]) => {
     if (!group.label) return true  // ラベルなし（トップ）は常に表示
-    return group.items.some(item => isActive(item))
-  }, [isActive])
+    return group.items.some(item => isActive(item)) || hoveredGroup === group.id
+  }, [isActive, hoveredGroup])
 
   // カテゴリヘッダーをクリック → そのカテゴリの最初のアイテムに遷移
   const handleGroupClick = useCallback((group: typeof visibleGroups[0]) => {
@@ -279,7 +280,11 @@ export const AdminSidebar = memo(function AdminSidebar() {
   const SidebarContent = () => (
     <div className="flex flex-col h-full py-3">
       {visibleGroups.map((group, gi) => (
-        <div key={group.id}>
+        <div
+          key={group.id}
+          onMouseEnter={() => group.label && setHoveredGroup(group.id)}
+          onMouseLeave={() => setHoveredGroup(null)}
+        >
           {/* グループセパレーター */}
           {gi > 0 && group.label && (
             <div className="mx-3 my-1 border-t border-border/40" />

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -294,21 +294,22 @@ export const AdminSidebar = memo(function AdminSidebar() {
           {group.label && (
             <button
               onClick={() => handleGroupClick(group)}
-              className="w-full flex items-center justify-between px-3 pt-2 pb-1 hover:text-slate-600 transition-colors group"
+              className="w-full flex items-center justify-between px-3 pt-2 pb-1 transition-colors duration-150 group"
             >
-              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400 group-hover:text-slate-600">
+              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400 transition-colors duration-150 group-hover:text-slate-600">
                 {group.label}
               </span>
-              {isGroupOpen(group)
-                ? <ChevronDown className="w-3 h-3 text-slate-300 group-hover:text-slate-500" />
-                : <ChevronRight className="w-3 h-3 text-slate-300 group-hover:text-slate-500" />
-              }
+              <ChevronRight className={`w-3 h-3 text-slate-300 transition-all duration-200 group-hover:text-slate-500 ${
+                isGroupOpen(group) ? 'rotate-90' : 'rotate-0'
+              }`} />
             </button>
           )}
 
           {/* グループアイテム */}
-          {isGroupOpen(group) && (
-            <div className="space-y-0.5 px-2">
+          <div className={`overflow-hidden transition-all duration-200 ease-out ${
+            isGroupOpen(group) ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+          }`}>
+            <div className="space-y-0.5 px-2 pb-1">
               {group.items.map(item => {
                 const active = isActive(item)
                 const showSubs = active && item.subItems && item.subItems.length > 0
@@ -322,10 +323,10 @@ export const AdminSidebar = memo(function AdminSidebar() {
                   <div key={item.id}>
                     <Link
                       to={item.path}
-                      className={`relative flex items-center px-3 py-2 text-sm transition-colors ${
+                      className={`relative flex items-center px-3 py-2 text-sm transition-all duration-150 ${
                         active
                           ? 'bg-blue-50 text-blue-700 font-medium'
-                          : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                          : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 hover:translate-x-0.5'
                       }`}
                     >
                       <span className="truncate">{item.label}</span>
@@ -366,7 +367,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
                 )
               })}
             </div>
-          )}
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -399,7 +399,7 @@ function SidebarContent({
           )}
 
           {isGroupOpen(group) && (
-            <div className="sidebar-items-enter space-y-0.5 px-2 pb-1">
+            <div className={`space-y-0.5 px-2 pb-1 ${group.label ? 'sidebar-items-enter' : ''}`}>
                 {group.items.map(item => {
                   const active = isActive(item)
                   const showSubs = active && item.subItems && item.subItems.length > 0

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -64,7 +64,6 @@ export const AdminSidebar = memo(function AdminSidebar() {
   const slug = organization?.slug || 'queens-waltz'
 
   const [mobileOpen, setMobileOpen] = useState(false)
-  const [hoveredGroup, setHoveredGroup] = useState<string | null>(null)
   const navigate = useNavigate()
 
   // パス変更でモバイルドロワーを閉じる
@@ -265,11 +264,11 @@ export const AdminSidebar = memo(function AdminSidebar() {
 
   if (!user || user.role === 'customer' || !isAdminPage) return null
 
-  // カテゴリが開いているか（アクティブ or ホバー中）
+  // カテゴリが開いているか（アクティブページが含まれる時のみ）
   const isGroupOpen = useCallback((group: typeof visibleGroups[0]) => {
     if (!group.label) return true  // ラベルなし（トップ）は常に表示
-    return group.items.some(item => isActive(item)) || hoveredGroup === group.id
-  }, [isActive, hoveredGroup])
+    return group.items.some(item => isActive(item))
+  }, [isActive])
 
   // カテゴリヘッダーをクリック → そのカテゴリの最初のアイテムに遷移
   const handleGroupClick = useCallback((group: typeof visibleGroups[0]) => {
@@ -280,11 +279,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
   const SidebarContent = () => (
     <div className="flex flex-col h-full py-3">
       {visibleGroups.map((group, gi) => (
-        <div
-          key={group.id}
-          onMouseEnter={() => group.label && setHoveredGroup(group.id)}
-          onMouseLeave={() => setHoveredGroup(null)}
-        >
+        <div key={group.id}>
           {/* グループセパレーター */}
           {gi > 0 && group.label && (
             <div className="mx-3 my-1 border-t border-border/40" />

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -117,16 +117,12 @@ export const AdminSidebar = memo(function AdminSidebar() {
       items: [
         {
           id: 'private-booking-management', label: '貸切管理', icon: ClipboardCheck,
-          path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'],
+          path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'], badge: pendingCount,
         },
         { id: 'private-booking-groups', label: 'グループ一覧', icon: Users, path: `/${slug}/private-booking-groups`, roles: ['admin', 'license_admin'] },
         {
           id: 'reservations', label: '予約管理', icon: Ticket,
-          path: `/${slug}/reservations`, roles: ['admin', 'license_admin'], badge: pendingCount,
-          subItems: [
-            { id: 'booking-list', label: '予約一覧', path: `/${slug}/reservations?tab=booking-list` },
-            { id: 'pending',      label: '承認待ち', path: `/${slug}/reservations?tab=pending` },
-          ],
+          path: `/${slug}/reservations`, roles: ['admin', 'license_admin'],
         },
       ],
     },
@@ -399,8 +395,17 @@ function SidebarContent({
             </button>
           )}
 
-          {isGroupOpen(group) && (
-            <div className={`space-y-0.5 px-2 pb-1 ${group.label ? 'sidebar-items-enter' : ''}`}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateRows: isGroupOpen(group) ? '1fr' : '0fr',
+              opacity: isGroupOpen(group) ? 1 : 0,
+              transition: 'grid-template-rows 200ms ease-out, opacity 200ms ease-out',
+              pointerEvents: isGroupOpen(group) ? undefined : 'none',
+            }}
+          >
+            <div style={{ overflow: 'hidden', minHeight: 0 }}>
+            <div className="space-y-0.5 px-2 pb-1">
                 {group.items.map(item => {
                   const active = isActive(item)
                   const showSubs = active && item.subItems && item.subItems.length > 0
@@ -456,7 +461,8 @@ function SidebarContent({
                   )
                 })}
             </div>
-          )}
+            </div>
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -6,7 +6,7 @@
  * - ロールベースでメニューをフィルタリング
  */
 import { useState, useMemo, useCallback, useEffect, memo } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useOrganization, checkIsLicenseAdmin } from '@/hooks/useOrganization'
 import { useStoreConfirmationPendingCount } from '@/hooks/useStoreConfirmationPendingCount'
@@ -64,8 +64,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
   const slug = organization?.slug || 'queens-waltz'
 
   const [mobileOpen, setMobileOpen] = useState(false)
-  // ホバー中のカテゴリID
-  const [hoveredGroup, setHoveredGroup] = useState<string | null>(null)
+  const navigate = useNavigate()
 
   // パス変更でモバイルドロワーを閉じる
   useEffect(() => {
@@ -265,37 +264,41 @@ export const AdminSidebar = memo(function AdminSidebar() {
 
   if (!user || user.role === 'customer' || !isAdminPage) return null
 
-  // カテゴリが開いているか（アクティブページが含まれる or ホバー中）
+  // カテゴリが開いているか（アクティブページが含まれる時だけ）
   const isGroupOpen = useCallback((group: typeof visibleGroups[0]) => {
     if (!group.label) return true  // ラベルなし（トップ）は常に表示
-    const hasActive = group.items.some(item => isActive(item))
-    return hasActive || hoveredGroup === group.id
-  }, [isActive, hoveredGroup, visibleGroups])
+    return group.items.some(item => isActive(item))
+  }, [isActive])
+
+  // カテゴリヘッダーをクリック → そのカテゴリの最初のアイテムに遷移
+  const handleGroupClick = useCallback((group: typeof visibleGroups[0]) => {
+    const firstItem = group.items[0]
+    if (firstItem) navigate(firstItem.path)
+  }, [navigate])
 
   const SidebarContent = () => (
     <div className="flex flex-col h-full py-3">
       {visibleGroups.map((group, gi) => (
-        <div
-          key={group.id}
-          onMouseEnter={() => group.label && setHoveredGroup(group.id)}
-          onMouseLeave={() => setHoveredGroup(null)}
-        >
+        <div key={group.id}>
           {/* グループセパレーター */}
           {gi > 0 && group.label && (
             <div className="mx-3 my-1 border-t border-border/40" />
           )}
 
-          {/* カテゴリ見出し（クリック不可、ホバーで展開） */}
+          {/* カテゴリ見出し（クリックで最初のアイテムへ遷移） */}
           {group.label && (
-            <div className="flex items-center justify-between px-3 pt-2 pb-1">
-              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+            <button
+              onClick={() => handleGroupClick(group)}
+              className="w-full flex items-center justify-between px-3 pt-2 pb-1 hover:text-slate-600 transition-colors group"
+            >
+              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400 group-hover:text-slate-600">
                 {group.label}
               </span>
               {isGroupOpen(group)
-                ? <ChevronDown className="w-3 h-3 text-slate-300" />
-                : <ChevronRight className="w-3 h-3 text-slate-300" />
+                ? <ChevronDown className="w-3 h-3 text-slate-300 group-hover:text-slate-500" />
+                : <ChevronRight className="w-3 h-3 text-slate-300 group-hover:text-slate-500" />
               }
-            </div>
+            </button>
           )}
 
           {/* グループアイテム */}

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -112,22 +112,29 @@ export const AdminSidebar = memo(function AdminSidebar() {
     },
     {
       id: 'reservations',
-      label: '予約・顧客',
-      icon: Ticket,
+      label: '貸切・予約',
+      icon: ClipboardCheck,
       items: [
-        {
-          id: 'reservations', label: '予約管理', icon: Ticket,
-          path: `/${slug}/reservations`, roles: ['admin', 'license_admin'], badge: pendingCount,
-          subItems: [
-            { id: 'booking-list', label: '予約一覧',       path: `/${slug}/reservations?tab=booking-list` },
-            { id: 'pending',      label: '承認待ち',       path: `/${slug}/reservations?tab=pending` },
-          ],
-        },
         {
           id: 'private-booking-management', label: '貸切管理', icon: ClipboardCheck,
           path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'],
         },
         { id: 'private-booking-groups', label: 'グループ一覧', icon: Users, path: `/${slug}/private-booking-groups`, roles: ['admin', 'license_admin'] },
+        {
+          id: 'reservations', label: '予約管理', icon: Ticket,
+          path: `/${slug}/reservations`, roles: ['admin', 'license_admin'], badge: pendingCount,
+          subItems: [
+            { id: 'booking-list', label: '予約一覧', path: `/${slug}/reservations?tab=booking-list` },
+            { id: 'pending',      label: '承認待ち', path: `/${slug}/reservations?tab=pending` },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'customers',
+      label: 'アカウント・顧客',
+      icon: UserCog,
+      items: [
         {
           id: 'accounts', label: 'アカウント', icon: UserCog,
           path: `/${slug}/accounts`, roles: ['admin', 'license_admin'],

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -87,6 +87,13 @@ export const AdminSidebar = memo(function AdminSidebar() {
         { id: 'dashboard', label: 'ダッシュボード', icon: LayoutDashboard, path: `/${slug}/dashboard`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'booking', label: '予約サイト', icon: Globe, path: `/${slug}`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'schedule', label: 'スケジュール', icon: CalendarDays, path: `/${slug}/schedule`, roles: ['admin', 'staff', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'schedule-sub',
+      label: 'シフト・GM',
+      icon: CalendarClock,
+      items: [
         { id: 'shift-submission', label: 'シフト提出', icon: CalendarClock, path: `/${slug}/shift-submission`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'gm-availability', label: 'GM確認', icon: UserCheck, path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'staff-profile', label: '担当作品', icon: UserCircle, path: `/${slug}/staff-profile`, roles: ['admin', 'staff', 'license_admin'] },

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -228,9 +228,11 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: 'MMQ運営',
       icon: Shield,
       items: [
-        { id: 'organizations', label: 'テナント管理', icon: Building2, path: `/${slug}/organizations`, roles: ['license_admin'] },
-        { id: 'scenario-masters', label: 'マスタ管理', icon: Shield, path: '/admin/scenario-masters', roles: ['license_admin'] },
-        { id: 'external-reports', label: '外部レポート', icon: FileCheck, path: `/${slug}/external-reports`, roles: ['license_admin'] },
+        { id: 'organizations',     label: 'テナント管理',       icon: Building2, path: `/${slug}/organizations`,     roles: ['license_admin'] },
+        { id: 'scenario-masters',  label: 'マスタ管理',         icon: Shield,    path: '/admin/scenario-masters',     roles: ['license_admin'] },
+        { id: 'external-reports',  label: '外部公演報告',       icon: FileCheck, path: `/${slug}/external-reports`,  roles: ['license_admin'] },
+        { id: 'license-reports',   label: 'ライセンス報告管理', icon: FileCheck, path: `/${slug}/license-reports`,   roles: ['license_admin'] },
+        { id: 'scenario-matcher',  label: 'シナリオマッチャー', icon: Shield,    path: `/${slug}/scenario-matcher`,   roles: ['license_admin'] },
       ],
     },
   ], [slug, pendingCount])

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -319,13 +319,22 @@ export const AdminSidebar = memo(function AdminSidebar() {
           )}
 
           {/* グループアイテム — grid-rows で height:auto アニメーション */}
-          <div className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
-            isGroupOpen(group) ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
-          }`}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateRows: isGroupOpen(group) ? '1fr' : '0fr',
+              opacity: isGroupOpen(group) ? 1 : 0,
+              transition: 'grid-template-rows 280ms ease-out, opacity 220ms ease-out',
+            }}
+          >
             <div className="overflow-hidden">
-            <div className={`space-y-0.5 px-2 pb-1 transition-transform duration-300 ease-out ${
-              isGroupOpen(group) ? 'translate-y-0' : '-translate-y-2'
-            }`}>
+            <div
+              style={{
+                transform: isGroupOpen(group) ? 'translateY(0)' : 'translateY(-6px)',
+                transition: 'transform 280ms ease-out',
+              }}
+              className="space-y-0.5 px-2 pb-1"
+            >
               {group.items.map(item => {
                 const active = isActive(item)
                 const showSubs = active && item.subItems && item.subItems.length > 0

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -305,10 +305,11 @@ export const AdminSidebar = memo(function AdminSidebar() {
             </button>
           )}
 
-          {/* グループアイテム */}
-          <div className={`overflow-hidden transition-[max-height,opacity] duration-300 ease-out ${
-            isGroupOpen(group) ? 'max-h-[600px] opacity-100' : 'max-h-0 opacity-0'
+          {/* グループアイテム — grid-rows で height:auto アニメーション */}
+          <div className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
+            isGroupOpen(group) ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
           }`}>
+            <div className="overflow-hidden">
             <div className={`space-y-0.5 px-2 pb-1 transition-transform duration-300 ease-out ${
               isGroupOpen(group) ? 'translate-y-0' : '-translate-y-2'
             }`}>
@@ -368,6 +369,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
                   </div>
                 )
               })}
+            </div>
             </div>
           </div>
         </div>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -18,6 +18,14 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
+type SubItem = {
+  id: string
+  label: string
+  path: string           // ?tab=xxx 付きURL
+  roles?: string[]
+  sectionLabel?: string  // 直前にセクション区切りを入れる場合のラベル
+}
+
 type NavItem = {
   id: string
   label: string
@@ -25,6 +33,7 @@ type NavItem = {
   path: string
   roles: string[]
   badge?: number
+  subItems?: SubItem[]   // そのページにいる時だけ展開表示
 }
 
 type NavGroup = {
@@ -95,7 +104,15 @@ export const AdminSidebar = memo(function AdminSidebar() {
       icon: CalendarClock,
       items: [
         { id: 'shift-submission', label: 'シフト提出', icon: CalendarClock, path: `/${slug}/shift-submission`, roles: ['admin', 'staff', 'license_admin'] },
-        { id: 'gm-availability', label: 'GM確認', icon: UserCheck, path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'] },
+        {
+          id: 'gm-availability', label: 'GM確認', icon: UserCheck,
+          path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'],
+          subItems: [
+            { id: 'gm-list', label: 'GM確認一覧', path: `/${slug}/gm-availability?tab=gm-list` },
+            { id: 'pending', label: '承認待ち',    path: `/${slug}/gm-availability?tab=pending` },
+            { id: 'schedule', label: 'スケジュール', path: `/${slug}/gm-availability?tab=schedule` },
+          ],
+        },
         { id: 'staff-profile', label: '担当作品', icon: UserCircle, path: `/${slug}/staff-profile`, roles: ['admin', 'staff', 'license_admin'] },
       ],
     },
@@ -104,9 +121,33 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: '予約・顧客',
       icon: Ticket,
       items: [
-        { id: 'reservations', label: '予約管理', icon: Ticket, path: `/${slug}/reservations`, roles: ['admin', 'license_admin'], badge: pendingCount },
-        { id: 'private-booking-management', label: '貸切管理', icon: ClipboardCheck, path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'] },
-        { id: 'accounts', label: 'アカウント', icon: UserCog, path: `/${slug}/accounts`, roles: ['admin', 'license_admin'] },
+        {
+          id: 'reservations', label: '予約管理', icon: Ticket,
+          path: `/${slug}/reservations`, roles: ['admin', 'license_admin'], badge: pendingCount,
+          subItems: [
+            { id: 'booking-list', label: '予約一覧',       path: `/${slug}/reservations?tab=booking-list` },
+            { id: 'pending',      label: '承認待ち',       path: `/${slug}/reservations?tab=pending` },
+          ],
+        },
+        {
+          id: 'private-booking-management', label: '貸切管理', icon: ClipboardCheck,
+          path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'],
+          subItems: [
+            { id: 'booking-list', label: '貸切一覧',   path: `/${slug}/private-booking-management?tab=booking-list` },
+            { id: 'groups',       label: 'グループ',   path: `/${slug}/private-booking-management?tab=groups` },
+            { id: 'pending',      label: '承認待ち',   path: `/${slug}/private-booking-management?tab=pending` },
+            { id: 'approved',     label: '承認済み',   path: `/${slug}/private-booking-management?tab=approved` },
+            { id: 'settings',     label: '設定',       path: `/${slug}/private-booking-management?tab=settings` },
+          ],
+        },
+        {
+          id: 'accounts', label: 'アカウント', icon: UserCog,
+          path: `/${slug}/accounts`, roles: ['admin', 'license_admin'],
+          subItems: [
+            { id: 'users',     label: 'ユーザー', path: `/${slug}/accounts?tab=users` },
+            { id: 'customers', label: '顧客',     path: `/${slug}/accounts?tab=customers` },
+          ],
+        },
         { id: 'coupons', label: 'クーポン', icon: Gift, path: `/${slug}/coupons`, roles: ['admin', 'license_admin'] },
       ],
     },
@@ -116,8 +157,8 @@ export const AdminSidebar = memo(function AdminSidebar() {
       icon: BookOpen,
       items: [
         { id: 'scenarios', label: 'シナリオ', icon: BookOpen, path: `/${slug}/scenarios`, roles: ['admin', 'staff', 'license_admin'] },
-        { id: 'blog', label: 'ブログ', icon: FileText, path: `/${slug}/blog`, roles: ['admin', 'license_admin'] },
-        { id: 'manual', label: 'マニュアル', icon: HelpCircle, path: `/${slug}/manual`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'blog',      label: 'ブログ',   icon: FileText, path: `/${slug}/blog`,      roles: ['admin', 'license_admin'] },
+        { id: 'manual',    label: 'マニュアル', icon: HelpCircle, path: `/${slug}/manual`, roles: ['admin', 'staff', 'license_admin'] },
       ],
     },
     {
@@ -125,9 +166,30 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: '売上・管理',
       icon: TrendingUp,
       items: [
-        { id: 'sales', label: '売上', icon: TrendingUp, path: `/${slug}/sales`, roles: ['admin', 'license_admin'] },
-        { id: 'license-management', label: '公演報告', icon: FileCheck, path: `/${slug}/license-management`, roles: ['admin', 'staff', 'license_admin'] },
-        { id: 'email-history', label: 'メール配信履歴', icon: Mail, path: `/${slug}/settings?tab=email-history`, roles: ['admin', 'license_admin'] },
+        {
+          id: 'sales', label: '売上', icon: TrendingUp,
+          path: `/${slug}/sales`, roles: ['admin', 'license_admin'],
+          subItems: [
+            { id: 'overview',             label: '売上概要',       path: `/${slug}/sales?tab=overview` },
+            { id: 'annual-analysis',      label: '年間分析',       path: `/${slug}/sales?tab=annual-analysis` },
+            { id: 'scenario-performance', label: 'シナリオ別',     path: `/${slug}/sales?tab=scenario-performance` },
+            { id: 'open-event-analysis',  label: '公演分析',       path: `/${slug}/sales?tab=open-event-analysis` },
+            { id: 'external-sales',       label: '外部売上',       path: `/${slug}/sales?tab=external-sales` },
+            { id: 'misc-transactions',    label: '雑収支管理',     path: `/${slug}/sales?tab=misc-transactions` },
+            { id: 'franchise-sales',      label: 'フランチャイズ', path: `/${slug}/sales?tab=franchise-sales` },
+            { id: 'staff-salary-report',  label: 'スタッフ報酬',   path: `/${slug}/sales?tab=staff-salary-report` },
+            { id: 'salary-calculation',   label: '給与計算',       path: `/${slug}/sales?tab=salary-calculation` },
+          ],
+        },
+        {
+          id: 'license-management', label: '公演報告', icon: FileCheck,
+          path: `/${slug}/license-management`, roles: ['admin', 'staff', 'license_admin'],
+          subItems: [
+            { id: 'send',     label: '公演報告', path: `/${slug}/license-management?tab=send` },
+            { id: 'received', label: '受信',     path: `/${slug}/license-management?tab=received`, roles: ['license_admin'] },
+            { id: 'summary',  label: '集計',     path: `/${slug}/license-management?tab=summary`,  roles: ['license_admin'] },
+          ],
+        },
       ],
     },
     {
@@ -135,9 +197,35 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: '設定',
       icon: Settings,
       items: [
-        { id: 'stores', label: '店舗', icon: Store, path: `/${slug}/stores`, roles: ['admin', 'license_admin'] },
-        { id: 'staff', label: 'スタッフ', icon: Users, path: `/${slug}/staff`, roles: ['admin', 'license_admin'] },
-        { id: 'settings', label: '設定', icon: Settings, path: `/${slug}/settings`, roles: ['admin', 'license_admin'] },
+        { id: 'stores', label: '店舗',   icon: Store, path: `/${slug}/stores`, roles: ['admin', 'license_admin'] },
+        { id: 'staff',  label: 'スタッフ', icon: Users, path: `/${slug}/staff`,  roles: ['admin', 'license_admin'] },
+        {
+          id: 'settings', label: '設定', icon: Settings,
+          path: `/${slug}/settings`, roles: ['admin', 'license_admin'],
+          subItems: [
+            // 組織設定
+            { id: 'organization-info',    label: '組織情報',       path: `/${slug}/settings?tab=organization-info` },
+            { id: 'organization-design',  label: '組織デザイン',   path: `/${slug}/settings?tab=organization-design` },
+            { id: 'faq',                  label: 'FAQ設定',        path: `/${slug}/settings?tab=faq` },
+            { id: 'blog',                 label: 'ブログ・お知らせ', path: `/${slug}/settings?tab=blog` },
+            { id: 'general',              label: '全体設定',       path: `/${slug}/settings?tab=general` },
+            // 店舗別設定
+            { id: 'store-basic',          label: '店舗基本設定',   path: `/${slug}/settings?tab=store-basic`,          sectionLabel: '店舗別設定' },
+            { id: 'business-hours',       label: '営業時間',       path: `/${slug}/settings?tab=business-hours` },
+            { id: 'performance-schedule', label: '公演スケジュール', path: `/${slug}/settings?tab=performance-schedule` },
+            { id: 'reservation',          label: '予約設定',       path: `/${slug}/settings?tab=reservation` },
+            { id: 'cancellation',         label: 'キャンセル設定', path: `/${slug}/settings?tab=cancellation` },
+            { id: 'pricing',              label: '料金設定',       path: `/${slug}/settings?tab=pricing` },
+            { id: 'salary',               label: '報酬',           path: `/${slug}/settings?tab=salary` },
+            { id: 'staff-setting',        label: 'スタッフ設定',   path: `/${slug}/settings?tab=staff` },
+            { id: 'email',                label: 'メール設定',     path: `/${slug}/settings?tab=email` },
+            { id: 'notifications',        label: '通知設定',       path: `/${slug}/settings?tab=notifications` },
+            { id: 'booking-notice',       label: '注意事項設定',   path: `/${slug}/settings?tab=booking-notice` },
+            { id: 'categories',           label: 'カテゴリ・作者', path: `/${slug}/settings?tab=categories` },
+            { id: 'system',               label: 'システム設定',   path: `/${slug}/settings?tab=system` },
+            { id: 'data',                 label: 'データ管理',     path: `/${slug}/settings?tab=data` },
+          ],
+        },
       ],
     },
     {
@@ -165,23 +253,28 @@ export const AdminSidebar = memo(function AdminSidebar() {
     })).filter(group => group.items.length > 0)
   }, [NAV_GROUPS, user, isLicAdmin])
 
-  // アクティブ判定
+  // アクティブ判定（ページレベル）
   const isActive = useCallback((item: NavItem) => {
-    const { pathname, search } = location
+    const { pathname } = location
     if (item.id === 'booking') {
       return pathname === `/${slug}` || (
         pathname.startsWith(`/${slug}/`) &&
         !ADMIN_PATH_SEGMENTS.some(seg => pathname.includes(`/${seg}`))
       )
     }
-    if (item.id === 'email-history') {
-      return pathname.includes('/settings') && new URLSearchParams(search).get('tab') === 'email-history'
-    }
-    if (item.id === 'settings') {
-      return pathname.includes('/settings') && new URLSearchParams(search).get('tab') !== 'email-history'
-    }
-    return pathname.includes(`/${item.id}`) || pathname.startsWith(item.path)
+    const basePath = item.path.split('?')[0]
+    return pathname === basePath || pathname.startsWith(basePath + '/')
   }, [location, slug])
+
+  // サブアイテムのアクティブ判定
+  const isSubActive = useCallback((sub: SubItem) => {
+    const { pathname, search } = location
+    const [basePath, query] = sub.path.split('?')
+    if (!query) return pathname === basePath
+    const tabParam = new URLSearchParams(query).get('tab')
+    const currentTab = new URLSearchParams(search).get('tab')
+    return pathname === basePath && currentTab === tabParam
+  }, [location])
 
   // 管理ページかどうか
   const isAdminPage = ADMIN_PATH_SEGMENTS.some(seg => location.pathname.includes(`/${seg}`))
@@ -216,23 +309,58 @@ export const AdminSidebar = memo(function AdminSidebar() {
             <div className="space-y-0.5 px-2">
               {group.items.map(item => {
                 const active = isActive(item)
+                const showSubs = active && item.subItems && item.subItems.length > 0
+                // サブアイテムのロールフィルタリング
+                const visibleSubs = showSubs
+                  ? item.subItems!.filter(s =>
+                      !s.roles || s.roles.includes(user!.role) || (isLicAdmin && s.roles.includes('license_admin'))
+                    )
+                  : []
                 return (
-                  <Link
-                    key={item.id}
-                    to={item.path}
-                    className={`relative flex items-center px-2 py-1.5 rounded-md text-sm transition-colors ${
-                      active
-                        ? 'bg-primary/10 text-primary font-medium'
-                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-                    }`}
-                  >
-                    <span className="truncate">{item.label}</span>
-                    {item.badge != null && item.badge > 0 && (
-                      <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">
-                        {item.badge > 99 ? '99+' : item.badge}
-                      </span>
+                  <div key={item.id}>
+                    <Link
+                      to={item.path}
+                      className={`relative flex items-center px-2 py-1.5 rounded-md text-sm transition-colors ${
+                        active
+                          ? 'bg-primary/10 text-primary font-medium'
+                          : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                      }`}
+                    >
+                      <span className="truncate">{item.label}</span>
+                      {item.badge != null && item.badge > 0 && (
+                        <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">
+                          {item.badge > 99 ? '99+' : item.badge}
+                        </span>
+                      )}
+                    </Link>
+                    {/* サブアイテム（そのページにいる時だけ展開） */}
+                    {showSubs && visibleSubs.length > 0 && (
+                      <div className="ml-3 pl-2 border-l border-border/60 space-y-0.5 mt-0.5 mb-1">
+                        {visibleSubs.map(sub => {
+                          const subActive = isSubActive(sub)
+                          return (
+                            <div key={sub.id}>
+                              {sub.sectionLabel && (
+                                <p className="text-[10px] font-semibold text-muted-foreground/60 px-2 pt-2 pb-0.5 uppercase tracking-wide">
+                                  {sub.sectionLabel}
+                                </p>
+                              )}
+                              <Link
+                                to={sub.path}
+                                className={`flex items-center px-2 py-1 rounded-md text-xs transition-colors ${
+                                  subActive
+                                    ? 'text-primary font-medium bg-primary/5'
+                                    : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                                }`}
+                              >
+                                <span className="truncate">{sub.label}</span>
+                              </Link>
+                            </div>
+                          )
+                        })}
+                      </div>
                     )}
-                  </Link>
+                  </div>
                 )
               })}
             </div>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -351,6 +351,86 @@ export const AdminSidebar = memo(function AdminSidebar() {
 })
 
 // ─── 外部コンポーネント（毎レンダーで再マウントしないよう AdminSidebar の外に定義） ───
+// グループのアイテムリスト。マウント時だけアニメーション、同グループ内ナビでは再生しない
+function GroupPanel({
+  group, isOpen, isActive, isSubActive, userRole, isLicAdmin,
+}: {
+  group: NavGroup & { items: NavItem[] }
+  isOpen: boolean
+  isActive: (item: NavItem) => boolean
+  isSubActive: (sub: SubItem) => boolean
+  userRole: string
+  isLicAdmin: boolean
+}) {
+  const [animate, setAnimate] = useState(!!group.label)
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className={animate ? 'sidebar-items-enter' : ''}
+      onAnimationEnd={() => setAnimate(false)}
+    >
+      <div className="space-y-0.5 px-2 pb-1">
+        {group.items.map(item => {
+          const active = isActive(item)
+          const showSubs = active && item.subItems && item.subItems.length > 0
+          const visibleSubs = showSubs
+            ? item.subItems!.filter(s =>
+                !s.roles || s.roles.includes(userRole) || (isLicAdmin && s.roles.includes('license_admin'))
+              )
+            : []
+          return (
+            <div key={item.id}>
+              <Link
+                to={item.path}
+                className={`relative flex items-center px-3 py-2 text-sm transition-all duration-150 ${
+                  active
+                    ? 'bg-blue-50 text-blue-700 font-medium'
+                    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 hover:translate-x-0.5'
+                }`}
+              >
+                <span className="truncate">{item.label}</span>
+                {item.badge != null && item.badge > 0 && (
+                  <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">
+                    {item.badge > 99 ? '99+' : item.badge}
+                  </span>
+                )}
+              </Link>
+              {showSubs && visibleSubs.length > 0 && (
+                <div className="ml-3 pl-2 border-l border-border/60 space-y-0.5 mt-0.5 mb-1">
+                  {visibleSubs.map(sub => {
+                    const subActive = isSubActive(sub)
+                    return (
+                      <div key={sub.id}>
+                        {sub.sectionLabel && (
+                          <p className="text-[10px] font-semibold text-muted-foreground/60 px-2 pt-2 pb-0.5 uppercase tracking-wide">
+                            {sub.sectionLabel}
+                          </p>
+                        )}
+                        <Link
+                          to={sub.path}
+                          className={`flex items-center px-2 py-1.5 text-xs transition-colors ${
+                            subActive
+                              ? 'bg-blue-50 text-blue-700 font-medium'
+                              : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
+                          }`}
+                        >
+                          <span className="truncate">{sub.label}</span>
+                        </Link>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 function SidebarContent({
   slug, bookingActive, visibleGroups,
   isGroupOpen, isActive, isSubActive,
@@ -395,66 +475,14 @@ function SidebarContent({
             </button>
           )}
 
-          {isGroupOpen(group) && (
-            <div className={group.label ? 'sidebar-items-enter' : ''}>
-            <div className="space-y-0.5 px-2 pb-1">
-                {group.items.map(item => {
-                  const active = isActive(item)
-                  const showSubs = active && item.subItems && item.subItems.length > 0
-                  const visibleSubs = showSubs
-                    ? item.subItems!.filter(s =>
-                        !s.roles || s.roles.includes(userRole) || (isLicAdmin && s.roles.includes('license_admin'))
-                      )
-                    : []
-                  return (
-                    <div key={item.id}>
-                      <Link
-                        to={item.path}
-                        className={`relative flex items-center px-3 py-2 text-sm transition-all duration-150 ${
-                          active
-                            ? 'bg-blue-50 text-blue-700 font-medium'
-                            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 hover:translate-x-0.5'
-                        }`}
-                      >
-                        <span className="truncate">{item.label}</span>
-                        {item.badge != null && item.badge > 0 && (
-                          <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">
-                            {item.badge > 99 ? '99+' : item.badge}
-                          </span>
-                        )}
-                      </Link>
-                      {showSubs && visibleSubs.length > 0 && (
-                        <div className="ml-3 pl-2 border-l border-border/60 space-y-0.5 mt-0.5 mb-1">
-                          {visibleSubs.map(sub => {
-                            const subActive = isSubActive(sub)
-                            return (
-                              <div key={sub.id}>
-                                {sub.sectionLabel && (
-                                  <p className="text-[10px] font-semibold text-muted-foreground/60 px-2 pt-2 pb-0.5 uppercase tracking-wide">
-                                    {sub.sectionLabel}
-                                  </p>
-                                )}
-                                <Link
-                                  to={sub.path}
-                                  className={`flex items-center px-2 py-1.5 text-xs transition-colors ${
-                                    subActive
-                                      ? 'bg-blue-50 text-blue-700 font-medium'
-                                      : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
-                                  }`}
-                                >
-                                  <span className="truncate">{sub.label}</span>
-                                </Link>
-                              </div>
-                            )
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
-            </div>
-            </div>
-          )}
+          <GroupPanel
+            group={group}
+            isOpen={isGroupOpen(group)}
+            isActive={isActive}
+            isSubActive={isSubActive}
+            userRole={userRole}
+            isLicAdmin={isLicAdmin}
+          />
         </div>
       ))}
     </div>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -127,11 +127,11 @@ export const AdminSidebar = memo(function AdminSidebar() {
           id: 'private-booking-management', label: '貸切管理', icon: ClipboardCheck,
           path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'],
           subItems: [
-            { id: 'booking-list', label: '貸切一覧',   path: `/${slug}/private-booking-management?tab=booking-list` },
-            { id: 'groups',       label: 'グループ',   path: `/${slug}/private-booking-management?tab=groups` },
-            { id: 'pending',      label: '承認待ち',   path: `/${slug}/private-booking-management?tab=pending` },
-            { id: 'approved',     label: '承認済み',   path: `/${slug}/private-booking-management?tab=approved` },
-            { id: 'settings',     label: '設定',       path: `/${slug}/private-booking-management?tab=settings` },
+            { id: 'store_pending', label: '店舗承認待ち', path: `/${slug}/private-booking-management?tab=store_pending` },
+            { id: 'gm_pending',    label: 'GM確認中',     path: `/${slug}/private-booking-management?tab=gm_pending` },
+            { id: 'all',           label: 'すべて',       path: `/${slug}/private-booking-management?tab=all` },
+            { id: 'rejected',      label: '却下済み',     path: `/${slug}/private-booking-management?tab=rejected` },
+            { id: 'groups',        label: 'グループ一覧', path: `/${slug}/private-booking-management?tab=groups` },
           ],
         },
         {

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -395,16 +395,8 @@ function SidebarContent({
             </button>
           )}
 
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateRows: isGroupOpen(group) ? '1fr' : '0fr',
-              opacity: isGroupOpen(group) ? 1 : 0,
-              transition: 'grid-template-rows 200ms ease-out, opacity 200ms ease-out',
-              pointerEvents: isGroupOpen(group) ? undefined : 'none',
-            }}
-          >
-            <div style={{ overflow: 'hidden', minHeight: 0 }}>
+          {isGroupOpen(group) && (
+            <div className={group.label ? 'sidebar-items-enter' : ''}>
             <div className="space-y-0.5 px-2 pb-1">
                 {group.items.map(item => {
                   const active = isActive(item)
@@ -462,7 +454,7 @@ function SidebarContent({
                 })}
             </div>
             </div>
-          </div>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -198,6 +198,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
           path: `/${slug}/settings`, roles: ['admin', 'license_admin'],
           subItems: [
             // 組織設定
+            { id: 'tenant-management',    label: 'テナント管理',   path: `/${slug}/settings?tab=tenant-management`, roles: ['license_admin'] },
             { id: 'organization-info',    label: '組織情報',       path: `/${slug}/settings?tab=organization-info` },
             { id: 'organization-design',  label: '組織デザイン',   path: `/${slug}/settings?tab=organization-design` },
             { id: 'faq',                  label: 'FAQ設定',        path: `/${slug}/settings?tab=faq` },

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -395,16 +395,8 @@ function SidebarContent({
             </button>
           )}
 
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateRows: isGroupOpen(group) ? '1fr' : '0fr',
-              transition: 'grid-template-rows 300ms ease-out',
-            }}
-          >
-            {/* min-height:0 が必須 — これがないと 0fr まで縮まらない */}
-            <div style={{ minHeight: 0, overflow: 'hidden' }}>
-              <div className="space-y-0.5 px-2 pb-1">
+          {isGroupOpen(group) && (
+            <div className="sidebar-items-enter space-y-0.5 px-2 pb-1">
                 {group.items.map(item => {
                   const active = isActive(item)
                   const showSubs = active && item.subItems && item.subItems.length > 0
@@ -459,9 +451,8 @@ function SidebarContent({
                     </div>
                   )
                 })}
-              </div>
             </div>
-          </div>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -294,7 +294,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
           {group.label && (
             <button
               onClick={() => toggleGroup(group.id)}
-              className="w-full flex items-center justify-between px-3 py-1.5 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors"
+              className="w-full flex items-center justify-between px-3 py-1.5 text-xs font-semibold text-slate-400 hover:text-slate-700 transition-colors"
             >
               <span>{group.label}</span>
               {openGroups[group.id]
@@ -320,10 +320,10 @@ export const AdminSidebar = memo(function AdminSidebar() {
                   <div key={item.id}>
                     <Link
                       to={item.path}
-                      className={`relative flex items-center px-2 py-1.5 rounded-md text-sm transition-colors ${
+                      className={`relative flex items-center px-3 py-2 text-sm transition-colors ${
                         active
-                          ? 'bg-primary/10 text-primary font-medium'
-                          : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                          ? 'bg-blue-50 text-blue-700 font-medium'
+                          : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
                       }`}
                     >
                       <span className="truncate">{item.label}</span>
@@ -347,10 +347,10 @@ export const AdminSidebar = memo(function AdminSidebar() {
                               )}
                               <Link
                                 to={sub.path}
-                                className={`flex items-center px-2 py-1 rounded-md text-xs transition-colors ${
+                                className={`flex items-center px-2 py-1.5 text-xs transition-colors ${
                                   subActive
-                                    ? 'text-primary font-medium bg-primary/5'
-                                    : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                                    ? 'bg-blue-50 text-blue-700 font-medium'
+                                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
                                 }`}
                               >
                                 <span className="truncate">{sub.label}</span>

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -341,8 +341,10 @@ export const AdminSidebar = memo(function AdminSidebar() {
   )
 })
 
-// ─── 外部コンポーネント（毎レンダーで再マウントしないよう AdminSidebar の外に定義） ───
-// グループのアイテムリスト。マウント時だけアニメーション、同グループ内ナビでは再生しない
+// ページ遷移ごとに AdminSidebar が再マウントされるため、モジュールスコープで
+// 直前のアクティブグループIDを保持する（再マウントを超えて永続）
+const lastActiveGroupId = { current: '' }
+
 function GroupPanel({
   group, isOpen, isActive, isSubActive, userRole, isLicAdmin,
 }: {
@@ -353,22 +355,23 @@ function GroupPanel({
   userRole: string
   isLicAdmin: boolean
 }) {
-  const divRef = useRef<HTMLDivElement>(null)
-  const prevIsOpenRef = useRef(isOpen) // マウント時の値で初期化
+  // マウント時点でこのグループが既にアクティブだったか（同カテゴリ内ナビ）
+  const alreadyActive = isOpen && !!group.label && lastActiveGroupId.current === group.id
+  if (isOpen && group.label) lastActiveGroupId.current = group.id
 
-  // isOpen が false→true になった瞬間だけ DOM 直接操作でアニメーションをリスタート
-  // React の style/class 再適用に依存しないため確実に動作する
+  const divRef = useRef<HTMLDivElement>(null)
+
   useLayoutEffect(() => {
-    const wasOpen = prevIsOpenRef.current
-    prevIsOpenRef.current = isOpen
-    if (!group.label || !divRef.current) return
-    if (!wasOpen && isOpen) {
-      const el = divRef.current
-      el.style.animationName = 'none'
-      void el.getBoundingClientRect() // reflow を強制してアニメーションをリセット
+    const el = divRef.current
+    if (!el || !group.label) return
+    // 常に CSS 自動アニメーションを止め、必要なときだけ手動リスタート
+    el.style.animationName = 'none'
+    if (!alreadyActive) {
+      void el.getBoundingClientRect()
       el.style.animationName = ''
     }
-  })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // マウント時のみ実行
 
   return (
     <div

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -5,7 +5,7 @@
  * - モバイルはハンバーガー → ドロワー
  * - ロールベースでメニューをフィルタリング
  */
-import { useState, useLayoutEffect, useRef, useMemo, useCallback, useEffect, memo } from 'react'
+import { useState, useMemo, useCallback, useEffect, memo } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useOrganization, checkIsLicenseAdmin } from '@/hooks/useOrganization'
@@ -98,15 +98,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
       icon: CalendarClock,
       items: [
         { id: 'shift-submission', label: 'シフト提出', icon: CalendarClock, path: `/${slug}/shift-submission`, roles: ['admin', 'staff', 'license_admin'] },
-        {
-          id: 'gm-availability', label: 'GM確認', icon: UserCheck,
-          path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'],
-          subItems: [
-            { id: 'gm-list', label: 'GM確認一覧', path: `/${slug}/gm-availability?tab=gm-list` },
-            { id: 'pending', label: '承認待ち',    path: `/${slug}/gm-availability?tab=pending` },
-            { id: 'schedule', label: 'スケジュール', path: `/${slug}/gm-availability?tab=schedule` },
-          ],
-        },
+        { id: 'gm-availability', label: 'GM確認', icon: UserCheck, path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'staff-profile', label: '担当作品', icon: UserCircle, path: `/${slug}/staff-profile`, roles: ['admin', 'staff', 'license_admin'] },
       ],
     },
@@ -362,21 +354,13 @@ function GroupPanel({
   userRole: string
   isLicAdmin: boolean
 }) {
-  const [animate, setAnimate] = useState(false)
-  const prevIsOpenRef = useRef(false)
-
-  // isOpen が false→true になった瞬間だけ animate=true にする
-  useLayoutEffect(() => {
-    if (isOpen && !prevIsOpenRef.current && group.label) setAnimate(true)
-    prevIsOpenRef.current = isOpen
-  })
-
-  if (!isOpen) return null
+  // display:none→blockでCSSアニメーションが自動リスタートする仕様を利用
+  // 同グループ内ナビでは display が変わらないのでアニメーション再発なし
 
   return (
     <div
-      className={animate ? 'sidebar-items-enter' : ''}
-      onAnimationEnd={() => setAnimate(false)}
+      className={group.label ? 'sidebar-items-enter' : ''}
+      style={group.label ? { display: isOpen ? 'block' : 'none' } : undefined}
     >
       <div className="space-y-0.5 px-2 pb-1">
         {group.items.map(item => {

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -59,7 +59,7 @@ type NavGroup = {
 // 管理サイトのパス判定用
 const ADMIN_PATH_SEGMENTS = [
   'dashboard', 'stores', 'staff', 'scenarios', 'schedule',
-  'shift-submission', 'gm-availability', 'private-booking-management',
+  'shift-submission', 'gm-availability', 'private-booking-management', 'private-booking-groups',
   'reservations', 'accounts', 'sales', 'settings', 'manual',
   'staff-profile', 'license-management', 'coupons', 'blog',
   'organizations', 'external-reports', 'scenario-masters',
@@ -126,14 +126,8 @@ export const AdminSidebar = memo(function AdminSidebar() {
         {
           id: 'private-booking-management', label: '貸切管理', icon: ClipboardCheck,
           path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'],
-          subItems: [
-            { id: 'store_pending', label: '店舗承認待ち', path: `/${slug}/private-booking-management?tab=store_pending` },
-            { id: 'gm_pending',    label: 'GM確認中',     path: `/${slug}/private-booking-management?tab=gm_pending` },
-            { id: 'all',           label: 'すべて',       path: `/${slug}/private-booking-management?tab=all` },
-            { id: 'rejected',      label: '却下済み',     path: `/${slug}/private-booking-management?tab=rejected` },
-            { id: 'groups',        label: 'グループ一覧', path: `/${slug}/private-booking-management?tab=groups` },
-          ],
         },
+        { id: 'private-booking-groups', label: 'グループ一覧', icon: Users, path: `/${slug}/private-booking-groups`, roles: ['admin', 'license_admin'] },
         {
           id: 'accounts', label: 'アカウント', icon: UserCog,
           path: `/${slug}/accounts`, roles: ['admin', 'license_admin'],

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -64,24 +64,8 @@ export const AdminSidebar = memo(function AdminSidebar() {
   const slug = organization?.slug || 'queens-waltz'
 
   const [mobileOpen, setMobileOpen] = useState(false)
-  // 展開状態: localStorage に永続化
-  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
-    try {
-      const stored = localStorage.getItem('admin-sidebar-open-groups')
-      return stored ? JSON.parse(stored) : { schedule: true }
-    } catch {
-      return { schedule: true }
-    }
-  })
-
-  const persistOpenGroups = useCallback((next: Record<string, boolean>) => {
-    setOpenGroups(next)
-    localStorage.setItem('admin-sidebar-open-groups', JSON.stringify(next))
-  }, [])
-
-  const toggleGroup = useCallback((groupId: string) => {
-    persistOpenGroups({ ...openGroups, [groupId]: !openGroups[groupId] })
-  }, [openGroups, persistOpenGroups])
+  // ホバー中のカテゴリID
+  const [hoveredGroup, setHoveredGroup] = useState<string | null>(null)
 
   // パス変更でモバイルドロワーを閉じる
   useEffect(() => {
@@ -281,31 +265,41 @@ export const AdminSidebar = memo(function AdminSidebar() {
 
   if (!user || user.role === 'customer' || !isAdminPage) return null
 
+  // カテゴリが開いているか（アクティブページが含まれる or ホバー中）
+  const isGroupOpen = useCallback((group: typeof visibleGroups[0]) => {
+    if (!group.label) return true  // ラベルなし（トップ）は常に表示
+    const hasActive = group.items.some(item => isActive(item))
+    return hasActive || hoveredGroup === group.id
+  }, [isActive, hoveredGroup, visibleGroups])
+
   const SidebarContent = () => (
     <div className="flex flex-col h-full py-3">
       {visibleGroups.map((group, gi) => (
-        <div key={group.id}>
+        <div
+          key={group.id}
+          onMouseEnter={() => group.label && setHoveredGroup(group.id)}
+          onMouseLeave={() => setHoveredGroup(null)}
+        >
           {/* グループセパレーター */}
           {gi > 0 && group.label && (
-            <div className="mx-3 my-1 border-t border-border/50" />
+            <div className="mx-3 my-1 border-t border-border/40" />
           )}
 
-          {/* グループヘッダー（折り畳みボタン） */}
+          {/* カテゴリ見出し（クリック不可、ホバーで展開） */}
           {group.label && (
-            <button
-              onClick={() => toggleGroup(group.id)}
-              className="w-full flex items-center justify-between px-3 py-1.5 text-xs font-semibold text-slate-400 hover:text-slate-700 transition-colors"
-            >
-              <span>{group.label}</span>
-              {openGroups[group.id]
-                ? <ChevronDown className="w-3 h-3" />
-                : <ChevronRight className="w-3 h-3" />
+            <div className="flex items-center justify-between px-3 pt-2 pb-1">
+              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+                {group.label}
+              </span>
+              {isGroupOpen(group)
+                ? <ChevronDown className="w-3 h-3 text-slate-300" />
+                : <ChevronRight className="w-3 h-3 text-slate-300" />
               }
-            </button>
+            </div>
           )}
 
           {/* グループアイテム */}
-          {(group.label === null || openGroups[group.id]) && (
+          {isGroupOpen(group) && (
             <div className="space-y-0.5 px-2">
               {group.items.map(item => {
                 const active = isActive(item)

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -104,6 +104,16 @@ export const AdminSidebar = memo(function AdminSidebar() {
       ],
     },
     {
+      id: 'basic-data',
+      label: '基本データ',
+      icon: Store,
+      items: [
+        { id: 'stores',    label: '店舗',     icon: Store,    path: `/${slug}/stores`,    roles: ['admin', 'license_admin'] },
+        { id: 'staff',     label: 'スタッフ', icon: Users,    path: `/${slug}/staff`,     roles: ['admin', 'license_admin'] },
+        { id: 'scenarios', label: 'シナリオ', icon: BookOpen, path: `/${slug}/scenarios`, roles: ['admin', 'staff', 'license_admin'] },
+      ],
+    },
+    {
       id: 'reservations',
       label: '貸切・予約',
       icon: ClipboardCheck,
@@ -133,8 +143,7 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: 'コンテンツ',
       icon: BookOpen,
       items: [
-        { id: 'scenarios', label: 'シナリオ', icon: BookOpen, path: `/${slug}/scenarios`, roles: ['admin', 'staff', 'license_admin'] },
-        { id: 'blog',      label: 'ブログ',   icon: FileText, path: `/${slug}/blog`,      roles: ['admin', 'license_admin'] },
+        { id: 'blog', label: 'ブログ', icon: FileText, path: `/${slug}/blog`, roles: ['admin', 'license_admin'] },
       ],
     },
     {
@@ -201,8 +210,6 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: '設定',
       icon: Settings,
       items: [
-        { id: 'stores', label: '店舗',   icon: Store, path: `/${slug}/stores`, roles: ['admin', 'license_admin'] },
-        { id: 'staff',  label: 'スタッフ', icon: Users, path: `/${slug}/staff`,  roles: ['admin', 'license_admin'] },
         {
           id: 'settings', label: '設定', icon: Settings,
           path: `/${slug}/settings`, roles: ['admin', 'license_admin'],

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -77,7 +77,6 @@ export const AdminSidebar = memo(function AdminSidebar() {
       label: null,
       items: [
         { id: 'dashboard', label: 'ダッシュボード', icon: LayoutDashboard, path: `/${slug}/dashboard`, roles: ['admin', 'staff', 'license_admin'] },
-        { id: 'booking', label: '予約サイト', icon: Globe, path: `/${slug}`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'schedule', label: 'スケジュール', icon: CalendarDays, path: `/${slug}/schedule`, roles: ['admin', 'staff', 'license_admin'] },
       ],
     },
@@ -276,8 +275,27 @@ export const AdminSidebar = memo(function AdminSidebar() {
     if (firstItem) navigate(firstItem.path)
   }, [navigate])
 
+  const bookingActive = isActive({ id: 'booking', label: '予約サイト', icon: Globe, path: `/${slug}`, roles: [] })
+
   const SidebarContent = () => (
-    <div className="flex flex-col h-full py-3">
+    <div className="flex flex-col h-full py-2">
+      {/* 予約サイト（最上部・専用スタイル） */}
+      <div className="px-2 pb-2 mb-1">
+        <Link
+          to={`/${slug}`}
+          className={`flex items-center gap-2 px-3 py-2.5 text-sm font-medium rounded-md border transition-all duration-150 ${
+            bookingActive
+              ? 'bg-primary text-primary-foreground border-primary'
+              : 'text-slate-700 border-slate-200 hover:bg-slate-50 hover:border-slate-300'
+          }`}
+        >
+          <Globe className="w-4 h-4 flex-shrink-0" />
+          <span>予約サイト</span>
+        </Link>
+      </div>
+
+      <div className="mx-3 border-t border-border/40 mb-1" />
+
       {visibleGroups.map((group, gi) => (
         <div key={group.id}>
           {/* グループセパレーター */}

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -1,0 +1,290 @@
+/**
+ * 管理画面用左サイドバーナビゲーション
+ * - カテゴリごとに折り畳み可能
+ * - スケジュールはデフォルト展開
+ * - モバイルはハンバーガー → ドロワー
+ * - ロールベースでメニューをフィルタリング
+ */
+import { useState, useMemo, useCallback, useEffect, memo } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { useOrganization, checkIsLicenseAdmin } from '@/hooks/useOrganization'
+import { useStoreConfirmationPendingCount } from '@/hooks/useStoreConfirmationPendingCount'
+import {
+  CalendarDays, Users, BookOpen, TrendingUp, CalendarClock, Settings,
+  ClipboardCheck, UserCog, Store, HelpCircle, Globe, LayoutDashboard,
+  UserCircle, UserCheck, Ticket, FileCheck, Shield, Gift, FileText,
+  Mail, Building2, ChevronDown, ChevronRight, Menu, X,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+type NavItem = {
+  id: string
+  label: string
+  icon: React.ElementType
+  path: string
+  roles: string[]
+  badge?: number
+}
+
+type NavGroup = {
+  id: string
+  label: string | null
+  icon?: React.ElementType
+  items: NavItem[]
+  defaultOpen?: boolean
+}
+
+// 管理サイトのパス判定用
+const ADMIN_PATH_SEGMENTS = [
+  'dashboard', 'stores', 'staff', 'scenarios', 'schedule',
+  'shift-submission', 'gm-availability', 'private-booking-management',
+  'reservations', 'accounts', 'sales', 'settings', 'manual',
+  'staff-profile', 'license-management', 'coupons', 'blog',
+  'organizations', 'external-reports', 'scenario-masters',
+  'license-reports', 'customer-management', 'user-management',
+]
+
+export const AdminSidebar = memo(function AdminSidebar() {
+  const { user } = useAuth()
+  const location = useLocation()
+  const { organization, organizationId } = useOrganization()
+  const { count: pendingCount } = useStoreConfirmationPendingCount()
+  const isLicAdmin = checkIsLicenseAdmin(user?.role, organizationId)
+
+  const slug = organization?.slug || 'queens-waltz'
+
+  const [mobileOpen, setMobileOpen] = useState(false)
+  // 展開状態: localStorage に永続化
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
+    try {
+      const stored = localStorage.getItem('admin-sidebar-open-groups')
+      return stored ? JSON.parse(stored) : { schedule: true }
+    } catch {
+      return { schedule: true }
+    }
+  })
+
+  const persistOpenGroups = useCallback((next: Record<string, boolean>) => {
+    setOpenGroups(next)
+    localStorage.setItem('admin-sidebar-open-groups', JSON.stringify(next))
+  }, [])
+
+  const toggleGroup = useCallback((groupId: string) => {
+    persistOpenGroups({ ...openGroups, [groupId]: !openGroups[groupId] })
+  }, [openGroups, persistOpenGroups])
+
+  // パス変更でモバイルドロワーを閉じる
+  useEffect(() => {
+    setMobileOpen(false)
+  }, [location.pathname])
+
+  const NAV_GROUPS: NavGroup[] = useMemo(() => [
+    {
+      id: 'top',
+      label: null,
+      items: [
+        { id: 'dashboard', label: 'ダッシュボード', icon: LayoutDashboard, path: `/${slug}/dashboard`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'booking', label: '予約サイト', icon: Globe, path: `/${slug}`, roles: ['admin', 'staff', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'schedule',
+      label: 'スケジュール',
+      icon: CalendarDays,
+      defaultOpen: true,
+      items: [
+        { id: 'schedule', label: 'スケジュール', icon: CalendarDays, path: `/${slug}/schedule`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'shift-submission', label: 'シフト提出', icon: CalendarClock, path: `/${slug}/shift-submission`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'gm-availability', label: 'GM確認', icon: UserCheck, path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'staff-profile', label: '担当作品', icon: UserCircle, path: `/${slug}/staff-profile`, roles: ['admin', 'staff', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'reservations',
+      label: '予約・顧客',
+      icon: Ticket,
+      items: [
+        { id: 'reservations', label: '予約管理', icon: Ticket, path: `/${slug}/reservations`, roles: ['admin', 'license_admin'], badge: pendingCount },
+        { id: 'private-booking-management', label: '貸切管理', icon: ClipboardCheck, path: `/${slug}/private-booking-management`, roles: ['admin', 'license_admin'] },
+        { id: 'accounts', label: 'アカウント', icon: UserCog, path: `/${slug}/accounts`, roles: ['admin', 'license_admin'] },
+        { id: 'coupons', label: 'クーポン', icon: Gift, path: `/${slug}/coupons`, roles: ['admin', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'content',
+      label: 'コンテンツ',
+      icon: BookOpen,
+      items: [
+        { id: 'scenarios', label: 'シナリオ', icon: BookOpen, path: `/${slug}/scenarios`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'blog', label: 'ブログ', icon: FileText, path: `/${slug}/blog`, roles: ['admin', 'license_admin'] },
+        { id: 'manual', label: 'マニュアル', icon: HelpCircle, path: `/${slug}/manual`, roles: ['admin', 'staff', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'sales',
+      label: '売上・管理',
+      icon: TrendingUp,
+      items: [
+        { id: 'sales', label: '売上', icon: TrendingUp, path: `/${slug}/sales`, roles: ['admin', 'license_admin'] },
+        { id: 'license-management', label: '公演報告', icon: FileCheck, path: `/${slug}/license-management`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'email-history', label: 'メール配信履歴', icon: Mail, path: `/${slug}/settings?tab=email-history`, roles: ['admin', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'settings',
+      label: '設定',
+      icon: Settings,
+      items: [
+        { id: 'stores', label: '店舗', icon: Store, path: `/${slug}/stores`, roles: ['admin', 'license_admin'] },
+        { id: 'staff', label: 'スタッフ', icon: Users, path: `/${slug}/staff`, roles: ['admin', 'license_admin'] },
+        { id: 'settings', label: '設定', icon: Settings, path: `/${slug}/settings`, roles: ['admin', 'license_admin'] },
+      ],
+    },
+    {
+      id: 'mmq',
+      label: 'MMQ運営',
+      icon: Shield,
+      items: [
+        { id: 'organizations', label: 'テナント管理', icon: Building2, path: `/${slug}/organizations`, roles: ['license_admin'] },
+        { id: 'scenario-masters', label: 'マスタ管理', icon: Shield, path: '/admin/scenario-masters', roles: ['license_admin'] },
+        { id: 'external-reports', label: '外部レポート', icon: FileCheck, path: `/${slug}/external-reports`, roles: ['license_admin'] },
+      ],
+    },
+  ], [slug, pendingCount])
+
+  // ロールフィルター
+  const visibleGroups = useMemo(() => {
+    if (!user?.role) return []
+    return NAV_GROUPS.map(group => ({
+      ...group,
+      items: group.items.filter(item => {
+        if (item.roles.includes(user.role)) return true
+        if (isLicAdmin && item.roles.includes('license_admin')) return true
+        return false
+      }),
+    })).filter(group => group.items.length > 0)
+  }, [NAV_GROUPS, user, isLicAdmin])
+
+  // アクティブ判定
+  const isActive = useCallback((item: NavItem) => {
+    const { pathname, search } = location
+    if (item.id === 'booking') {
+      return pathname === `/${slug}` || (
+        pathname.startsWith(`/${slug}/`) &&
+        !ADMIN_PATH_SEGMENTS.some(seg => pathname.includes(`/${seg}`))
+      )
+    }
+    if (item.id === 'email-history') {
+      return pathname.includes('/settings') && new URLSearchParams(search).get('tab') === 'email-history'
+    }
+    if (item.id === 'settings') {
+      return pathname.includes('/settings') && new URLSearchParams(search).get('tab') !== 'email-history'
+    }
+    return pathname.includes(`/${item.id}`) || pathname.startsWith(item.path)
+  }, [location, slug])
+
+  // 管理ページかどうか
+  const isAdminPage = ADMIN_PATH_SEGMENTS.some(seg => location.pathname.includes(`/${seg}`))
+
+  if (!user || user.role === 'customer' || !isAdminPage) return null
+
+  const SidebarContent = () => (
+    <div className="flex flex-col h-full py-3">
+      {visibleGroups.map((group, gi) => (
+        <div key={group.id}>
+          {/* グループセパレーター */}
+          {gi > 0 && group.label && (
+            <div className="mx-3 my-1 border-t border-border/50" />
+          )}
+
+          {/* グループヘッダー（折り畳みボタン） */}
+          {group.label && (
+            <button
+              onClick={() => toggleGroup(group.id)}
+              className="w-full flex items-center justify-between px-3 py-1.5 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <div className="flex items-center gap-1.5">
+                {group.icon && <group.icon className="w-3.5 h-3.5" />}
+                {group.label}
+              </div>
+              {openGroups[group.id]
+                ? <ChevronDown className="w-3 h-3" />
+                : <ChevronRight className="w-3 h-3" />
+              }
+            </button>
+          )}
+
+          {/* グループアイテム */}
+          {(group.label === null || openGroups[group.id]) && (
+            <div className="space-y-0.5 px-2">
+              {group.items.map(item => {
+                const active = isActive(item)
+                const Icon = item.icon
+                return (
+                  <Link
+                    key={item.id}
+                    to={item.path}
+                    className={`relative flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors ${
+                      active
+                        ? 'bg-primary/10 text-primary font-medium'
+                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                    }`}
+                  >
+                    <Icon className="w-4 h-4 flex-shrink-0" />
+                    <span className="truncate">{item.label}</span>
+                    {item.badge != null && item.badge > 0 && (
+                      <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">
+                        {item.badge > 99 ? '99+' : item.badge}
+                      </span>
+                    )}
+                  </Link>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+
+  return (
+    <>
+      {/* デスクトップサイドバー */}
+      <aside className="hidden md:flex flex-col w-48 shrink-0 border-r border-border bg-background h-full overflow-y-auto">
+        <SidebarContent />
+      </aside>
+
+      {/* モバイル: ハンバーガーボタン */}
+      <div className="md:hidden fixed bottom-4 left-4 z-50">
+        <Button
+          size="icon"
+          variant="default"
+          className="rounded-full shadow-lg h-12 w-12"
+          onClick={() => setMobileOpen(true)}
+        >
+          <Menu className="w-5 h-5" />
+        </Button>
+      </div>
+
+      {/* モバイル: ドロワー */}
+      {mobileOpen && (
+        <>
+          <div
+            className="md:hidden fixed inset-0 bg-black/40 z-40"
+            onClick={() => setMobileOpen(false)}
+          />
+          <aside className="md:hidden fixed left-0 top-0 bottom-0 w-56 bg-background border-r border-border z-50 overflow-y-auto shadow-xl">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <span className="font-bold text-sm">メニュー</span>
+              <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => setMobileOpen(false)}>
+                <X className="w-4 h-4" />
+              </Button>
+            </div>
+            <SidebarContent />
+          </aside>
+        </>
+      )}
+    </>
+  )
+})

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -36,6 +36,18 @@ type NavItem = {
   subItems?: SubItem[]   // そのページにいる時だけ展開表示
 }
 
+type SidebarContentProps = {
+  slug: string
+  bookingActive: boolean
+  visibleGroups: NavGroup[]
+  isGroupOpen: (group: NavGroup) => boolean
+  isActive: (item: NavItem) => boolean
+  isSubActive: (sub: SubItem) => boolean
+  userRole: string
+  isLicAdmin: boolean
+  handleGroupClick: (group: NavGroup) => void
+}
+
 type NavGroup = {
   id: string
   label: string | null
@@ -277,133 +289,21 @@ export const AdminSidebar = memo(function AdminSidebar() {
 
   const bookingActive = isActive({ id: 'booking', label: '予約サイト', icon: Globe, path: `/${slug}`, roles: [] })
 
-  const SidebarContent = () => (
-    <div className="flex flex-col h-full py-2">
-      {/* 予約サイト（最上部・専用スタイル） */}
-      <div className="px-2 pb-2 mb-1">
-        <Link
-          to={`/${slug}`}
-          className={`flex items-center gap-2 px-3 py-2.5 text-sm font-medium rounded-md border transition-all duration-150 ${
-            bookingActive
-              ? 'bg-primary text-primary-foreground border-primary'
-              : 'text-slate-700 border-slate-200 hover:bg-slate-50 hover:border-slate-300'
-          }`}
-        >
-          <Globe className="w-4 h-4 flex-shrink-0" />
-          <span>予約サイト</span>
-        </Link>
-      </div>
-
-      <div className="mx-3 border-t border-border/40 mb-1" />
-
-      {visibleGroups.map((group, gi) => (
-        <div key={group.id}>
-          {/* グループセパレーター */}
-          {gi > 0 && group.label && (
-            <div className="mx-3 my-1 border-t border-border/40" />
-          )}
-
-          {/* カテゴリ見出し（クリックで最初のアイテムへ遷移） */}
-          {group.label && (
-            <button
-              onClick={() => handleGroupClick(group)}
-              className="w-full flex items-center justify-between px-3 pt-2 pb-1 transition-colors duration-150 group"
-            >
-              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400 transition-colors duration-150 group-hover:text-slate-600">
-                {group.label}
-              </span>
-              <ChevronRight className={`w-3 h-3 text-slate-300 transition-all duration-200 group-hover:text-slate-500 ${
-                isGroupOpen(group) ? 'rotate-90' : 'rotate-0'
-              }`} />
-            </button>
-          )}
-
-          {/* グループアイテム — grid-rows で height:auto アニメーション */}
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateRows: isGroupOpen(group) ? '1fr' : '0fr',
-              opacity: isGroupOpen(group) ? 1 : 0,
-              transition: 'grid-template-rows 280ms ease-out, opacity 220ms ease-out',
-            }}
-          >
-            <div className="overflow-hidden">
-            <div
-              style={{
-                transform: isGroupOpen(group) ? 'translateY(0)' : 'translateY(-6px)',
-                transition: 'transform 280ms ease-out',
-              }}
-              className="space-y-0.5 px-2 pb-1"
-            >
-              {group.items.map(item => {
-                const active = isActive(item)
-                const showSubs = active && item.subItems && item.subItems.length > 0
-                // サブアイテムのロールフィルタリング
-                const visibleSubs = showSubs
-                  ? item.subItems!.filter(s =>
-                      !s.roles || s.roles.includes(user!.role) || (isLicAdmin && s.roles.includes('license_admin'))
-                    )
-                  : []
-                return (
-                  <div key={item.id}>
-                    <Link
-                      to={item.path}
-                      className={`relative flex items-center px-3 py-2 text-sm transition-all duration-150 ${
-                        active
-                          ? 'bg-blue-50 text-blue-700 font-medium'
-                          : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 hover:translate-x-0.5'
-                      }`}
-                    >
-                      <span className="truncate">{item.label}</span>
-                      {item.badge != null && item.badge > 0 && (
-                        <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">
-                          {item.badge > 99 ? '99+' : item.badge}
-                        </span>
-                      )}
-                    </Link>
-                    {/* サブアイテム（そのページにいる時だけ展開） */}
-                    {showSubs && visibleSubs.length > 0 && (
-                      <div className="ml-3 pl-2 border-l border-border/60 space-y-0.5 mt-0.5 mb-1">
-                        {visibleSubs.map(sub => {
-                          const subActive = isSubActive(sub)
-                          return (
-                            <div key={sub.id}>
-                              {sub.sectionLabel && (
-                                <p className="text-[10px] font-semibold text-muted-foreground/60 px-2 pt-2 pb-0.5 uppercase tracking-wide">
-                                  {sub.sectionLabel}
-                                </p>
-                              )}
-                              <Link
-                                to={sub.path}
-                                className={`flex items-center px-2 py-1.5 text-xs transition-colors ${
-                                  subActive
-                                    ? 'bg-blue-50 text-blue-700 font-medium'
-                                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
-                                }`}
-                              >
-                                <span className="truncate">{sub.label}</span>
-                              </Link>
-                            </div>
-                          )
-                        })}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  )
-
   return (
     <>
       {/* デスクトップサイドバー */}
       <aside className="hidden md:flex flex-col w-48 shrink-0 border-r border-border bg-background h-full overflow-y-auto">
-        <SidebarContent />
+        <SidebarContent
+          slug={slug}
+          bookingActive={bookingActive}
+          visibleGroups={visibleGroups}
+          isGroupOpen={isGroupOpen}
+          isActive={isActive}
+          isSubActive={isSubActive}
+          userRole={user!.role}
+          isLicAdmin={isLicAdmin}
+          handleGroupClick={handleGroupClick}
+        />
       </aside>
 
       {/* モバイル: ハンバーガーボタン */}
@@ -432,10 +332,145 @@ export const AdminSidebar = memo(function AdminSidebar() {
                 <X className="w-4 h-4" />
               </Button>
             </div>
-            <SidebarContent />
+            <SidebarContent
+          slug={slug}
+          bookingActive={bookingActive}
+          visibleGroups={visibleGroups}
+          isGroupOpen={isGroupOpen}
+          isActive={isActive}
+          isSubActive={isSubActive}
+          userRole={user!.role}
+          isLicAdmin={isLicAdmin}
+          handleGroupClick={handleGroupClick}
+        />
           </aside>
         </>
       )}
     </>
   )
 })
+
+// ─── 外部コンポーネント（毎レンダーで再マウントしないよう AdminSidebar の外に定義） ───
+function SidebarContent({
+  slug, bookingActive, visibleGroups,
+  isGroupOpen, isActive, isSubActive,
+  userRole, isLicAdmin, handleGroupClick,
+}: SidebarContentProps) {
+  return (
+    <div className="flex flex-col h-full py-2">
+      {/* 予約サイト（最上部・専用スタイル） */}
+      <div className="px-2 pb-2 mb-1">
+        <Link
+          to={`/${slug}`}
+          className={`flex items-center gap-2 px-3 py-2.5 text-sm font-medium rounded-md border transition-all duration-150 ${
+            bookingActive
+              ? 'bg-primary text-primary-foreground border-primary'
+              : 'text-slate-700 border-slate-200 hover:bg-slate-50 hover:border-slate-300'
+          }`}
+        >
+          <Globe className="w-4 h-4 flex-shrink-0" />
+          <span>予約サイト</span>
+        </Link>
+      </div>
+
+      <div className="mx-3 border-t border-border/40 mb-1" />
+
+      {visibleGroups.map((group, gi) => (
+        <div key={group.id}>
+          {gi > 0 && group.label && (
+            <div className="mx-3 my-1 border-t border-border/40" />
+          )}
+
+          {group.label && (
+            <button
+              onClick={() => handleGroupClick(group)}
+              className="w-full flex items-center justify-between px-3 pt-2 pb-1 transition-colors duration-150 group"
+            >
+              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400 transition-colors duration-150 group-hover:text-slate-600">
+                {group.label}
+              </span>
+              <ChevronRight className={`w-3 h-3 text-slate-300 transition-all duration-200 group-hover:text-slate-500 ${
+                isGroupOpen(group) ? 'rotate-90' : 'rotate-0'
+              }`} />
+            </button>
+          )}
+
+          {/* grid-rows アニメーション（外部コンポーネントなので transition が正常に動く） */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateRows: isGroupOpen(group) ? '1fr' : '0fr',
+              opacity: isGroupOpen(group) ? 1 : 0,
+              transition: 'grid-template-rows 280ms ease-out, opacity 220ms ease-out',
+            }}
+          >
+            <div className="overflow-hidden">
+              <div
+                style={{
+                  transform: isGroupOpen(group) ? 'translateY(0)' : 'translateY(-6px)',
+                  transition: 'transform 280ms ease-out',
+                }}
+                className="space-y-0.5 px-2 pb-1"
+              >
+                {group.items.map(item => {
+                  const active = isActive(item)
+                  const showSubs = active && item.subItems && item.subItems.length > 0
+                  const visibleSubs = showSubs
+                    ? item.subItems!.filter(s =>
+                        !s.roles || s.roles.includes(userRole) || (isLicAdmin && s.roles.includes('license_admin'))
+                      )
+                    : []
+                  return (
+                    <div key={item.id}>
+                      <Link
+                        to={item.path}
+                        className={`relative flex items-center px-3 py-2 text-sm transition-all duration-150 ${
+                          active
+                            ? 'bg-blue-50 text-blue-700 font-medium'
+                            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 hover:translate-x-0.5'
+                        }`}
+                      >
+                        <span className="truncate">{item.label}</span>
+                        {item.badge != null && item.badge > 0 && (
+                          <span className="ml-auto min-w-[18px] h-[18px] flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full px-1">
+                            {item.badge > 99 ? '99+' : item.badge}
+                          </span>
+                        )}
+                      </Link>
+                      {showSubs && visibleSubs.length > 0 && (
+                        <div className="ml-3 pl-2 border-l border-border/60 space-y-0.5 mt-0.5 mb-1">
+                          {visibleSubs.map(sub => {
+                            const subActive = isSubActive(sub)
+                            return (
+                              <div key={sub.id}>
+                                {sub.sectionLabel && (
+                                  <p className="text-[10px] font-semibold text-muted-foreground/60 px-2 pt-2 pb-0.5 uppercase tracking-wide">
+                                    {sub.sectionLabel}
+                                  </p>
+                                )}
+                                <Link
+                                  to={sub.path}
+                                  className={`flex items-center px-2 py-1.5 text-xs transition-colors ${
+                                    subActive
+                                      ? 'bg-blue-50 text-blue-700 font-medium'
+                                      : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
+                                  }`}
+                                >
+                                  <span className="truncate">{sub.label}</span>
+                                </Link>
+                              </div>
+                            )
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -46,7 +46,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
               </div>
             )}
             <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-clip">
-              <div data-scroll-content className={`${containerPadding} w-full`}>
+              <div data-scroll-content className={containerPadding}>
                 {children}
               </div>
             </div>
@@ -68,7 +68,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
             </div>
           )}
           <div className="flex-1 min-w-0">
-            <div className={`${containerPadding} w-full`}>
+            <div className={containerPadding}>
               {children}
             </div>
           </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -35,18 +35,19 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
 }) => {
   if (stickyLayout) {
     return (
-      <div className="h-screen flex flex-col bg-background overflow-hidden">
+      // w-screen + overflow-hidden でページ横スクロールを完全に封じる
+      <div className="h-screen w-screen flex flex-col bg-background overflow-hidden">
         <Header />
-        <div className="flex flex-1 min-h-0 w-full">
+        <div className="flex flex-1 min-h-0 min-w-0">
           <AdminSidebar />
-          <div className={`flex-1 flex min-h-0 ${className}`}>
+          <div className={`flex-1 flex min-h-0 min-w-0 ${className}`}>
             {sidebar && (
               <div className="border-r border-slate-200 shrink-0">
                 {sidebar}
               </div>
             )}
-            <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden">
-              <div data-scroll-content className={`${containerPadding} w-full min-w-0`}>
+            <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-auto">
+              <div data-scroll-content className={`${containerPadding} min-w-0`}>
                 {children}
               </div>
             </div>
@@ -57,9 +58,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    // max-w-full で body の横はみ出しを防ぐ
+    <div className="min-h-screen max-w-full bg-background overflow-x-hidden">
       <Header />
-      <div className="flex w-full">
+      <div className="flex min-w-0">
         <AdminSidebar />
         <div className={`flex flex-1 min-w-0 ${className}`}>
           {sidebar && (
@@ -67,8 +69,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
               {sidebar}
             </div>
           )}
-          <div className="flex-1 min-w-0 overflow-x-hidden">
-            <div className={`${containerPadding} w-full min-w-0`}>
+          <div className="flex-1 min-w-0">
+            <div className={`${containerPadding} min-w-0`}>
               {children}
             </div>
           </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -45,8 +45,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                 {sidebar}
               </div>
             )}
-            <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-clip">
-              <div data-scroll-content className={containerPadding}>
+            <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden">
+              <div data-scroll-content className={`${containerPadding} w-full min-w-0`}>
                 {children}
               </div>
             </div>
@@ -67,8 +67,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
               {sidebar}
             </div>
           )}
-          <div className="flex-1 min-w-0">
-            <div className={containerPadding}>
+          <div className="flex-1 min-w-0 overflow-x-hidden">
+            <div className={`${containerPadding} w-full min-w-0`}>
               {children}
             </div>
           </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -24,37 +24,29 @@ interface AppLayoutProps {
  *   {メインコンテンツ}
  * </AppLayout>
  */
-export const AppLayout: React.FC<AppLayoutProps> = ({ 
+export const AppLayout: React.FC<AppLayoutProps> = ({
   currentPage,
-  sidebar, 
-  children, 
-  maxWidth = 'max-w-[1440px]',
+  sidebar,
+  children,
+  maxWidth,          // 非推奨・後方互換用。基本は使わない
   containerPadding = 'px-[10px] py-3 sm:py-4 md:py-6',
   stickyLayout = false,
   className = ''
 }) => {
   if (stickyLayout) {
-    // 固定レイアウト: ヘッダー・サイドバーを固定、コンテンツのみスクロール
     return (
       <div className="h-screen flex flex-col bg-background overflow-hidden">
-        {/* ヘッダー（固定） */}
         <Header />
-
-        {/* ボディ: サイドバー + コンテンツ */}
         <div className="flex flex-1 min-h-0 w-full">
           <AdminSidebar />
-
-          {/* メインエリア */}
           <div className={`flex-1 flex min-h-0 ${className}`}>
-            {/* ページ内サイドバー（シナリオ等） */}
             {sidebar && (
               <div className="border-r border-slate-200 shrink-0">
                 {sidebar}
               </div>
             )}
-            {/* スクロール可能コンテンツ */}
             <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-clip">
-              <div data-scroll-content className={`${containerPadding} ${maxWidth} mx-auto`}>
+              <div data-scroll-content className={`${containerPadding} w-full`}>
                 {children}
               </div>
             </div>
@@ -64,25 +56,19 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
     )
   }
 
-  // 通常レイアウト: ページ全体がスクロール
   return (
     <div className="min-h-screen bg-background">
       <Header />
-
       <div className="flex w-full">
         <AdminSidebar />
-
-        {/* メインエリア */}
         <div className={`flex flex-1 min-w-0 ${className}`}>
-          {/* ページ内サイドバー（シナリオ等） */}
           {sidebar && (
             <div className="border-r border-slate-200 shrink-0">
               {sidebar}
             </div>
           )}
-          {/* メインコンテンツ */}
           <div className="flex-1 min-w-0">
-            <div className={`${containerPadding} ${maxWidth} mx-auto`}>
+            <div className={`${containerPadding} w-full`}>
               {children}
             </div>
           </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import { Header } from './Header'
-import { NavigationBar } from './NavigationBar'
+import { AdminSidebar } from './AdminSidebar'
 
 interface AppLayoutProps {
   currentPage: string
@@ -34,28 +34,29 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   className = ''
 }) => {
   if (stickyLayout) {
-    // 固定レイアウト: ヘッダー・ナビ・サイドバーを固定、コンテンツのみスクロール
+    // 固定レイアウト: ヘッダー・サイドバーを固定、コンテンツのみスクロール
     return (
       <div className="h-screen flex flex-col bg-background overflow-hidden">
         {/* ヘッダー（固定） */}
         <Header />
-        
-        {/* ナビゲーションバー（固定） */}
-        <NavigationBar currentPage={currentPage} />
-        
-        {/* メインエリア（サイドバー含めてmax-width適用） */}
-        <div className={`flex-1 flex min-h-0 ${maxWidth} ${className} mx-auto w-full`}>
-          {/* サイドバー */}
-          {sidebar && (
-            <div className="border-r border-slate-200 shrink-0">
-              {sidebar}
-            </div>
-          )}
-          
-          {/* メインコンテンツ（スクロール可能） */}
-          <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-clip">
-            <div data-scroll-content className={containerPadding}>
-              {children}
+
+        {/* ボディ: サイドバー + コンテンツ */}
+        <div className="flex flex-1 min-h-0 w-full">
+          <AdminSidebar />
+
+          {/* メインエリア */}
+          <div className={`flex-1 flex min-h-0 ${className}`}>
+            {/* ページ内サイドバー（シナリオ等） */}
+            {sidebar && (
+              <div className="border-r border-slate-200 shrink-0">
+                {sidebar}
+              </div>
+            )}
+            {/* スクロール可能コンテンツ */}
+            <div data-scroll-container className="flex-1 min-w-0 overflow-y-auto overflow-x-clip">
+              <div data-scroll-content className={`${containerPadding} ${maxWidth} mx-auto`}>
+                {children}
+              </div>
             </div>
           </div>
         </div>
@@ -67,21 +68,23 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <NavigationBar currentPage={currentPage} />
-      
-      {/* サイドバー含めてmax-width適用 */}
-      <div className={`flex ${maxWidth} ${className} mx-auto w-full`}>
-        {/* サイドバー */}
-        {sidebar && (
-          <div className="border-r border-slate-200 shrink-0">
-            {sidebar}
-          </div>
-        )}
-        
-        {/* メインコンテンツ */}
-        <div className="flex-1 min-w-0">
-          <div className={containerPadding}>
-            {children}
+
+      <div className="flex w-full">
+        <AdminSidebar />
+
+        {/* メインエリア */}
+        <div className={`flex flex-1 min-w-0 ${className}`}>
+          {/* ページ内サイドバー（シナリオ等） */}
+          {sidebar && (
+            <div className="border-r border-slate-200 shrink-0">
+              {sidebar}
+            </div>
+          )}
+          {/* メインコンテンツ */}
+          <div className="flex-1 min-w-0">
+            <div className={`${containerPadding} ${maxWidth} mx-auto`}>
+              {children}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -124,6 +124,11 @@ export function Footer({ organizationSlug, organizationName, stores = [], minima
                     初めての方へ
                   </Link>
                 </li>
+                <li>
+                  <Link to="/start" className="text-sm hover:text-white transition-colors">
+                    店舗登録
+                  </Link>
+                </li>
               </ul>
             </div>
 
@@ -205,6 +210,7 @@ export function Footer({ organizationSlug, organizationName, stores = [], minima
             <Link to="/privacy" className="hover:text-gray-300 transition-colors">プライバシー</Link>
             <Link to="/security" className="hover:text-gray-300 transition-colors">セキュリティ</Link>
             <Link to="/contact" className="hover:text-gray-300 transition-colors">お問い合わせ</Link>
+            <Link to="/for-business" className="hover:text-gray-300 transition-colors">店舗の方へ</Link>
           </div>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+  overflow-x: hidden;
+  max-width: 100vw;
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/index.css
+++ b/src/index.css
@@ -268,3 +268,11 @@
     pointer-events: none;
   }
 }
+
+@keyframes sidebar-items-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.sidebar-items-enter {
+  animation: sidebar-items-in 240ms ease-out both;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -277,15 +277,13 @@ html, body {
 @keyframes sidebar-items-in {
   from {
     opacity: 0;
-    transform: scaleY(0.6) translateY(-4px);
-    transform-origin: top;
+    transform: translateY(-6px);
   }
   to {
     opacity: 1;
-    transform: scaleY(1) translateY(0);
-    transform-origin: top;
+    transform: translateY(0);
   }
 }
 .sidebar-items-enter {
-  animation: sidebar-items-in 220ms ease-out both;
+  animation: sidebar-items-in 180ms ease-out both;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -270,9 +270,17 @@
 }
 
 @keyframes sidebar-items-in {
-  from { opacity: 0; transform: translateY(-6px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: scaleY(0.6) translateY(-4px);
+    transform-origin: top;
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1) translateY(0);
+    transform-origin: top;
+  }
 }
 .sidebar-items-enter {
-  animation: sidebar-items-in 240ms ease-out both;
+  animation: sidebar-items-in 220ms ease-out both;
 }

--- a/src/pages/AccountManagement/index.tsx
+++ b/src/pages/AccountManagement/index.tsx
@@ -5,48 +5,25 @@
  * @access admin
  * @organization 全組織
  */
-import { useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { AppLayout } from '@/components/layout/AppLayout'
-import { UnifiedSidebar, SidebarMenuItem } from '@/components/layout/UnifiedSidebar'
-import { Users, UserCog } from 'lucide-react'
-import { useSessionState } from '@/hooks/useSessionState'
-
-// サブページコンポーネント
 import { UserManagementContent } from './pages/UserManagementContent'
 import { CustomerManagementContent } from './pages/CustomerManagementContent'
 
-// サイドバーメニュー項目
-const ACCOUNT_MENU_ITEMS: SidebarMenuItem[] = [
-  { id: 'users', label: 'ユーザー', icon: UserCog, description: 'スタッフ・管理者のアカウント' },
-  { id: 'customers', label: '顧客', icon: Users, description: '予約顧客の管理' },
-]
-
 export function AccountManagement() {
-  const [activeTab, setActiveTab] = useSessionState('accountManagementActiveTab', 'users')
+  const [searchParams] = useSearchParams()
+  const activeTab = searchParams.get('tab') || 'users'
 
   const renderContent = () => {
     switch (activeTab) {
-      case 'users':
-        return <UserManagementContent />
-      case 'customers':
-        return <CustomerManagementContent />
-      default:
-        return <UserManagementContent />
+      case 'customers': return <CustomerManagementContent />
+      default:          return <UserManagementContent />
     }
   }
 
   return (
     <AppLayout
       currentPage="accounts"
-      sidebar={
-        <UnifiedSidebar
-          title="アカウント管理"
-          mode="list"
-          menuItems={ACCOUNT_MENU_ITEMS}
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-        />
-      }
       maxWidth="max-w-[1440px]"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}
@@ -57,4 +34,3 @@ export function AccountManagement() {
 }
 
 export default AccountManagement
-

--- a/src/pages/AccountManagement/pages/UserManagementContent.tsx
+++ b/src/pages/AccountManagement/pages/UserManagementContent.tsx
@@ -233,7 +233,7 @@ export function UserManagementContent() {
           title={
             <div className="flex items-center gap-2">
               <UserCog className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">ユーザー</span>
+              <span className="text-lg font-bold">ユーザー管理</span>
             </div>
           }
           description="スタッフ・管理者のアカウントとロールを管理"

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Header } from '@/components/layout/Header'
-import { NavigationBar } from '@/components/layout/NavigationBar'
+import { AdminSidebar } from '@/components/layout/AdminSidebar'
 import { LoadingScreen } from '@/components/layout/LoadingScreen'
 import { useAuth } from '@/contexts/AuthContext'
 import { useOrganization } from '@/hooks/useOrganization'
@@ -650,14 +650,16 @@ export function AdminDashboard() {
     const shouldShowNavigation = isStaff
     
     return (
-      <div className="min-h-screen bg-background">
+      <div className="min-h-screen bg-background flex flex-col">
         <Header onPageChange={handlePageChange} />
-        {shouldShowNavigation && (
-          <NavigationBar currentPage={currentPage} onPageChange={handlePageChange} />
-        )}
-        <Suspense fallback={<LoadingScreen message="マイページを読み込み中..." />}>
-          <MyPage />
-        </Suspense>
+        <div className="flex flex-1">
+          {shouldShowNavigation && <AdminSidebar />}
+          <div className="flex-1">
+            <Suspense fallback={<LoadingScreen message="マイページを読み込み中..." />}>
+              <MyPage />
+            </Suspense>
+          </div>
+        </div>
       </div>
     )
   }
@@ -927,23 +929,22 @@ export function AdminDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background flex flex-col">
       <Header onPageChange={handlePageChange} />
-      {shouldShowNavigation && (
-        <NavigationBar currentPage={currentPage} onPageChange={handlePageChange} />
-      )}
-
-      <main className="container mx-auto max-w-[1440px] px-[10px] py-3 sm:py-4 md:py-6">
-        <Suspense fallback={<LoadingScreen message="ダッシュボードを読み込み中..." />}>
-          {currentPage === 'dashboard' ? (
-            <DashboardHome onPageChange={handlePageChange} />
-          ) : currentPage === 'report-form' ? (
-            <ExternalReportForm />
-          ) : (
-            <DashboardHome onPageChange={handlePageChange} />
-          )}
-        </Suspense>
-      </main>
+      <div className="flex flex-1">
+        {shouldShowNavigation && <AdminSidebar />}
+        <main className="flex-1 max-w-[1440px] mx-auto px-[10px] py-3 sm:py-4 md:py-6">
+          <Suspense fallback={<LoadingScreen message="ダッシュボードを読み込み中..." />}>
+            {currentPage === 'dashboard' ? (
+              <DashboardHome onPageChange={handlePageChange} />
+            ) : currentPage === 'report-form' ? (
+              <ExternalReportForm />
+            ) : (
+              <DashboardHome onPageChange={handlePageChange} />
+            )}
+          </Suspense>
+        </main>
+      </div>
     </div>
   )
 }

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -850,10 +850,28 @@ export function AdminDashboard() {
     )
   }
 
-  // 組織管理ページ → 設定ページにリダイレクト
   if (currentPage === 'organizations' || currentPage === 'organization-settings') {
-    navigate('/settings', { replace: true })
-    return null
+    return (
+      <Suspense fallback={<LoadingScreen message="テナント管理を読み込み中..." />}>
+        <OrganizationManagement />
+      </Suspense>
+    )
+  }
+
+  if (currentPage === 'external-reports') {
+    return (
+      <Suspense fallback={<LoadingScreen message="外部レポートを読み込み中..." />}>
+        <ExternalReports />
+      </Suspense>
+    )
+  }
+
+  if (currentPage === 'license-reports') {
+    return (
+      <Suspense fallback={<LoadingScreen message="ライセンス報告を読み込み中..." />}>
+        <LicenseReportManagement />
+      </Suspense>
+    )
   }
 
   if (currentPage === 'license-management') {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -56,7 +56,9 @@ const ScenarioMasterAdmin = lazyWithRetry(() => import('./ScenarioMasterAdmin').
 const ScenarioMasterEdit = lazyWithRetry(() => import('./ScenarioMasterAdmin/ScenarioMasterEdit').then(m => ({ default: m.ScenarioMasterEdit })))
 const OrganizationSettings = lazyWithRetry(() => import('./OrganizationSettings'))
 const OrganizationRegister = lazyWithRetry(() => import('./OrganizationRegister'))
+const OrgSignup = lazyWithRetry(() => import('./OrgSignup'))
 const LandingPage = lazyWithRetry(() => import('./LandingPage'))
+const ForBusinessPage = lazyWithRetry(() => import('./ForBusiness').then(m => ({ default: m.ForBusinessPage })))
 const AuthorDashboard = lazyWithRetry(() => import('./AuthorDashboard'))
 const AuthorLogin = lazyWithRetry(() => import('./AuthorLogin'))
 const ExternalReportForm = lazyWithRetry(() => import('./ExternalReportForm'))
@@ -157,7 +159,7 @@ function parsePath(pathname: string): { page: string, scenarioId: string | null,
   }
   
   // 特殊ページのチェック（組織スラッグなし）
-  const specialPages = ['login', 'signup', 'reset-password', 'set-password', 'complete-profile', 'coupon-present', 'register', 'about', 
+  const specialPages = ['login', 'signup', 'reset-password', 'set-password', 'complete-profile', 'coupon-present', 'register', 'start', 'about',
     'accept-invitation', 'author-dashboard', 'author-login', 'mypage', 'my-page', 'scenario',
     // 静的ページ
     'terms', 'privacy', 'security', 'legal', 'contact', 'faq', 'guide', 'cancel-policy', 'stores', 'company',
@@ -809,7 +811,7 @@ export function AdminDashboard() {
   if (currentPage === 'for-business') {
     return (
       <Suspense fallback={<LoadingScreen message="読み込み中..." />}>
-        <LandingPage />
+        <ForBusinessPage />
       </Suspense>
     )
   }
@@ -874,6 +876,14 @@ export function AdminDashboard() {
     return (
       <Suspense fallback={<LoadingScreen message="読み込み中..." />}>
         <OrganizationRegister />
+      </Suspense>
+    )
+  }
+
+  if (currentPage === 'start') {
+    return (
+      <Suspense fallback={<LoadingScreen message="読み込み中..." />}>
+        <OrgSignup />
       </Suspense>
     )
   }

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -36,6 +36,7 @@ const GMAvailabilityCheck = lazyWithRetry(() => import('./GMAvailabilityCheck').
 const PrivateBookingScenarioSelect = lazyWithRetry(() => import('./PrivateBookingScenarioSelect').then(m => ({ default: m.PrivateBookingScenarioSelect })))
 const PrivateBookingRequestPage = lazyWithRetry(() => import('./PrivateBookingRequestPage').then(m => ({ default: m.PrivateBookingRequestPage })))
 const PrivateBookingManagement = lazyWithRetry(() => import('./PrivateBookingManagement').then(m => ({ default: m.PrivateBookingManagement })))
+const PrivateGroupListPage = lazyWithRetry(() => import('./PrivateBookingManagement/PrivateGroupListPage'))
 const AccountManagement = lazyWithRetry(() => import('./AccountManagement').then(m => ({ default: m.AccountManagement })))
 const CustomerManagement = lazyWithRetry(() => import('./CustomerManagement'))
 const UserManagement = lazyWithRetry(() => import('./UserManagement').then(m => ({ default: m.UserManagement })))
@@ -105,7 +106,7 @@ const GettingStartedPage = lazyWithRetry(() => import('./static').then(m => ({ d
 // 管理ページのパス一覧
 const ADMIN_PATHS = [
   'dashboard', 'stores', 'staff', 'staff-profile', 'scenarios', 'scenarios-edit',
-  'schedule', 'shift-submission', 'gm-availability', 'private-booking-management',
+  'schedule', 'shift-submission', 'gm-availability', 'private-booking-management', 'private-booking-groups',
   'reservations', 'accounts', 'sales', 'settings', 'manual', 'add-demo-participants',
   'scenario-matcher', 'organizations', 'external-reports', 'license-reports', 'license-management',
   'customer-management', 'user-management', 'coupons', 'blog'
@@ -539,6 +540,14 @@ export function AdminDashboard() {
     return (
       <Suspense fallback={<LoadingScreen message="貸切予約管理を読み込み中..." />}>
         <PrivateBookingManagement />
+      </Suspense>
+    )
+  }
+
+  if (currentPage === 'private-booking-groups') {
+    return (
+      <Suspense fallback={<LoadingScreen message="グループ一覧を読み込み中..." />}>
+        <PrivateGroupListPage />
       </Suspense>
     )
   }

--- a/src/pages/CompleteProfile.tsx
+++ b/src/pages/CompleteProfile.tsx
@@ -202,6 +202,33 @@ export function CompleteProfile() {
 
     ;(async () => {
       try {
+        // admin/staff ユーザーは顧客プロフィールフォームをスキップしてダッシュボードへ
+        const { data: userRecord } = await supabase
+          .from('users')
+          .select('role, organization_id')
+          .eq('id', userId)
+          .maybeSingle()
+
+        if (cancelled) return
+
+        const isStaffOrAdmin =
+          userRecord?.role === 'admin' ||
+          userRecord?.role === 'staff' ||
+          userRecord?.role === 'license_admin'
+
+        if (isStaffOrAdmin) {
+          logger.log('✅ admin/staff ユーザーのためダッシュボードへリダイレクト')
+          setProfileGate('leaving')
+          const { data: org } = await supabase
+            .from('organizations')
+            .select('slug')
+            .eq('id', userRecord?.organization_id)
+            .maybeSingle()
+          const dest = org?.slug ? `/${org.slug}/dashboard` : '/dashboard'
+          navigate(dest, { replace: true })
+          return
+        }
+
         const { data: rows, error } = await supabase
           .from('customers')
           .select('id, name, phone, email')

--- a/src/pages/CouponManagement/index.tsx
+++ b/src/pages/CouponManagement/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Header } from '@/components/layout/Header'
-import { NavigationBar } from '@/components/layout/NavigationBar'
+import { AdminSidebar } from '@/components/layout/AdminSidebar'
 import { Button } from '@/components/ui/button'
 import { Plus, RefreshCw, Ticket } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
@@ -130,13 +130,11 @@ export function CouponManagement() {
   const shouldShowNavigation = isStaff
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background flex flex-col">
       <Header onPageChange={handlePageChange} />
-      {shouldShowNavigation && (
-        <NavigationBar currentPage="coupons" onPageChange={handlePageChange} />
-      )}
-
-      <main className="container mx-auto max-w-[1440px] px-[10px] py-3 sm:py-4 md:py-6">
+      <div className="flex flex-1">
+        {shouldShowNavigation && <AdminSidebar />}
+        <main className="flex-1 max-w-[1440px] mx-auto px-[10px] py-3 sm:py-4 md:py-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-3">
             <Ticket className="h-6 w-6" />
@@ -167,7 +165,8 @@ export function CouponManagement() {
           onViewStats={handleViewStats}
           toggleLoading={toggleLoading}
         />
-      </main>
+        </main>
+      </div>
 
       <CampaignDialog
         open={editDialogOpen}

--- a/src/pages/ExternalReports/index.tsx
+++ b/src/pages/ExternalReports/index.tsx
@@ -25,6 +25,7 @@ import { ReportCreateDialog } from './components/ReportCreateDialog'
 import { format } from '@/lib/dateFns'
 import { ja } from 'date-fns/locale'
 import { PageHeader } from '@/components/layout/PageHeader'
+import { AppLayout } from '@/components/layout/AppLayout'
 
 export default function ExternalReports() {
   const { organization, staff, isLoading: orgLoading } = useOrganization()
@@ -65,6 +66,12 @@ export default function ExternalReports() {
   }
 
   return (
+    <AppLayout
+      currentPage="external-reports"
+      maxWidth="max-w-[1440px]"
+      containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
+      stickyLayout={true}
+    >
     <div className="space-y-6">
       <PageHeader
         title={
@@ -188,6 +195,7 @@ export default function ExternalReports() {
         }}
       />
     </div>
+    </AppLayout>
   )
 }
 

--- a/src/pages/ForBusiness/index.tsx
+++ b/src/pages/ForBusiness/index.tsx
@@ -1,0 +1,380 @@
+/**
+ * 店舗オーナー向け訴求ランディングページ
+ * @path /for-business
+ */
+import { useNavigate, Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import {
+  Calendar, BarChart3, Users, Globe, ChevronRight, ArrowRight,
+  CheckCircle2, Zap, Clock, FileText, Bell, Shield, Building2,
+  BookOpen, Star
+} from 'lucide-react'
+
+const PRIMARY = '#E60012'
+const DARK = '#111111'
+
+const FEATURES = [
+  {
+    icon: Calendar,
+    title: 'スケジュール管理',
+    desc: '公演スケジュールをカレンダーで一元管理。シフト提出・GM割り当てまで完結します。',
+    color: '#3b82f6',
+    bg: '#eff6ff',
+  },
+  {
+    icon: Users,
+    title: 'スタッフ・GM管理',
+    desc: 'スタッフの役割・空き状況を管理。招待リンクを送るだけで追加できます。',
+    color: '#8b5cf6',
+    bg: '#f5f3ff',
+  },
+  {
+    icon: BarChart3,
+    title: '売上・分析レポート',
+    desc: '日次・月次の売上を自動集計。ライセンス報告書もワンクリックで出力。',
+    color: '#10b981',
+    bg: '#ecfdf5',
+  },
+  {
+    icon: BookOpen,
+    title: 'シナリオ管理',
+    desc: '公演シナリオを一覧管理。GMごとの担当シナリオも設定できます。',
+    color: '#f59e0b',
+    bg: '#fffbeb',
+  },
+  {
+    icon: FileText,
+    title: 'マニュアル・情報共有',
+    desc: 'スタッフ向けのマニュアルをアプリ内で作成・共有。いつでもどこでも確認できます。',
+    color: '#ec4899',
+    bg: '#fdf2f8',
+  },
+  {
+    icon: Bell,
+    title: 'Discord 通知連携',
+    desc: '予約・キャンセル・シフトの変更を Discord に自動通知。見落としを防ぎます。',
+    color: '#6366f1',
+    bg: '#eef2ff',
+  },
+]
+
+const BOOKING_FEATURES = [
+  '24時間オンライン予約受付',
+  '予約確定・リマインドメールの自動送信',
+  '空席リアルタイム表示',
+  '予約サイトのデザインカスタマイズ',
+  'キャンセル・変更の自動受付',
+  '貸切グループ予約対応',
+]
+
+const STEPS = [
+  {
+    number: '01',
+    title: '組織を登録する',
+    desc: 'メールアドレスとパスワードを設定するだけ。30秒で完了。',
+    time: '30秒',
+  },
+  {
+    number: '02',
+    title: '店舗・シナリオを設定する',
+    desc: '店舗情報とシナリオを入力。スタッフを招待して準備完了。',
+    time: '約10分',
+  },
+  {
+    number: '03',
+    title: 'すぐに使い始める',
+    desc: 'スケジュール管理・売上管理・スタッフ管理をすぐに開始できます。',
+    time: '即日',
+  },
+]
+
+export function ForBusinessPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen bg-white overflow-x-hidden">
+      <Header />
+
+      {/* ═══ ヒーロー ═══ */}
+      <section
+        className="relative min-h-[80vh] flex items-center justify-center overflow-hidden"
+        style={{ background: `linear-gradient(135deg, ${DARK} 0%, #1a0000 60%, #0d0000 100%)` }}
+      >
+        <div
+          className="absolute inset-0 opacity-[0.07]"
+          style={{ backgroundImage: `repeating-linear-gradient(45deg, white 0px, white 1px, transparent 1px, transparent 60px)` }}
+        />
+        <div
+          className="absolute top-0 right-0 w-[500px] h-[500px] opacity-15 pointer-events-none"
+          style={{ background: `radial-gradient(circle, ${PRIMARY} 0%, transparent 70%)` }}
+        />
+
+        <div className="relative z-10 text-center px-4 max-w-4xl mx-auto">
+          <div className="inline-flex items-center gap-2 bg-white/10 border border-white/20 rounded-full px-4 py-1.5 mb-8 text-sm text-white/70">
+            <Building2 className="w-3.5 h-3.5" style={{ color: PRIMARY }} />
+            マーダーミステリー店舗向け管理プラットフォーム
+          </div>
+
+          <h1 className="text-4xl md:text-6xl font-black text-white leading-tight tracking-tight mb-6">
+            店舗運営の手間を、<br />
+            <span style={{ color: PRIMARY }}>まるごと解消。</span>
+          </h1>
+
+          <p className="text-base md:text-lg text-white/60 max-w-2xl mx-auto mb-10 leading-relaxed">
+            MMQは、マーダーミステリー店舗のスケジュール・スタッフ・売上管理をひとつにまとめた
+            プラットフォームです。<br />
+            <span className="text-white/80 font-semibold">管理機能はずっと無料</span>でご利用いただけます。
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button
+              size="lg"
+              className="text-base font-bold px-10 h-14 rounded-none shadow-2xl"
+              style={{ backgroundColor: PRIMARY, color: '#fff' }}
+              onClick={() => navigate('/start')}
+            >
+              無料で始める
+              <ArrowRight className="ml-2 w-5 h-5" />
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              className="text-base font-bold px-10 h-14 rounded-none border-white/20 text-white bg-transparent hover:bg-white/10"
+              onClick={() => navigate('/pricing')}
+            >
+              料金プランを見る
+              <ChevronRight className="ml-1 w-4 h-4" />
+            </Button>
+          </div>
+
+          <p className="mt-6 text-white/30 text-xs">登録無料・クレジットカード不要</p>
+        </div>
+      </section>
+
+      {/* ═══ こんな悩みありませんか ═══ */}
+      <section className="py-16 px-4 bg-gray-50 border-b border-gray-100">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="text-sm font-bold tracking-widest mb-3 text-gray-400">PROBLEM</p>
+          <h2 className="text-2xl md:text-3xl font-black text-gray-900 mb-10">
+            こんな悩み、ありませんか？
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-left">
+            {[
+              { emoji: '📋', text: 'スケジュール管理がスプレッドシートでバラバラ' },
+              { emoji: '📞', text: 'スタッフとの情報共有にLINEを使っていて漏れが怖い' },
+              { emoji: '💸', text: '売上の集計や報告書作成に毎月時間がかかる' },
+            ].map(({ emoji, text }) => (
+              <div key={text} className="bg-white border border-gray-200 p-5 flex items-start gap-3">
+                <span className="text-2xl mt-0.5">{emoji}</span>
+                <p className="text-gray-700 font-medium text-sm">{text}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8 flex items-center justify-center gap-3">
+            <div className="h-px bg-gray-200 flex-1" />
+            <span className="text-gray-400 text-sm font-bold">MMQが全部解決します</span>
+            <div className="h-px bg-gray-200 flex-1" />
+          </div>
+        </div>
+      </section>
+
+      {/* ═══ 管理機能（無料） ═══ */}
+      <section className="py-20 px-4 bg-white">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-14">
+            <div className="inline-flex items-center gap-2 bg-green-50 border border-green-200 rounded-full px-4 py-1.5 mb-4 text-sm font-bold text-green-700">
+              ずっと無料
+            </div>
+            <p className="text-sm font-bold tracking-widest mb-3 text-gray-400">MANAGEMENT FEATURES</p>
+            <h2 className="text-3xl md:text-4xl font-black text-gray-900">
+              管理機能
+            </h2>
+            <p className="text-gray-500 mt-3 text-sm">店舗数・スタッフ数の制限なし。すべて無料でお使いいただけます。</p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">
+            {FEATURES.map(({ icon: Icon, title, desc, color, bg }) => (
+              <div
+                key={title}
+                className="p-6 border border-gray-100 hover:shadow-md transition-shadow"
+              >
+                <div
+                  className="w-11 h-11 flex items-center justify-center mb-4 rounded-lg"
+                  style={{ backgroundColor: bg }}
+                >
+                  <Icon className="w-5 h-5" style={{ color }} />
+                </div>
+                <h3 className="text-base font-bold text-gray-900 mb-2">{title}</h3>
+                <p className="text-sm text-gray-500 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ═══ 予約サイト公開（有料オプション） ═══ */}
+      <section
+        className="py-20 px-4"
+        style={{ background: `linear-gradient(135deg, ${DARK} 0%, #1a0000 100%)` }}
+      >
+        <div className="max-w-5xl mx-auto">
+          <div className="grid md:grid-cols-2 gap-12 items-center">
+            <div>
+              <div className="inline-flex items-center gap-2 bg-white/10 border border-white/20 rounded-full px-4 py-1.5 mb-6 text-sm text-white/70">
+                <Zap className="w-3.5 h-3.5" style={{ color: PRIMARY }} />
+                オプション / ¥4,980/月
+              </div>
+              <p className="text-sm font-bold tracking-widest mb-3" style={{ color: PRIMARY }}>BOOKING SITE</p>
+              <h2 className="text-3xl md:text-4xl font-black text-white leading-tight mb-6">
+                予約サイトも<br />公開できます
+              </h2>
+              <p className="text-white/60 text-sm leading-relaxed mb-8">
+                管理機能に加えて、お客様向けの予約サイトを公開できます。
+                24時間自動受付・自動メール送信で、予約対応の手間をゼロに。
+              </p>
+              <ul className="space-y-3 mb-8">
+                {BOOKING_FEATURES.map(text => (
+                  <li key={text} className="flex items-start gap-3">
+                    <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: PRIMARY }} />
+                    <span className="text-white/80 text-sm">{text}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                variant="outline"
+                className="border-white/30 text-white bg-transparent hover:bg-white/10 rounded-none"
+                onClick={() => navigate('/pricing')}
+              >
+                料金プランの詳細
+                <ChevronRight className="ml-1 w-4 h-4" />
+              </Button>
+            </div>
+
+            <div className="relative hidden md:block">
+              <div
+                className="rounded-none border border-white/10 overflow-hidden"
+                style={{ backgroundColor: '#1a1a1a' }}
+              >
+                <div className="px-4 py-3 border-b border-white/10 flex items-center gap-2">
+                  <div className="w-2 h-2 rounded-full" style={{ backgroundColor: PRIMARY }} />
+                  <span className="text-white/60 text-xs">予約サイト（サンプル）</span>
+                </div>
+                <div className="p-4 space-y-3">
+                  {[
+                    { title: '消えた探偵', time: '120分', players: '4〜6人', status: '残2枠' },
+                    { title: '深夜の研究室', time: '90分', players: '3〜5人', status: '満員' },
+                    { title: '幽霊船の謎', time: '150分', players: '5〜8人', status: '残4枠' },
+                  ].map(({ title, time, players, status }) => (
+                    <div key={title} className="flex items-center gap-3 p-3 bg-white/5 border border-white/10">
+                      <div className="w-9 h-9 bg-white/10 flex items-center justify-center text-lg flex-shrink-0">🎭</div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-white text-xs font-medium truncate">{title}</p>
+                        <p className="text-white/40 text-xs">{time} · {players}</p>
+                      </div>
+                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                        status === '満員'
+                          ? 'bg-red-900/50 text-red-300'
+                          : 'bg-green-900/50 text-green-300'
+                      }`}>{status}</span>
+                    </div>
+                  ))}
+                  <Button
+                    size="sm"
+                    className="w-full rounded-none text-xs font-bold mt-2"
+                    style={{ backgroundColor: PRIMARY }}
+                  >
+                    予約する
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ═══ 始め方 ═══ */}
+      <section className="py-20 px-4 bg-white">
+        <div className="max-w-4xl mx-auto text-center">
+          <p className="text-sm font-bold tracking-widest mb-3 text-gray-400">HOW TO START</p>
+          <h2 className="text-3xl md:text-4xl font-black text-gray-900 mb-14">
+            3ステップで始められます
+          </h2>
+          <div className="grid md:grid-cols-3 gap-8">
+            {STEPS.map(({ number, title, desc, time }) => (
+              <div key={number} className="text-left">
+                <div
+                  className="text-5xl font-black mb-4 leading-none"
+                  style={{ color: `${PRIMARY}20` }}
+                >
+                  {number}
+                </div>
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="font-bold text-gray-900">{title}</h3>
+                  <span className="text-xs text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">
+                    <Clock className="w-3 h-3 inline mr-1" />{time}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-500 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ═══ 安心・サポート ═══ */}
+      <section className="py-16 px-4 bg-gray-50">
+        <div className="max-w-4xl mx-auto">
+          <div className="grid md:grid-cols-3 gap-6 text-center">
+            {[
+              { icon: Shield, title: 'セキュリティ', desc: 'Supabase による認証・データ暗号化。安心してご利用いただけます。' },
+              { icon: Star, title: 'クイーンズワルツ採用実績', desc: '国内最大級のマーダーミステリー専門店が実際に使用しています。' },
+              { icon: Globe, title: 'いつでも解約可能', desc: '契約期間の縛りはありません。いつでも無料プランに戻せます。' },
+            ].map(({ icon: Icon, title, desc }) => (
+              <div key={title} className="p-6">
+                <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-white border border-gray-200 flex items-center justify-center">
+                  <Icon className="w-5 h-5 text-gray-600" />
+                </div>
+                <h3 className="font-bold text-gray-900 mb-2 text-sm">{title}</h3>
+                <p className="text-xs text-gray-500 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ═══ 最終CTA ═══ */}
+      <section
+        className="py-24 px-4 text-center"
+        style={{ background: `linear-gradient(135deg, ${DARK} 0%, #2a0000 100%)` }}
+      >
+        <div className="max-w-2xl mx-auto">
+          <h2 className="text-4xl md:text-5xl font-black text-white mb-6 leading-tight">
+            まずは<span style={{ color: PRIMARY }}>無料</span>で<br />試してみてください。
+          </h2>
+          <p className="text-white/50 mb-10 text-sm leading-relaxed">
+            管理機能はずっと無料。店舗数・スタッフ数の制限もありません。
+          </p>
+          <Button
+            size="lg"
+            className="font-bold px-12 h-14 rounded-none shadow-2xl text-base"
+            style={{ backgroundColor: PRIMARY, color: '#fff' }}
+            onClick={() => navigate('/start')}
+          >
+            無料で組織を登録する
+            <ArrowRight className="ml-2 w-5 h-5" />
+          </Button>
+          <p className="mt-6 text-white/30 text-xs">
+            登録無料・クレジットカード不要・
+            <Link to="/pricing" className="underline hover:text-white/50">料金プランを見る</Link>
+          </p>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}
+
+export default ForBusinessPage

--- a/src/pages/GMAvailabilityCheck/components/CandidateSelector.tsx
+++ b/src/pages/GMAvailabilityCheck/components/CandidateSelector.tsx
@@ -1,5 +1,4 @@
-import { Badge } from '@/components/ui/badge'
-import { Calendar, Clock, CheckCircle2, Circle } from 'lucide-react'
+import { CheckCircle2, CircleDashed } from 'lucide-react'
 import { formatDate } from '../utils/gmFormatters'
 
 interface Candidate {
@@ -37,95 +36,64 @@ export function CandidateSelector({
 }: CandidateSelectorProps) {
   return (
     <div>
-      <p className="text-sm font-medium mb-2 text-purple-800">
-        {isConfirmed 
-          ? 'お客様希望候補日時（確定済み）' 
-          : isGMConfirmed 
-            ? 'お客様希望候補日時（GM回答済み・店側確認待ち）' 
-            : isResponded
-              ? 'お客様希望候補日時（回答済み）'
-              : 'お客様希望候補日時（出勤可能な日時を選択）'}
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1.5">
+        候補日時
+        {!isConfirmed && !isResponded && !isGMConfirmed && (
+          <span className="ml-1 font-normal normal-case text-purple-600">（出勤可能な日時を選択）</span>
+        )}
       </p>
-      {(isGMConfirmed || isResponded || isConfirmed) && selectedCandidates.length > 0 && (
-        <p className="text-xs text-purple-600 mb-2">
-          ✓ = GMが出勤可能と回答した日時
-        </p>
-      )}
-      <div className="space-y-2">
+      <div className="space-y-1">
         {candidates.map((candidate) => {
           const isSelected = selectedCandidates.includes(candidate.order)
           const isAvailable = candidateAvailability[candidate.order] !== false
           const hasGmConflict = gmScheduleConflicts?.[candidate.order] === true
-          // 自分が未回答かつ予約が未確定なら選択可能（他GMが回答済みでも選択可能）
           const canClick = !isResponded && !isConfirmed && isAvailable
-          
-          // 状態に応じたスタイルを決定
-          let cardStyle = ''
+
+          let rowStyle = ''
           if (!isAvailable) {
-            // 満席
-            cardStyle = 'bg-red-50 border-red-200 cursor-not-allowed opacity-60'
-          } else if (hasGmConflict && canClick && !isSelected) {
-            // 自分の既存予定と被る可能性（警告）
-            cardStyle = 'bg-orange-50 border-orange-200 hover:border-orange-300 cursor-pointer'
+            rowStyle = 'border-gray-200 bg-gray-50 cursor-not-allowed opacity-60'
           } else if (hasGmConflict && canClick && isSelected) {
-            // 警告 + 選択中
-            cardStyle = 'bg-orange-50 border-orange-400 cursor-pointer'
+            rowStyle = 'border-orange-400 bg-orange-50 cursor-pointer'
+          } else if (hasGmConflict && canClick) {
+            rowStyle = 'border-orange-200 bg-orange-50 hover:border-orange-300 cursor-pointer'
           } else if (isConfirmed && isSelected) {
-            // 確定済み＋自分が選択した候補 → 強調表示
-            cardStyle = 'border-green-500 bg-green-50 cursor-default'
+            rowStyle = 'border-green-400 bg-green-50 cursor-default'
           } else if (isConfirmed && !isSelected) {
-            // 確定済み＋自分が選択していない候補 → disabled（灰色）
-            cardStyle = 'bg-gray-50 border-gray-200 cursor-default opacity-60'
+            rowStyle = 'border-gray-200 bg-gray-50 cursor-default opacity-60'
           } else if (isResponded && isSelected) {
-            // 回答済み＋自分が選択した候補
-            cardStyle = 'border-purple-500 bg-purple-50/30 cursor-default'
+            rowStyle = 'border-purple-400 bg-purple-50 cursor-default'
           } else if (isResponded && !isSelected) {
-            // 回答済み＋自分が選択していない候補 → disabled（灰色）
-            cardStyle = 'bg-gray-50 border-gray-200 cursor-default opacity-60'
+            rowStyle = 'border-gray-200 bg-gray-50 cursor-default opacity-60'
           } else if (isSelected && canClick) {
-            // 選択中（編集可能）
-            cardStyle = 'border-purple-500 bg-purple-50/30 cursor-pointer'
+            rowStyle = 'border-purple-400 bg-purple-50 cursor-pointer'
           } else if (canClick) {
-            // 未選択（編集可能）
-            cardStyle = 'border-gray-200 hover:border-purple-300 cursor-pointer'
+            rowStyle = 'border-gray-200 bg-gray-50 hover:border-purple-300 hover:bg-purple-50/40 cursor-pointer'
           } else {
-            // その他（予期しないケース）
-            cardStyle = 'border-gray-200 cursor-default'
+            rowStyle = 'border-gray-200 bg-gray-50 cursor-default'
           }
-          
+
           return (
             <div
               key={candidate.order}
-              className={`flex items-center gap-3 p-3 rounded border ${cardStyle}`}
+              className={`px-3 py-2 rounded text-sm border transition-colors ${rowStyle}`}
               onClick={() => canClick && onToggle(candidate.order)}
             >
-              <div className="flex-1">
-                <div className="flex items-center gap-3">
-                  <Badge variant="outline" className="bg-gray-100 text-gray-800 border-0 rounded-[2px] font-normal">
-                    候補{candidate.order}
-                  </Badge>
-                  {hasGmConflict && (
-                    <Badge variant="secondary" className="bg-orange-100 text-orange-800 border-0 rounded-[2px] font-normal text-xs">
-                      ⚠️ 予定と重複の可能性
-                    </Badge>
-                  )}
-                  <div className="flex items-center gap-2 text-sm">
-                    <Calendar className="w-4 h-4 text-muted-foreground" />
-                    <span className="">{formatDate(candidate.date)}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm">
-                    <Clock className="w-4 h-4 text-muted-foreground" />
-                    <span>{candidate.timeSlot} {candidate.startTime} - {candidate.endTime}</span>
-                  </div>
-                </div>
+              <div className="flex items-center gap-2 flex-wrap">
+                {isConfirmed && isSelected
+                  ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
+                  : isSelected
+                  ? <CheckCircle2 className="w-4 h-4 text-purple-500 shrink-0" />
+                  : <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />}
+                <span className="font-medium">{formatDate(candidate.date)}</span>
+                <span className="text-muted-foreground text-xs whitespace-nowrap">
+                  {candidate.timeSlot} {candidate.startTime}–{candidate.endTime}
+                </span>
+                {hasGmConflict && (
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-orange-100 text-orange-800 border border-orange-200">
+                    ⚠️ 予定と重複の可能性
+                  </span>
+                )}
               </div>
-              {isAvailable && (
-                isSelected ? (
-                  <CheckCircle2 className="w-5 h-5 text-purple-600" />
-                ) : (
-                  <Circle className="w-5 h-5 text-gray-300" />
-                )
-              )}
             </div>
           )
         })}

--- a/src/pages/GMAvailabilityCheck/components/RequestCard.tsx
+++ b/src/pages/GMAvailabilityCheck/components/RequestCard.tsx
@@ -40,7 +40,6 @@ export function RequestCard({
   onCancelEdit
 }: RequestCardProps) {
   const isResponded = request.response_status === 'available' || request.response_status === 'all_unavailable'
-  const canEdit = isResponded && !isEditing
   const isConfirmed = request.reservation_status === 'confirmed'
   const isGMConfirmed = request.reservation_status === 'gm_confirmed'
   const elapsedTime = getElapsedTime(request.created_at)
@@ -49,83 +48,44 @@ export function RequestCard({
 
   return (
     <Card className="shadow-none border">
-      <CardHeader className="bg-purple-50 border-b">
-        <div className="flex justify-between items-start">
-          <div>
-            <CardTitle className="text-base text-purple-900">
-              {request.scenario_title}
-            </CardTitle>
-            <div className="mt-2 space-y-1 text-xs text-purple-700">
-              <div>お客様: {request.customer_name}</div>
-              <div>予約番号: {request.reservation_number}</div>
-            </div>
-            {request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 && (
-              <div className="flex items-center gap-2 flex-wrap mt-2">
-                <span className="text-sm text-purple-700">希望店舗:</span>
-                {request.candidate_datetimes.requestedStores.map((store: any, index: number) => (
-                  <Badge key={index} variant="outline" className="bg-purple-50 text-purple-800 border-purple-200 text-xs">
-                    {store.storeName}
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </div>
-          <div className="flex flex-col items-end gap-2">
-            <Badge
-              variant="secondary"
-              className={
-                isConfirmed
-                  ? 'bg-green-100 text-green-800'
-                  : isGMConfirmed
-                    ? 'bg-purple-100 text-purple-800'
-                    : isResponded
-                      ? 'bg-green-100 text-green-800'
-                      : request.has_other_gm_response
-                        ? 'bg-purple-100 text-purple-800'
-                        : 'bg-purple-100 text-purple-800'
-              }
-            >
-              {isConfirmed
-                ? '確定済み'
-                : isGMConfirmed
-                  ? 'GM確認済み（店側確認待ち）'
-                  : isResponded
-                    ? '回答済み'
-                    : request.has_other_gm_response
-                      ? '他GM回答済み'
-                      : '未回答'}
-            </Badge>
-            <span className={`text-xs ${elapsedTimeColor}`}>{elapsedTime}の申込</span>
-          </div>
+      <CardHeader className="pt-3 pb-2 space-y-0">
+        {/* タイトル + ステータスバッジ */}
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base leading-snug">{request.scenario_title}</CardTitle>
+          <Badge variant="secondary" className="bg-gray-100 text-gray-800 border-0 rounded-[2px] font-normal shrink-0">
+            {isConfirmed
+              ? '確定済み'
+              : isGMConfirmed
+                ? 'GM確認済み'
+                : isResponded
+                  ? '回答済み'
+                  : request.has_other_gm_response
+                    ? '他GM回答済み'
+                    : '未回答'}
+          </Badge>
         </div>
-      </CardHeader>
-      <CardContent className="pt-4">
-        <div className="space-y-3">
-          {/* 開催予定店舗 */}
-          <div className="mb-4">
-            <div className="text-xs text-muted-foreground mb-1">開催予定店舗</div>
-            {request.candidate_datetimes?.confirmedStore ? (
-              <div className="">{request.candidate_datetimes.confirmedStore.storeName}</div>
-            ) : request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 ? (
-              <>
-                <div className="flex gap-2 flex-wrap">
-                  {request.candidate_datetimes?.requestedStores?.map((store: any, index: number) => (
-                    <span key={index} className="">
-                      {store.storeName}{index < (request.candidate_datetimes?.requestedStores?.length || 0) - 1 ? ' / ' : ''}
-                    </span>
-                  ))}
-                </div>
-                {(request.candidate_datetimes?.requestedStores?.length || 0) > 1 && (
-                  <div className="text-xs text-muted-foreground mt-1">
-                    ※ 最終店舗は店舗管理者が決定します
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="text-muted-foreground">店舗未定（店舗管理者が決定します）</div>
-            )}
-          </div>
 
+        {/* サマリー1行 */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1.5 text-xs text-muted-foreground">
+          <span>#{request.reservation_number}</span>
+          <span>{request.customer_name}</span>
+          <span className={elapsedTimeColor}>{elapsedTime}</span>
+        </div>
+
+        {/* 希望店舗 */}
+        {request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1 mt-1">
+            <span className="text-xs text-muted-foreground shrink-0">希望店舗:</span>
+            {request.candidate_datetimes.requestedStores.map((store: any, index: number) => (
+              <span key={index} className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200 whitespace-nowrap">
+                {store.storeName}
+              </span>
+            ))}
+          </div>
+        )}
+      </CardHeader>
+      <CardContent className="md:pt-0">
+        <div className="space-y-3">
           {/* 候補日時選択 */}
           <CandidateSelector
             candidates={request.candidate_datetimes?.candidates || []}

--- a/src/pages/GMAvailabilityCheck/index.tsx
+++ b/src/pages/GMAvailabilityCheck/index.tsx
@@ -3,16 +3,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { PageHeader } from '@/components/layout/PageHeader'
-import { UnifiedSidebar, SidebarMenuItem } from '@/components/layout/UnifiedSidebar'
-import { CheckCircle, Clock, Calendar, Settings, UserCheck } from 'lucide-react'
-
-// サイドバーのメニュー項目定義
-const GM_MENU_ITEMS: SidebarMenuItem[] = [
-  { id: 'gm-list', label: 'GM確認一覧', icon: CheckCircle },
-  { id: 'pending', label: '承認待ち', icon: Clock },
-  { id: 'schedule', label: 'スケジュール', icon: Calendar },
-  { id: 'settings', label: '設定', icon: Settings }
-]
+import { UserCheck } from 'lucide-react'
 import { MonthSwitcher } from '@/components/patterns/calendar'
 import { useAuth } from '@/contexts/AuthContext'
 import { useGMRequests } from './hooks/useGMRequests'
@@ -26,7 +17,6 @@ import { formatMonthYear } from './utils/gmFormatters'
  */
 export function GMAvailabilityCheck() {
   const { user } = useAuth()
-  const [sidebarActiveTab, setSidebarActiveTab] = useState('availability-check')
 
   // フック
   const {
@@ -98,15 +88,6 @@ export function GMAvailabilityCheck() {
     return (
       <AppLayout
         currentPage="gm-availability"
-        sidebar={
-          <UnifiedSidebar
-            title="GM確認"
-            mode="list"
-            menuItems={GM_MENU_ITEMS}
-            activeTab={sidebarActiveTab}
-            onTabChange={setSidebarActiveTab}
-          />
-        }
         maxWidth="max-w-[1440px]"
         containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
         stickyLayout={true}
@@ -121,15 +102,6 @@ export function GMAvailabilityCheck() {
   return (
     <AppLayout
       currentPage="gm-availability"
-      sidebar={
-        <UnifiedSidebar
-          title="GM確認"
-          mode="list"
-          menuItems={GM_MENU_ITEMS}
-          activeTab={sidebarActiveTab}
-          onTabChange={setSidebarActiveTab}
-        />
-      }
       maxWidth="max-w-[1440px]"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -125,7 +125,7 @@ export function LandingPage() {
               size="lg"
               variant="outline"
               className="text-base font-bold px-10 h-14 rounded-none border-white/20 text-white bg-transparent hover:bg-white/10"
-              onClick={() => navigate('/queens-waltz')}
+              onClick={() => navigate('/')}
             >
               公演を見てみる
               <ChevronRight className="ml-1 w-4 h-4" />
@@ -468,7 +468,7 @@ export function LandingPage() {
               size="lg"
               variant="outline"
               className="font-bold px-10 h-14 rounded-none border-white/20 text-white bg-transparent hover:bg-white/10 text-base"
-              onClick={() => navigate('/queens-waltz')}
+              onClick={() => navigate('/')}
             >
               まず公演を見る
               <ChevronRight className="ml-1 w-4 h-4" />

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -494,6 +494,40 @@ export function LandingPage() {
         </div>
       </section>
 
+      {/* ═══ 店舗オーナー向けCTA ═══ */}
+      <section className="py-16 px-4 bg-gray-50 border-t border-gray-200">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="text-xs font-bold tracking-widest text-gray-400 uppercase mb-3">FOR STORE OWNERS</p>
+          <h2 className="text-2xl md:text-3xl font-black text-gray-900 mb-4">
+            店舗オーナーの方へ
+          </h2>
+          <p className="text-gray-500 text-sm leading-relaxed mb-6 max-w-xl mx-auto">
+            MMQはプレイヤー向けの予約・記録機能に加え、店舗向けの管理機能も提供しています。<br />
+            スケジュール管理・スタッフ管理・売上レポートが<span className="font-semibold text-gray-700">ずっと無料</span>で使えます。
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button
+              size="lg"
+              className="font-bold px-8 h-12 rounded-none text-sm"
+              style={{ backgroundColor: PRIMARY, color: '#fff' }}
+              onClick={() => navigate('/for-business')}
+            >
+              無料で店舗登録する
+              <ArrowRight className="ml-2 w-4 h-4" />
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              className="font-bold px-8 h-12 rounded-none border-gray-300 text-gray-700 text-sm"
+              onClick={() => navigate('/pricing')}
+            >
+              料金プランを見る
+              <ChevronRight className="ml-1 w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      </section>
+
       <Footer />
     </div>
   )

--- a/src/pages/LicenseManagement/index.tsx
+++ b/src/pages/LicenseManagement/index.tsx
@@ -4,48 +4,22 @@
  * @purpose ライセンス管理の統合ページ（報告受付・公演報告・作者レポート・集計）
  * @access admin, staff（一部機能はライセンス管理組織のみ）
  */
-
+import { useSearchParams } from 'react-router-dom'
 import { AppLayout } from '@/components/layout/AppLayout'
-import { UnifiedSidebar, SidebarMenuItem } from '@/components/layout/UnifiedSidebar'
 import { Card, CardContent } from '@/components/ui/card'
-import { 
-  FileCheck, 
-  Send, 
-  BarChart3,
-  Loader2,
-  AlertCircle
-} from 'lucide-react'
+import { Loader2, AlertCircle } from 'lucide-react'
 import { useOrganization } from '@/hooks/useOrganization'
-import { useSessionState } from '@/hooks/useSessionState'
-
-// 既存コンポーネントをインポート
 import { ReportsReceived } from './tabs/ReportsReceived'
 import { SendReports } from './tabs/SendReports'
 import { LicenseSummary } from './tabs/LicenseSummary'
 
-// サイドバーのメニュー項目定義（ライセンス管理組織用）
-const LICENSE_MENU_ITEMS: SidebarMenuItem[] = [
-  { id: 'received', label: '受信', icon: FileCheck, description: '加盟店からの公演報告を確認' },
-  { id: 'send', label: '送信', icon: Send, description: '作者・版元へライセンス料報告' },
-  { id: 'summary', label: '集計', icon: BarChart3, description: '月別・作品別の集計' },
-]
-
-// 一般組織用のメニュー
-const LICENSE_MENU_ITEMS_EXTERNAL: SidebarMenuItem[] = [
-  { id: 'send', label: '公演報告', icon: Send, description: 'MMQへ公演実績を報告' },
-]
-
 export default function LicenseManagement() {
   const { organization, staff, isLicenseManager, isLoading } = useOrganization()
-  const [activeTab, setActiveTab] = useSessionState('licenseManagementTab', 'received')
+  const [searchParams] = useSearchParams()
+  const rawTab = searchParams.get('tab') || 'send'
+  // ライセンス管理組織以外は send 固定
+  const effectiveTab = isLicenseManager ? rawTab : 'send'
 
-  // メニュー項目を権限に応じて選択
-  const menuItems = isLicenseManager ? LICENSE_MENU_ITEMS : LICENSE_MENU_ITEMS_EXTERNAL
-
-  // ライセンス管理組織以外の場合、sendタブに強制
-  const effectiveTab = isLicenseManager ? activeTab : 'send'
-
-  // コンテンツの条件分岐表示
   const renderContent = () => {
     if (isLoading) {
       return (
@@ -54,7 +28,6 @@ export default function LicenseManagement() {
         </div>
       )
     }
-
     if (!organization || !staff) {
       return (
         <div className="p-4">
@@ -67,38 +40,16 @@ export default function LicenseManagement() {
         </div>
       )
     }
-
     switch (effectiveTab) {
-      case 'received':
-        return isLicenseManager ? <ReportsReceived staffId={staff.id} /> : null
-      case 'send':
-        return <SendReports organizationId={organization.id} staffId={staff.id} isLicenseManager={isLicenseManager} />
-      case 'summary':
-        return isLicenseManager ? <LicenseSummary /> : null
-      default:
-        return <SendReports organizationId={organization.id} staffId={staff.id} isLicenseManager={isLicenseManager} />
+      case 'received': return isLicenseManager ? <ReportsReceived staffId={staff.id} /> : null
+      case 'summary':  return isLicenseManager ? <LicenseSummary /> : null
+      default:         return <SendReports organizationId={organization.id} staffId={staff.id} isLicenseManager={isLicenseManager} />
     }
   }
-
-  // サイドバーのタイトルと説明
-  const sidebarTitle = isLicenseManager ? 'ライセンス管理' : '公演報告'
-  const sidebarDescription = isLicenseManager 
-    ? '加盟店からの報告受付・作者への報告' 
-    : '公演実績をMMQに報告'
 
   return (
     <AppLayout
       currentPage="license-management"
-      sidebar={
-        <UnifiedSidebar
-          title={sidebarTitle}
-          description={sidebarDescription}
-          mode="list"
-          menuItems={menuItems}
-          activeTab={effectiveTab}
-          onTabChange={setActiveTab}
-        />
-      }
       maxWidth="max-w-[1440px]"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}

--- a/src/pages/LicenseReportManagement/index.tsx
+++ b/src/pages/LicenseReportManagement/index.tsx
@@ -36,6 +36,7 @@ import { LicenseSummaryCard } from './components/LicenseSummaryCard'
 import { format } from '@/lib/dateFns'
 import { ja } from 'date-fns/locale'
 import type { ExternalPerformanceReport } from '@/types'
+import { AppLayout } from '@/components/layout/AppLayout'
 
 export default function LicenseReportManagement() {
   const { organization, staff, isLicenseManager, isLoading: orgLoading } = useOrganization()
@@ -90,7 +91,13 @@ export default function LicenseReportManagement() {
   }
 
   return (
-    <div className="p-4 md:p-6 space-y-6">
+    <AppLayout
+      currentPage="license-reports"
+      maxWidth="max-w-[1440px]"
+      containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
+      stickyLayout={true}
+    >
+    <div className="space-y-6">
       {/* ヘッダー */}
       <div>
         <h1 className="text-2xl font-bold flex items-center gap-2">
@@ -287,6 +294,7 @@ export default function LicenseReportManagement() {
         />
       )}
     </div>
+    </AppLayout>
   )
 }
 

--- a/src/pages/Manual/index.tsx
+++ b/src/pages/Manual/index.tsx
@@ -381,6 +381,18 @@ export function ManualPage() {
   // エディターモード
   const [editorMode, setEditorMode] = useState<EditorMode>({ type: 'view' })
 
+  // URL の ?tab= / ?action= が外部ナビゲーション（AdminSidebar等）で変わったときに同期
+  useEffect(() => {
+    if (searchParams.get('action') === 'new') {
+      setEditorMode({ type: 'new' })
+      return
+    }
+    const resolved = resolveTab(searchParams.get('tab'))
+    setActiveTab(resolved)
+    setEditorMode({ type: 'view' })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
+
   const handleTabChange = (id: string) => {
     setActiveTab(id)
     setSearchParams({ tab: id }, { replace: true })
@@ -468,18 +480,6 @@ export function ManualPage() {
   return (
     <AppLayout
       currentPage="manual"
-      sidebar={
-        <ManualSidebar
-          activeTab={activeTab}
-          onTabChange={handleTabChange}
-          dbStaffPages={dbStaffPages}
-          dbAdminPages={dbAdminPages}
-          isAdmin={isAdmin}
-          onNewPage={() => setEditorMode({ type: 'new' })}
-          onEditPage={pageId => setEditorMode({ type: 'edit', pageId })}
-          blockBasedSlugs={blockBasedSlugs}
-        />
-      }
       maxWidth="max-w-[1440px]"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}

--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -83,24 +83,9 @@ export default function OrgSignup() {
   })
 
   const [agreedToTerms, setAgreedToTerms] = useState(false)
-  // ユーザーが識別子を手動編集したかどうか（true なら組織名からの自動生成を止める）
-  const [slugEdited, setSlugEdited] = useState(false)
-
-  const generateSlug = (name: string) =>
-    name
-      .toLowerCase()
-      .replace(/[^a-z0-9぀-ゟ゠-ヿ一-龯]/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-|-$/g, '')
-      .slice(0, 30)
 
   const handleOrgNameChange = (name: string) => {
-    setOrgData(prev => ({
-      ...prev,
-      name,
-      // 手動編集済みなら slug を維持、未編集なら組織名から随時生成
-      slug: slugEdited ? prev.slug : generateSlug(name),
-    }))
+    setOrgData(prev => ({ ...prev, name }))
   }
 
   const validateOrganization = (): boolean => {
@@ -369,10 +354,7 @@ export default function OrgSignup() {
                   id="org-slug"
                   name="org-identifier-field"
                   value={orgData.slug}
-                  onChange={e => {
-                    setSlugEdited(true)
-                    setOrgData(prev => ({ ...prev, slug: e.target.value.toLowerCase() }))
-                  }}
+                  onChange={e => setOrgData(prev => ({ ...prev, slug: e.target.value.toLowerCase() }))}
                   placeholder="例: sample-escape"
                   autoComplete="off"
                 />

--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -1,0 +1,550 @@
+/**
+ * 組織向け新規登録ページ（公開向け）
+ * @path /start
+ * @purpose 他組織がMMQを導入する際のセルフサービス登録フォーム
+ * @access 未ログインユーザー
+ */
+import { logger } from '@/utils/logger'
+import { useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Building2,
+  Mail,
+  User,
+  Lock,
+  CheckCircle,
+  Loader2,
+  AlertCircle,
+  ArrowRight,
+  ArrowLeft,
+  Check,
+  Calendar,
+  BarChart3,
+  Users,
+  Zap,
+} from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { toast } from 'sonner'
+
+type Step = 'organization' | 'admin' | 'confirm' | 'complete'
+
+const STEPS: { id: Exclude<Step, 'complete'>; label: string }[] = [
+  { id: 'organization', label: '組織情報' },
+  { id: 'admin', label: '管理者アカウント' },
+  { id: 'confirm', label: '確認' },
+]
+
+const BENEFITS = [
+  {
+    icon: Calendar,
+    title: 'スケジュール管理',
+    desc: '公演スケジュールをカレンダーで一元管理。シフト提出・GM割り当てまで完結。',
+  },
+  {
+    icon: BarChart3,
+    title: '売上・分析レポート',
+    desc: '日次・月次の売上を自動集計。ライセンス報告書もワンクリックで出力。',
+  },
+  {
+    icon: Users,
+    title: 'スタッフ・GM管理',
+    desc: 'スタッフの役割・空き状況を管理。招待リンクで簡単に追加できます。',
+  },
+  {
+    icon: Zap,
+    title: 'オンライン予約受付（有料）',
+    desc: '24時間自動受付・自動メール送信。月額¥4,980で予約サイトを公開。',
+  },
+]
+
+export default function OrgSignup() {
+  const [searchParams] = useSearchParams()
+  const selectedPlan = searchParams.get('plan') ?? 'free'
+
+  const [currentStep, setCurrentStep] = useState<Step>('organization')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [orgData, setOrgData] = useState({
+    name: '',
+    slug: '',
+    contact_email: '',
+  })
+
+  const [adminData, setAdminData] = useState({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  })
+
+  const [agreedToTerms, setAgreedToTerms] = useState(false)
+
+  const generateSlug = (name: string) =>
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9぀-ゟ゠-ヿ一-龯]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 30)
+
+  const handleOrgNameChange = (name: string) => {
+    setOrgData(prev => ({
+      ...prev,
+      name,
+      slug: prev.slug || generateSlug(name),
+    }))
+  }
+
+  const validateOrganization = (): boolean => {
+    if (!orgData.name.trim()) { setError('組織名を入力してください'); return false }
+    if (!orgData.slug.trim()) { setError('識別子を入力してください'); return false }
+    if (!/^[a-z0-9-]+$/.test(orgData.slug)) { setError('識別子は半角英数字とハイフンのみ使用できます'); return false }
+    setError(null)
+    return true
+  }
+
+  const validateAdmin = (): boolean => {
+    if (!adminData.name.trim()) { setError('管理者名を入力してください'); return false }
+    if (!adminData.email.trim()) { setError('メールアドレスを入力してください'); return false }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(adminData.email)) { setError('有効なメールアドレスを入力してください'); return false }
+    if (adminData.password.length < 8) { setError('パスワードは8文字以上で入力してください'); return false }
+    if (adminData.password !== adminData.confirmPassword) { setError('パスワードが一致しません'); return false }
+    setError(null)
+    return true
+  }
+
+  const handleNext = () => {
+    if (currentStep === 'organization' && validateOrganization()) setCurrentStep('admin')
+    else if (currentStep === 'admin' && validateAdmin()) setCurrentStep('confirm')
+  }
+
+  const handleBack = () => {
+    setError(null)
+    if (currentStep === 'admin') setCurrentStep('organization')
+    else if (currentStep === 'confirm') setCurrentStep('admin')
+  }
+
+  // 組織をロールバック（RPC経由で作成した場合）
+  const rollbackOrganization = async (orgId: string) => {
+    try {
+      // SECURITY DEFINER RPC で作成した組織を削除するには管理者権限が必要なため、
+      // フロントからは直接削除できない。signUp が失敗した場合は孤立した組織が残るが、
+      // slug でアクセスされることはなく、定期クリーンアップで除去する想定。
+      logger.warn('孤立した組織が発生した可能性があります（org_id=%s）。手動確認が必要です。', orgId)
+    } catch (e) {
+      logger.error('rollbackOrganization:', e)
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!agreedToTerms) { setError('利用規約に同意してください'); return }
+    setIsSubmitting(true)
+    setError(null)
+    let createdOrgId: string | null = null
+
+    try {
+      // 1. SECURITY DEFINER RPC で組織を作成（anon 可、RLSをバイパス）
+      const { data: newOrg, error: orgError } = await supabase.rpc(
+        'register_organization_for_signup',
+        {
+          p_name:          orgData.name.trim(),
+          p_slug:          orgData.slug.trim(),
+          p_contact_email: orgData.contact_email.trim() || adminData.email.trim(),
+        }
+      )
+
+      if (orgError) throw orgError
+      if (!newOrg?.id) throw new Error('組織の作成に失敗しました')
+
+      createdOrgId = newOrg.id
+
+      // 2. signUp に user_metadata を渡す
+      //    handle_new_user トリガーが users + staff レコードを自動作成する
+      const { error: authError } = await supabase.auth.signUp({
+        email: adminData.email.trim(),
+        password: adminData.password,
+        options: {
+          data: {
+            organization_id: newOrg.id,
+            invited_as:      'admin',
+            admin_name:      adminData.name.trim(),
+          },
+        },
+      })
+
+      if (authError) {
+        if (createdOrgId) await rollbackOrganization(createdOrgId)
+        throw authError
+      }
+
+      // 3. users / staff の手動INSERT は不要（トリガーが処理する）
+      setCurrentStep('complete')
+      toast.success('組織を登録しました！確認メールをご確認ください。')
+    } catch (err: unknown) {
+      logger.error('Registration failed:', err)
+      const msg = err instanceof Error ? err.message : '登録に失敗しました'
+      if (msg.includes('already registered')) {
+        setError('このメールアドレスは既に登録されています')
+      } else if (msg.includes('slug_already_exists')) {
+        setError('この識別子は既に使用されています')
+      } else if (msg.includes('invalid_slug_format')) {
+        setError('識別子は半角英数字とハイフンのみ使用できます')
+      } else {
+        setError(msg)
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const currentStepIndex = STEPS.findIndex(s => s.id === currentStep)
+
+  // ═══ 完了画面 ═══
+  if (currentStep === 'complete') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+        <div className="w-full max-w-md text-center space-y-6">
+          <div className="mx-auto w-20 h-20 rounded-full bg-green-100 flex items-center justify-center">
+            <CheckCircle className="w-10 h-10 text-green-600" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">登録完了！</h1>
+            <p className="text-gray-500 text-sm leading-relaxed">
+              確認メールを <span className="font-medium text-gray-700">{adminData.email}</span> に送信しました。<br />
+              メールのリンクをクリックしてアカウントを有効化してください。
+            </p>
+          </div>
+          <div className="bg-white border border-gray-200 rounded-lg p-4 text-left space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-gray-500">組織名</span>
+              <span className="font-medium">{orgData.name}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">管理者</span>
+              <span className="font-medium">{adminData.name}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">ログインURL</span>
+              <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded">
+                {window.location.origin}/{orgData.slug}
+              </code>
+            </div>
+          </div>
+          <Link to="/login">
+            <Button className="w-full">ログインページへ</Button>
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  // ═══ メイン登録フォーム ═══
+  return (
+    <div className="min-h-screen bg-white lg:grid lg:grid-cols-[1fr_480px]">
+      {/* ── 左パネル：訴求エリア ── */}
+      <div
+        className="hidden lg:flex flex-col justify-between p-12 text-white"
+        style={{ background: 'linear-gradient(160deg, #111111 0%, #1a0000 60%, #0d0000 100%)' }}
+      >
+        <div>
+          <div className="flex items-center gap-2 mb-12">
+            <div className="w-8 h-8 bg-red-600 flex items-center justify-center rounded-sm">
+              <span className="text-white font-black text-sm">M</span>
+            </div>
+            <span className="font-bold text-lg text-white">MMQ</span>
+          </div>
+
+          <h1 className="text-3xl font-black leading-tight mb-4">
+            マーダーミステリー店舗の<br />
+            <span className="text-red-500">運営をもっと簡単に。</span>
+          </h1>
+          <p className="text-white/60 text-sm leading-relaxed mb-10">
+            MMQは、マーダーミステリー店舗向けの総合管理プラットフォームです。<br />
+            管理機能はずっと無料でお使いいただけます。
+          </p>
+
+          <ul className="space-y-6">
+            {BENEFITS.map(({ icon: Icon, title, desc }) => (
+              <li key={title} className="flex gap-4">
+                <div className="w-10 h-10 rounded-lg bg-white/10 flex items-center justify-center flex-shrink-0">
+                  <Icon className="w-5 h-5 text-red-400" />
+                </div>
+                <div>
+                  <p className="font-semibold text-white text-sm mb-0.5">{title}</p>
+                  <p className="text-white/50 text-xs leading-relaxed">{desc}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <p className="text-white/30 text-xs">
+          既存のアカウントをお持ちの方は{' '}
+          <Link to="/login" className="text-white/60 hover:text-white underline">
+            こちらからログイン
+          </Link>
+        </p>
+      </div>
+
+      {/* ── 右パネル：フォームエリア ── */}
+      <div className="flex flex-col justify-center p-6 lg:p-10 bg-gray-50 lg:bg-white">
+        {/* モバイルのみロゴ */}
+        <div className="flex items-center gap-2 mb-8 lg:hidden">
+          <div className="w-7 h-7 bg-red-600 flex items-center justify-center rounded-sm">
+            <span className="text-white font-black text-xs">M</span>
+          </div>
+          <span className="font-bold text-gray-900">MMQ</span>
+        </div>
+
+        <div className="max-w-sm w-full mx-auto">
+          <h2 className="text-xl font-bold text-gray-900 mb-1">組織を登録する</h2>
+          <p className="text-sm text-gray-500 mb-6">
+            管理機能は無料でご利用いただけます
+          </p>
+
+          {/* ステップインジケーター */}
+          <div className="flex items-center gap-1 mb-6">
+            {STEPS.map((step, i) => (
+              <div key={step.id} className="flex items-center flex-1">
+                <div className={`
+                  w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0
+                  ${i < currentStepIndex
+                    ? 'bg-green-500 text-white'
+                    : i === currentStepIndex
+                      ? 'bg-gray-900 text-white'
+                      : 'bg-gray-200 text-gray-400'
+                  }
+                `}>
+                  {i < currentStepIndex ? <Check className="w-3.5 h-3.5" /> : i + 1}
+                </div>
+                <span className={`ml-1.5 text-xs hidden sm:block truncate ${i === currentStepIndex ? 'text-gray-700 font-medium' : 'text-gray-400'}`}>
+                  {step.label}
+                </span>
+                {i < STEPS.length - 1 && (
+                  <div className={`flex-1 h-px mx-2 ${i < currentStepIndex ? 'bg-green-400' : 'bg-gray-200'}`} />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* エラー */}
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-red-700 bg-red-50 border border-red-200 px-3 py-2.5 rounded-md mb-4">
+              <AlertCircle className="w-4 h-4 flex-shrink-0" />
+              {error}
+            </div>
+          )}
+
+          {/* ── ステップ1：組織情報 ── */}
+          {currentStep === 'organization' && (
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="org-name" className="text-sm font-medium">組織名 <span className="text-red-500">*</span></Label>
+                <div className="relative">
+                  <Building2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    id="org-name"
+                    value={orgData.name}
+                    onChange={e => handleOrgNameChange(e.target.value)}
+                    placeholder="例: 株式会社サンプル脱出ゲーム"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="org-slug" className="text-sm font-medium">
+                  識別子（URL用）<span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="org-slug"
+                  value={orgData.slug}
+                  onChange={e => setOrgData(prev => ({ ...prev, slug: e.target.value.toLowerCase() }))}
+                  placeholder="例: sample-escape"
+                />
+                <p className="text-xs text-gray-400">
+                  半角英数字・ハイフンのみ。<br />
+                  予約サイトのURL（{window.location.origin}/<span className="font-mono">{orgData.slug || 'your-org'}</span>）に使用されます。
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="org-email" className="text-sm font-medium">連絡先メールアドレス</Label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    id="org-email"
+                    type="email"
+                    value={orgData.contact_email}
+                    onChange={e => setOrgData(prev => ({ ...prev, contact_email: e.target.value }))}
+                    placeholder="例: contact@example.com"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+
+              <Button className="w-full" onClick={handleNext}>
+                次へ：管理者アカウント
+                <ArrowRight className="w-4 h-4 ml-2" />
+              </Button>
+            </div>
+          )}
+
+          {/* ── ステップ2：管理者アカウント ── */}
+          {currentStep === 'admin' && (
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="admin-name" className="text-sm font-medium">管理者名 <span className="text-red-500">*</span></Label>
+                <div className="relative">
+                  <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    id="admin-name"
+                    value={adminData.name}
+                    onChange={e => setAdminData(prev => ({ ...prev, name: e.target.value }))}
+                    placeholder="例: 山田太郎"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="admin-email" className="text-sm font-medium">メールアドレス <span className="text-red-500">*</span></Label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    id="admin-email"
+                    type="email"
+                    value={adminData.email}
+                    onChange={e => setAdminData(prev => ({ ...prev, email: e.target.value }))}
+                    placeholder="例: admin@example.com"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="admin-password" className="text-sm font-medium">パスワード <span className="text-red-500">*</span></Label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    id="admin-password"
+                    type="password"
+                    value={adminData.password}
+                    onChange={e => setAdminData(prev => ({ ...prev, password: e.target.value }))}
+                    placeholder="8文字以上"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="admin-confirm" className="text-sm font-medium">パスワード（確認）<span className="text-red-500">*</span></Label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    id="admin-confirm"
+                    type="password"
+                    value={adminData.confirmPassword}
+                    onChange={e => setAdminData(prev => ({ ...prev, confirmPassword: e.target.value }))}
+                    placeholder="もう一度入力"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <Button variant="outline" className="flex-1" onClick={handleBack}>
+                  <ArrowLeft className="w-4 h-4 mr-2" />
+                  戻る
+                </Button>
+                <Button className="flex-1" onClick={handleNext}>
+                  次へ：確認
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* ── ステップ3：確認 ── */}
+          {currentStep === 'confirm' && (
+            <div className="space-y-4">
+              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3 text-sm">
+                <div>
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">組織情報</p>
+                  <div className="space-y-1.5">
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">組織名</span>
+                      <span className="font-medium text-gray-900">{orgData.name}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">識別子</span>
+                      <span className="font-mono text-gray-900 text-xs">{orgData.slug}</span>
+                    </div>
+                    {orgData.contact_email && (
+                      <div className="flex justify-between">
+                        <span className="text-gray-500">連絡先</span>
+                        <span className="text-gray-900">{orgData.contact_email}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="border-t border-gray-200 pt-3">
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">管理者アカウント</p>
+                  <div className="space-y-1.5">
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">名前</span>
+                      <span className="font-medium text-gray-900">{adminData.name}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">メール</span>
+                      <span className="text-gray-900">{adminData.email}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-2.5">
+                <Checkbox
+                  id="terms"
+                  checked={agreedToTerms}
+                  onCheckedChange={checked => setAgreedToTerms(checked === true)}
+                />
+                <Label htmlFor="terms" className="text-sm text-gray-600 leading-relaxed cursor-pointer">
+                  <Link to="/terms" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">利用規約</Link>
+                  {' '}と{' '}
+                  <Link to="/privacy" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">プライバシーポリシー</Link>
+                  に同意します
+                </Label>
+              </div>
+
+              <div className="flex gap-2">
+                <Button variant="outline" className="flex-1" onClick={handleBack}>
+                  <ArrowLeft className="w-4 h-4 mr-2" />
+                  戻る
+                </Button>
+                <Button
+                  className="flex-1"
+                  onClick={handleSubmit}
+                  disabled={isSubmitting || !agreedToTerms}
+                >
+                  {isSubmitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                  登録する
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <p className="text-xs text-center text-gray-400 mt-6">
+            既にアカウントをお持ちの方は{' '}
+            <Link to="/login" className="text-gray-600 hover:underline">ログイン</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -301,7 +301,7 @@ export default function OrgSignup() {
           <span className="font-bold text-gray-900">MMQ</span>
         </div>
 
-        <div className="max-w-sm w-full mx-auto">
+        <form autoComplete="off" onSubmit={e => e.preventDefault()} className="max-w-sm w-full mx-auto">
           <h2 className="text-xl font-bold text-gray-900 mb-1">組織を登録する</h2>
           <p className="text-sm text-gray-500 mb-6">
             管理機能は無料でご利用いただけます
@@ -364,6 +364,7 @@ export default function OrgSignup() {
                 </Label>
                 <Input
                   id="org-slug"
+                  name="org-identifier-field"
                   value={orgData.slug}
                   onChange={e => setOrgData(prev => ({ ...prev, slug: e.target.value.toLowerCase() }))}
                   placeholder="例: sample-escape"
@@ -550,7 +551,7 @@ export default function OrgSignup() {
             既にアカウントをお持ちの方は{' '}
             <Link to="/login" className="text-gray-600 hover:underline">ログイン</Link>
           </p>
-        </div>
+        </form>
       </div>
     </div>
   )

--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -83,6 +83,8 @@ export default function OrgSignup() {
   })
 
   const [agreedToTerms, setAgreedToTerms] = useState(false)
+  // ユーザーが識別子を手動編集したかどうか（true なら組織名からの自動生成を止める）
+  const [slugEdited, setSlugEdited] = useState(false)
 
   const generateSlug = (name: string) =>
     name
@@ -96,7 +98,8 @@ export default function OrgSignup() {
     setOrgData(prev => ({
       ...prev,
       name,
-      slug: prev.slug || generateSlug(name),
+      // 手動編集済みなら slug を維持、未編集なら組織名から随時生成
+      slug: slugEdited ? prev.slug : generateSlug(name),
     }))
   }
 
@@ -366,7 +369,10 @@ export default function OrgSignup() {
                   id="org-slug"
                   name="org-identifier-field"
                   value={orgData.slug}
-                  onChange={e => setOrgData(prev => ({ ...prev, slug: e.target.value.toLowerCase() }))}
+                  onChange={e => {
+                    setSlugEdited(true)
+                    setOrgData(prev => ({ ...prev, slug: e.target.value.toLowerCase() }))
+                  }}
                   placeholder="例: sample-escape"
                   autoComplete="off"
                 />

--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -353,6 +353,7 @@ export default function OrgSignup() {
                     onChange={e => handleOrgNameChange(e.target.value)}
                     placeholder="例: 株式会社サンプル脱出ゲーム"
                     className="pl-9"
+                    autoComplete="organization"
                   />
                 </div>
               </div>
@@ -366,6 +367,7 @@ export default function OrgSignup() {
                   value={orgData.slug}
                   onChange={e => setOrgData(prev => ({ ...prev, slug: e.target.value.toLowerCase() }))}
                   placeholder="例: sample-escape"
+                  autoComplete="off"
                 />
                 <p className="text-xs text-gray-400">
                   半角英数字・ハイフンのみ。<br />
@@ -384,6 +386,7 @@ export default function OrgSignup() {
                     onChange={e => setOrgData(prev => ({ ...prev, contact_email: e.target.value }))}
                     placeholder="例: contact@example.com"
                     className="pl-9"
+                    autoComplete="off"
                   />
                 </div>
               </div>
@@ -408,6 +411,7 @@ export default function OrgSignup() {
                     onChange={e => setAdminData(prev => ({ ...prev, name: e.target.value }))}
                     placeholder="例: 山田太郎"
                     className="pl-9"
+                    autoComplete="name"
                   />
                 </div>
               </div>
@@ -423,6 +427,7 @@ export default function OrgSignup() {
                     onChange={e => setAdminData(prev => ({ ...prev, email: e.target.value }))}
                     placeholder="例: admin@example.com"
                     className="pl-9"
+                    autoComplete="email"
                   />
                 </div>
               </div>
@@ -438,6 +443,7 @@ export default function OrgSignup() {
                     onChange={e => setAdminData(prev => ({ ...prev, password: e.target.value }))}
                     placeholder="8文字以上"
                     className="pl-9"
+                    autoComplete="new-password"
                   />
                 </div>
               </div>
@@ -453,6 +459,7 @@ export default function OrgSignup() {
                     onChange={e => setAdminData(prev => ({ ...prev, confirmPassword: e.target.value }))}
                     placeholder="もう一度入力"
                     className="pl-9"
+                    autoComplete="new-password"
                   />
                 </div>
               </div>

--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -6,7 +6,8 @@
  */
 import { logger } from '@/utils/logger'
 import { useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams, useNavigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -32,9 +33,14 @@ import { toast } from 'sonner'
 
 type Step = 'organization' | 'admin' | 'confirm' | 'complete'
 
-const STEPS: { id: Exclude<Step, 'complete'>; label: string }[] = [
+const STEPS_NEW: { id: Exclude<Step, 'complete'>; label: string }[] = [
   { id: 'organization', label: '組織情報' },
   { id: 'admin', label: '管理者アカウント' },
+  { id: 'confirm', label: '確認' },
+]
+
+const STEPS_EXISTING: { id: Exclude<Step, 'complete'>; label: string }[] = [
+  { id: 'organization', label: '組織情報' },
   { id: 'confirm', label: '確認' },
 ]
 
@@ -64,6 +70,11 @@ const BENEFITS = [
 export default function OrgSignup() {
   const [searchParams] = useSearchParams()
   const selectedPlan = searchParams.get('plan') ?? 'free'
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const isLoggedIn = !!user
+
+  const STEPS = isLoggedIn ? STEPS_EXISTING : STEPS_NEW
 
   const [currentStep, setCurrentStep] = useState<Step>('organization')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -107,14 +118,18 @@ export default function OrgSignup() {
   }
 
   const handleNext = () => {
-    if (currentStep === 'organization' && validateOrganization()) setCurrentStep('admin')
-    else if (currentStep === 'admin' && validateAdmin()) setCurrentStep('confirm')
+    if (currentStep === 'organization' && validateOrganization()) {
+      // ログイン済みの場合は admin ステップをスキップ
+      setCurrentStep(isLoggedIn ? 'confirm' : 'admin')
+    } else if (currentStep === 'admin' && validateAdmin()) {
+      setCurrentStep('confirm')
+    }
   }
 
   const handleBack = () => {
     setError(null)
     if (currentStep === 'admin') setCurrentStep('organization')
-    else if (currentStep === 'confirm') setCurrentStep('admin')
+    else if (currentStep === 'confirm') setCurrentStep(isLoggedIn ? 'organization' : 'admin')
   }
 
   // 組織をロールバック（RPC経由で作成した場合）
@@ -142,7 +157,7 @@ export default function OrgSignup() {
         {
           p_name:          orgData.name.trim(),
           p_slug:          orgData.slug.trim(),
-          p_contact_email: orgData.contact_email.trim() || adminData.email.trim(),
+          p_contact_email: orgData.contact_email.trim() || (isLoggedIn ? user?.email ?? '' : adminData.email.trim()),
         }
       )
 
@@ -151,28 +166,44 @@ export default function OrgSignup() {
 
       createdOrgId = newOrg.id
 
-      // 2. signUp に user_metadata を渡す
-      //    handle_new_user トリガーが users + staff レコードを自動作成する
-      const { error: authError } = await supabase.auth.signUp({
-        email: adminData.email.trim(),
-        password: adminData.password,
-        options: {
-          data: {
-            organization_id: newOrg.id,
-            invited_as:      'admin',
-            admin_name:      adminData.name.trim(),
+      if (isLoggedIn) {
+        // ── ログイン済みパス: 既存アカウントを admin に昇格 ──
+        const { error: claimError } = await supabase.rpc('claim_organization_as_admin', {
+          p_org_id:     newOrg.id,
+          p_admin_name: user?.email ?? '',
+        })
+        if (claimError) {
+          if (createdOrgId) await rollbackOrganization(createdOrgId)
+          throw claimError
+        }
+        setCurrentStep('complete')
+        toast.success('組織を登録しました！')
+        // セッションのロール変更を反映するためリロード
+        setTimeout(() => navigate(`/${newOrg.slug}/dashboard`), 1500)
+      } else {
+        // ── 新規アカウントパス: signUp に user_metadata を渡す ──
+        //    handle_new_user トリガーが users + staff レコードを自動作成する
+        const { error: authError } = await supabase.auth.signUp({
+          email: adminData.email.trim(),
+          password: adminData.password,
+          options: {
+            data: {
+              organization_id: newOrg.id,
+              invited_as:      'admin',
+              admin_name:      adminData.name.trim(),
+            },
           },
-        },
-      })
+        })
 
-      if (authError) {
-        if (createdOrgId) await rollbackOrganization(createdOrgId)
-        throw authError
+        if (authError) {
+          if (createdOrgId) await rollbackOrganization(createdOrgId)
+          throw authError
+        }
+
+        // users / staff の手動INSERT は不要（トリガーが処理する）
+        setCurrentStep('complete')
+        toast.success('組織を登録しました！確認メールをご確認ください。')
       }
-
-      // 3. users / staff の手動INSERT は不要（トリガーが処理する）
-      setCurrentStep('complete')
-      toast.success('組織を登録しました！確認メールをご確認ください。')
     } catch (err: unknown) {
       logger.error('Registration failed:', err)
       const msg = err instanceof Error ? err.message : '登録に失敗しました'
@@ -202,10 +233,16 @@ export default function OrgSignup() {
           </div>
           <div>
             <h1 className="text-2xl font-bold text-gray-900 mb-2">登録完了！</h1>
-            <p className="text-gray-500 text-sm leading-relaxed">
-              確認メールを <span className="font-medium text-gray-700">{adminData.email}</span> に送信しました。<br />
-              メールのリンクをクリックしてアカウントを有効化してください。
-            </p>
+            {isLoggedIn ? (
+              <p className="text-gray-500 text-sm leading-relaxed">
+                ダッシュボードに移動しています…
+              </p>
+            ) : (
+              <p className="text-gray-500 text-sm leading-relaxed">
+                確認メールを <span className="font-medium text-gray-700">{adminData.email}</span> に送信しました。<br />
+                メールのリンクをクリックしてアカウントを有効化してください。
+              </p>
+            )}
           </div>
           <div className="bg-white border border-gray-200 rounded-lg p-4 text-left space-y-2 text-sm">
             <div className="flex justify-between">
@@ -271,12 +308,14 @@ export default function OrgSignup() {
           </ul>
         </div>
 
-        <p className="text-white/30 text-xs">
-          既存のアカウントをお持ちの方は{' '}
-          <Link to="/login" className="text-white/60 hover:text-white underline">
-            こちらからログイン
-          </Link>
-        </p>
+        {!isLoggedIn && (
+          <p className="text-white/30 text-xs">
+            既存のアカウントをお持ちの方は{' '}
+            <Link to={`/login?next=${encodeURIComponent('/start')}`} className="text-white/60 hover:text-white underline">
+              こちらからログイン
+            </Link>
+          </p>
+        )}
       </div>
 
       {/* ── 右パネル：フォームエリア ── */}
@@ -535,10 +574,12 @@ export default function OrgSignup() {
             </div>
           )}
 
-          <p className="text-xs text-center text-gray-400 mt-6">
-            既にアカウントをお持ちの方は{' '}
-            <Link to="/login" className="text-gray-600 hover:underline">ログイン</Link>
-          </p>
+          {!isLoggedIn && (
+            <p className="text-xs text-center text-gray-400 mt-6">
+              既にアカウントをお持ちの方は{' '}
+              <Link to={`/login?next=${encodeURIComponent('/start')}`} className="text-gray-600 hover:underline">ログイン</Link>
+            </p>
+          )}
         </form>
       </div>
     </div>

--- a/src/pages/OrganizationManagement/index.tsx
+++ b/src/pages/OrganizationManagement/index.tsx
@@ -6,21 +6,24 @@
  * @access ライセンス管理者のみ
  * @organization ライセンス管理組織のみ
  */
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
-import { 
-  Building2, 
-  Plus, 
-  Search, 
-  Users, 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Building2,
+  Plus,
+  Search,
+  Users,
   Mail,
   CheckCircle,
   XCircle,
   Loader2,
-  Pencil
+  Pencil,
+  Clock,
+  Globe
 } from 'lucide-react'
 import { useOrganization, useOrganizations } from '@/hooks/useOrganization'
 import { getSafeErrorMessage } from '@/lib/apiErrorHandler'
@@ -29,7 +32,18 @@ import { OrganizationInviteDialog } from './components/OrganizationInviteDialog'
 import { OrganizationEditDialog } from './components/OrganizationEditDialog'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { PageHeader } from '@/components/layout/PageHeader'
+import { supabase } from '@/lib/supabase'
+import { toast } from 'sonner'
 import type { Organization } from '@/types'
+
+type PendingApplication = {
+  id: string
+  name: string
+  slug: string
+  contact_email: string | null
+  created_at: string
+  updated_at: string
+}
 
 export default function OrganizationManagement() {
   const { isLicenseManager, isLoading: orgLoading } = useOrganization()
@@ -38,6 +52,34 @@ export default function OrganizationManagement() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [inviteTargetOrg, setInviteTargetOrg] = useState<Organization | null>(null)
   const [editTargetOrg, setEditTargetOrg] = useState<Organization | null>(null)
+  const [pendingApps, setPendingApps] = useState<PendingApplication[]>([])
+  const [isLoadingPending, setIsLoadingPending] = useState(false)
+  const [approvingId, setApprovingId] = useState<string | null>(null)
+
+  const fetchPendingApplications = useCallback(async () => {
+    setIsLoadingPending(true)
+    const { data } = await supabase.rpc('get_pending_booking_site_applications')
+    setPendingApps((data as PendingApplication[]) ?? [])
+    setIsLoadingPending(false)
+  }, [])
+
+  useEffect(() => {
+    if (isLicenseManager) fetchPendingApplications()
+  }, [isLicenseManager, fetchPendingApplications])
+
+  const handleApprove = async (orgId: string) => {
+    setApprovingId(orgId)
+    try {
+      const { error: approveError } = await supabase.rpc('approve_booking_site', { p_org_id: orgId })
+      if (approveError) throw approveError
+      toast.success('承認しました。プランが pro に変更されました。')
+      await Promise.all([fetchPendingApplications(), refetch()])
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : '承認に失敗しました')
+    } finally {
+      setApprovingId(null)
+    }
+  }
 
   // 検索フィルター
   const filteredOrganizations = organizations.filter(org =>
@@ -158,6 +200,78 @@ export default function OrganizationManagement() {
         </Card>
       </div>
 
+      <Tabs defaultValue="organizations">
+        <TabsList>
+          <TabsTrigger value="organizations" className="flex items-center gap-2">
+            <Building2 className="w-4 h-4" />
+            組織一覧
+          </TabsTrigger>
+          <TabsTrigger value="applications" className="flex items-center gap-2">
+            <Globe className="w-4 h-4" />
+            予約サイト申請
+            {pendingApps.length > 0 && (
+              <Badge variant="destructive" className="ml-1 px-1.5 py-0 text-xs">
+                {pendingApps.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* ── 申請一覧タブ ── */}
+        <TabsContent value="applications" className="mt-4">
+          {isLoadingPending ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : pendingApps.length === 0 ? (
+            <Card>
+              <CardContent className="p-8 text-center text-muted-foreground">
+                申請中の組織はありません
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {pendingApps.map(app => (
+                <Card key={app.id}>
+                  <CardContent className="p-4 flex items-center justify-between gap-4">
+                    <div className="space-y-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium truncate">{app.name}</p>
+                        <Badge variant="outline" className="text-amber-600 border-amber-300 bg-amber-50 flex-shrink-0">
+                          <Clock className="w-3 h-3 mr-1" />
+                          申請中
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-muted-foreground">/{app.slug}</p>
+                      {app.contact_email && (
+                        <p className="text-xs text-muted-foreground">{app.contact_email}</p>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        申請日: {new Date(app.updated_at).toLocaleDateString('ja-JP')}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      onClick={() => handleApprove(app.id)}
+                      disabled={approvingId === app.id}
+                      className="flex-shrink-0"
+                    >
+                      {approvingId === app.id
+                        ? <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        : <CheckCircle className="w-4 h-4 mr-2" />
+                      }
+                      承認する
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* ── 組織一覧タブ ── */}
+        <TabsContent value="organizations" className="mt-4 space-y-4">
+
       {/* 検索 */}
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
@@ -263,6 +377,8 @@ export default function OrganizationManagement() {
           refetch()
         }}
       />
+        </TabsContent>
+      </Tabs>
       </div>
     </AppLayout>
   )

--- a/src/pages/OrganizationRegister/index.tsx
+++ b/src/pages/OrganizationRegister/index.tsx
@@ -7,8 +7,8 @@
  * @organization なし（新規組織作成）
  */
 import { logger } from '@/utils/logger'
-import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -32,6 +32,13 @@ import { toast } from 'sonner'
 type Step = 'organization' | 'admin' | 'confirm' | 'complete'
 
 export default function OrganizationRegister() {
+  const navigate = useNavigate()
+
+  // /register は /start にリダイレクト
+  useEffect(() => {
+    navigate('/start', { replace: true })
+  }, [navigate])
+
   const [currentStep, setCurrentStep] = useState<Step>('organization')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/src/pages/OrganizationSettings/index.tsx
+++ b/src/pages/OrganizationSettings/index.tsx
@@ -14,20 +14,23 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
-import { 
-  Building2, 
-  Mail, 
-  User, 
-  Save, 
-  Loader2, 
+import {
+  Building2,
+  Mail,
+  User,
+  Save,
+  Loader2,
   Users,
   CheckCircle,
   Clock,
   RefreshCw,
-  Timer
+  Timer,
+  Globe,
+  Send
 } from 'lucide-react'
 import { useOrganization } from '@/hooks/useOrganization'
 import { updateOrganization } from '@/lib/organization'
+import { supabase } from '@/lib/supabase'
 import { getInvitationsByOrganization, resendInvitation, deleteInvitation } from '@/lib/api/invitationsApi'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { PageHeader } from '@/components/layout/PageHeader'
@@ -37,6 +40,7 @@ import type { OrganizationInvitation } from '@/types'
 export default function OrganizationSettings() {
   const { organization, isLoading: orgLoading, refetch } = useOrganization()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isApplying, setIsApplying] = useState(false)
   const [invitations, setInvitations] = useState<OrganizationInvitation[]>([])
   const [isLoadingInvitations, setIsLoadingInvitations] = useState(false)
   
@@ -97,6 +101,24 @@ export default function OrganizationSettings() {
       toast.error('更新に失敗しました')
     } finally {
       setIsSubmitting(false)
+    }
+  }
+
+  // 予約サイト公開を申請
+  const handleApplyBookingSite = async () => {
+    setIsApplying(true)
+    try {
+      const { error } = await supabase.rpc('apply_for_booking_site')
+      if (error) throw error
+      toast.success('予約サイト公開を申請しました。審査をお待ちください。')
+      refetch()
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '申請に失敗しました'
+      if (msg.includes('already_pending')) toast.error('既に申請中です')
+      else if (msg.includes('already_approved')) toast.error('既に承認済みです')
+      else toast.error(msg)
+    } finally {
+      setIsApplying(false)
     }
   }
 
@@ -260,19 +282,59 @@ export default function OrganizationSettings() {
         {/* プラン情報 */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">プラン情報</CardTitle>
+            <CardTitle className="text-lg flex items-center gap-2">
+              <Globe className="w-5 h-5" />
+              プラン・予約サイト公開
+            </CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="flex items-center gap-4">
-              <div>
-                <Badge className="text-lg px-4 py-1">
-                  {(organization.plan || 'free').toUpperCase()}
-                </Badge>
-              </div>
-              <div className="text-sm text-muted-foreground">
-                プランの変更は管理者にお問い合わせください
-              </div>
+          <CardContent className="space-y-4">
+            {/* 現在のプラン */}
+            <div className="flex items-center gap-3">
+              <Badge variant={organization.plan === 'free' ? 'secondary' : 'default'} className="px-3 py-1">
+                {organization.plan === 'free' ? '無料プラン' : `${organization.plan.toUpperCase()} プラン`}
+              </Badge>
+              {organization.plan !== 'free' && (
+                <span className="text-sm text-green-600 font-medium flex items-center gap-1">
+                  <CheckCircle className="w-4 h-4" />
+                  予約サイト公開中
+                </span>
+              )}
             </div>
+
+            {/* 予約サイト公開の申請ステータス */}
+            {organization.plan === 'free' && (
+              <div className="border rounded-lg p-4 space-y-3">
+                <p className="text-sm font-medium">予約サイト公開（月額 ¥4,980）</p>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  24時間オンライン予約受付・自動メール送信・予約サイトのカスタマイズが利用できます。
+                </p>
+
+                {organization.booking_site_status === 'pending' ? (
+                  <div className="flex items-center gap-2 text-amber-600 bg-amber-50 rounded px-3 py-2 text-sm">
+                    <Clock className="w-4 h-4 flex-shrink-0" />
+                    <span>申請中です。MMQ運営による審査をお待ちください。</span>
+                  </div>
+                ) : organization.booking_site_status === 'approved' ? (
+                  <div className="flex items-center gap-2 text-green-600 bg-green-50 rounded px-3 py-2 text-sm">
+                    <CheckCircle className="w-4 h-4 flex-shrink-0" />
+                    <span>承認されました。プランが更新されます。</span>
+                  </div>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleApplyBookingSite}
+                    disabled={isApplying}
+                  >
+                    {isApplying
+                      ? <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      : <Send className="w-4 h-4 mr-2" />
+                    }
+                    予約サイト公開を申請する
+                  </Button>
+                )}
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/src/pages/PrivateBookingManagement/PrivateGroupListPage.tsx
+++ b/src/pages/PrivateBookingManagement/PrivateGroupListPage.tsx
@@ -1,0 +1,13 @@
+import { AppLayout } from '@/components/layout/AppLayout'
+import { PrivateGroupList } from './components/PrivateGroupList'
+
+export default function PrivateGroupListPage() {
+  return (
+    <AppLayout
+      currentPage="private-booking-groups"
+      containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
+    >
+      <PrivateGroupList />
+    </AppLayout>
+  )
+}

--- a/src/pages/PrivateBookingManagement/components/ActionButtons.tsx
+++ b/src/pages/PrivateBookingManagement/components/ActionButtons.tsx
@@ -4,19 +4,14 @@ import { CheckCircle2, XCircle, Trash2 } from 'lucide-react'
 interface ActionButtonsProps {
   onApprove: () => void
   onReject: () => void
-  onCancel: () => void
   onDelete?: () => void
   disabled: boolean
   submitting?: boolean
 }
 
-/**
- * 承認/却下/削除ボタンコンポーネント
- */
 export const ActionButtons = ({
   onApprove,
   onReject,
-  onCancel,
   onDelete,
   disabled,
   submitting = false
@@ -24,14 +19,6 @@ export const ActionButtons = ({
   return (
     <div className="space-y-2">
       <div className="flex gap-2">
-        <Button
-          variant="outline"
-          className="flex-1 text-sm"
-          onClick={onCancel}
-          size="sm"
-        >
-          戻る
-        </Button>
         <Button
           variant="destructive"
           className="flex-1 text-sm"

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -175,40 +175,32 @@ export const BookingRequestCard = ({
         <div className="space-y-3">
           {/* ── GM回答状況 ── */}
           {request.gm_responses && request.gm_responses.length > 0 && (
-            <div className="bg-purple-50 p-3 rounded-lg">
-              <div className="flex items-center justify-between mb-2">
-                <h4 className="text-sm font-medium text-purple-900">GM回答状況</h4>
+            <div className="bg-purple-50 px-3 py-2 rounded-lg">
+              <div className="flex items-center justify-between mb-1.5">
+                <h4 className="text-xs font-semibold text-purple-800 uppercase tracking-wide">GM回答状況</h4>
                 {onResendDiscordNotification && hasUnrespondedGMs && isWaitingStatus && (
                   <Button variant="ghost" size="sm"
-                    className="h-7 px-2 text-xs text-purple-700 hover:text-purple-900 hover:bg-purple-100"
+                    className="h-6 px-2 text-xs text-purple-700 hover:text-purple-900 hover:bg-purple-100"
                     onClick={handleResend} disabled={resending}
                   >
-                    <RefreshCw className={cn('w-3.5 h-3.5 mr-1', resending && 'animate-spin')} />
+                    <RefreshCw className={cn('w-3 h-3 mr-1', resending && 'animate-spin')} />
                     {resending ? '送信中...' : 'Discord再通知'}
                   </Button>
                 )}
               </div>
-              <div className="space-y-1">
+              <div className="flex flex-wrap gap-x-3 gap-y-1">
                 {request.gm_responses.map((response, index) => {
                   const responded = hasGmResponded(response)
-                  const replyIso = responded ? pickGmReplyIsoString(response) : null
-                  const replyLabel = formatGmReplyReceivedAt(replyIso)
+                  const available = isGmMarkedAvailable(response)
+                  const candidates = response.available_candidates
                   return (
-                    <div key={index} className="text-sm text-purple-800">
-                      {response.gm_name || 'GM名不明'}:{' '}
-                      {!responded
-                        ? <span className="text-gray-500">⏳ 未回答</span>
-                        : isGmMarkedAvailable(response) ? '✅ 出勤可能' : '❌ 出勤不可'
-                      }
-                      {responded && (response.available_candidates?.length ?? 0) > 0 && (
-                        <span className="ml-2 text-purple-600">
-                          (候補{response.available_candidates!.map(i => i + 1).join(', ')})
-                        </span>
+                    <span key={index} className={`text-xs ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
+                      {!responded ? '⏳' : available ? '✅' : '❌'}
+                      {' '}{response.gm_name || 'GM名不明'}
+                      {responded && available && (candidates?.length ?? 0) > 0 && (
+                        <span className="text-purple-500 ml-0.5">({candidates!.map(i => i + 1).join(',')})</span>
                       )}
-                      {replyLabel && (
-                        <span className="ml-2 text-xs text-purple-600">・回答 {replyLabel}</span>
-                      )}
-                    </div>
+                    </span>
                   )
                 })}
               </div>
@@ -235,9 +227,8 @@ export const BookingRequestCard = ({
                       : isGMResponded && isGMSelected ? <CheckCircle2 className="w-4 h-4 text-purple-600 shrink-0" />
                       : isWaitingForGM ? <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />
                       : <XCircle className="w-4 h-4 text-red-400 shrink-0" />}
-                    <span className="text-xs text-muted-foreground shrink-0">候補{candidate.order}</span>
                     <span className="font-medium">{formatDate(candidate.date)}</span>
-                    <span className="text-muted-foreground">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+                    <span className="text-muted-foreground text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
                   </div>
                 )
               })}

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -72,7 +72,9 @@ interface BookingRequestCardProps {
   // 候補日クリックで承認モードへ
   selectedCandidateOrder?: number | null
   onSelectCandidate?: (req: BookingRequest, order: number) => void
-  inlineApprovalContent?: React.ReactNode  // 選択中候補行の直下に挿入
+  inlineApprovalContent?: React.ReactNode
+  // 候補ごとの空き店舗（承認モード時のみ渡す）
+  storesPerCandidate?: Record<number, Array<{ id: string; name: string; short_name?: string }>>
 }
 
 export const BookingRequestCard = ({
@@ -81,6 +83,7 @@ export const BookingRequestCard = ({
   selectedCandidateOrder,
   onSelectCandidate,
   inlineApprovalContent,
+  storesPerCandidate,
 }: BookingRequestCardProps) => {
   const [resending, setResending] = useState(false)
   const [codeCopied, setCodeCopied] = useState(false)
@@ -220,13 +223,15 @@ export const BookingRequestCard = ({
                 const isThisSelected = selectedCandidateOrder === candidate.order
                 const clickable = !!onSelectCandidate
 
+                const availableStores = storesPerCandidate?.[candidate.order]
+
                 return (
                   <div key={candidate.order}>
                     {/* 候補行 */}
                     <div
                       onClick={() => clickable && onSelectCandidate(request, candidate.order)}
                       className={cn(
-                        'flex items-center gap-2 px-3 py-2 rounded text-sm border transition-colors',
+                        'px-3 py-2 rounded text-sm border transition-colors',
                         clickable ? 'cursor-pointer' : '',
                         isThisSelected
                           ? 'border-purple-400 bg-purple-50 rounded-b-none'
@@ -237,23 +242,41 @@ export const BookingRequestCard = ({
                           : 'border-gray-200 bg-gray-50'
                       )}
                     >
-                      {isConfirmed && isGMAvailable
-                        ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
-                        : isThisSelected
-                        ? <CheckCircle2 className="w-4 h-4 text-purple-500 shrink-0" />
-                        : <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />}
+                      {/* 1行目：アイコン + 日付 + 時間 */}
+                      <div className="flex items-center gap-2">
+                        {isConfirmed && isGMAvailable
+                          ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
+                          : isThisSelected
+                          ? <CheckCircle2 className="w-4 h-4 text-purple-500 shrink-0" />
+                          : <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />}
+                        <span className="font-medium">{formatDate(candidate.date)}</span>
+                        <span className="text-muted-foreground text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+                      </div>
 
-                      <span className="font-medium">{formatDate(candidate.date)}</span>
-                      <span className="text-muted-foreground text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
-
-                      {/* 対応可能GMバッジ */}
-                      {availableGMs.length > 0 && (
-                        <div className="flex items-center gap-1 ml-auto flex-wrap">
+                      {/* 2行目：GMバッジ + 店舗バッジ（データがある時のみ） */}
+                      {(availableGMs.length > 0 || availableStores) && (
+                        <div className="flex flex-wrap items-center gap-1 mt-1.5 pl-6">
                           {availableGMs.map((gm, i) => (
                             <span key={i} className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 font-medium">
-                              {gm.gm_name?.slice(0, 3) ?? 'GM'}
+                              {gm.gm_name?.slice(0, 4) ?? 'GM'}
                             </span>
                           ))}
+                          {availableStores && availableStores.length > 0 && (
+                            <>
+                              {availableGMs.length > 0 && <span className="text-gray-300 text-xs">|</span>}
+                              {availableStores.slice(0, 4).map(s => (
+                                <span key={s.id} className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200">
+                                  {s.short_name || s.name}
+                                </span>
+                              ))}
+                              {availableStores.length > 4 && (
+                                <span className="text-xs text-gray-400">+{availableStores.length - 4}</span>
+                              )}
+                            </>
+                          )}
+                          {availableStores && availableStores.length === 0 && (
+                            <span className="text-xs text-red-500">空き店舗なし</span>
+                          )}
                         </div>
                       )}
                     </div>

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -202,19 +202,24 @@ export const BookingRequestCard = ({
                   </Button>
                 )}
               </div>
-              <div className="flex flex-wrap gap-x-3 gap-y-1">
+              <div className="flex flex-wrap gap-x-3 gap-y-1.5">
                 {request.gm_responses.map((response, index) => {
                   const responded = hasGmResponded(response)
                   const available = isGmMarkedAvailable(response)
                   const candidates = response.available_candidates
                   return (
-                    <span key={index} className={`text-xs ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
-                      {!responded ? '⏳' : available ? '✅' : '❌'}
-                      {' '}{response.gm_name || 'GM名不明'}
-                      {responded && available && (candidates?.length ?? 0) > 0 && (
-                        <span className="text-purple-500 ml-0.5">({candidates!.map(i => i + 1).join(',')})</span>
+                    <div key={index} className="flex flex-col gap-0.5">
+                      <span className={`text-xs ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
+                        {!responded ? '⏳' : available ? '✅' : '❌'}
+                        {' '}{response.gm_name || 'GM名不明'}
+                        {responded && available && (candidates?.length ?? 0) > 0 && (
+                          <span className="text-purple-500 ml-0.5">({candidates!.map(i => i + 1).join(',')})</span>
+                        )}
+                      </span>
+                      {responded && response.notes && (
+                        <span className="text-xs text-purple-600 pl-4 whitespace-pre-wrap">💬 {response.notes}</span>
                       )}
-                    </span>
+                    </div>
                   )
                 })}
               </div>

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -3,11 +3,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import { Calendar, Clock, CheckCircle2, XCircle, CircleDashed, RefreshCw } from 'lucide-react'
+import {
+  Calendar, Clock, CheckCircle2, XCircle, CircleDashed,
+  RefreshCw, ChevronDown, ChevronUp, Copy, Check, Mail, Phone
+} from 'lucide-react'
 import { StatusBadge } from './StatusBadge'
 import {
   formatDate,
-  formatDateTime,
   formatGmReplyReceivedAt,
   pickGmReplyIsoString,
   getElapsedTime,
@@ -18,6 +20,7 @@ import {
   isPlannedCountOutsideScenarioRange
 } from '../utils/bookingFormatters'
 import { isGmAvailableForCandidate, isGmMarkedAvailable, hasGmResponded } from '../utils/gmAvailabilityStatus'
+import { cn } from '@/lib/utils'
 
 interface Candidate {
   order: number
@@ -44,13 +47,17 @@ interface BookingRequest {
   id: string
   reservation_number: string
   scenario_title: string
+  scenario_master_id?: string
   customer_name: string
+  customer_email?: string
+  customer_phone?: string
   participant_count: number
   joined_member_count?: number
   scenario_player_count_range?: { min: number; max: number } | null
   status: string
   created_at: string
   notes?: string
+  invite_code?: string
   candidate_datetimes?: {
     candidates: Candidate[]
     requestedStores?: Array<{ storeId: string; storeName: string }>
@@ -61,105 +68,122 @@ interface BookingRequest {
 
 interface BookingRequestCardProps {
   request: BookingRequest
-  onSelectRequest: (request: BookingRequest) => void
-  showActionButton?: boolean
   onResendDiscordNotification?: (request: { id: string; scenario_title: string }) => Promise<void>
+  // インライン承認
+  isApprovalOpen?: boolean
+  onToggleApproval?: () => void
+  inlineApprovalContent?: React.ReactNode
 }
-
-/**
- * 貸切リクエストカードコンポーネント
- */
-import { cn } from '@/lib/utils'
-
-// ...
 
 export const BookingRequestCard = ({
   request,
-  onSelectRequest,
-  showActionButton = false,
-  onResendDiscordNotification
+  onResendDiscordNotification,
+  isApprovalOpen = false,
+  onToggleApproval,
+  inlineApprovalContent,
 }: BookingRequestCardProps) => {
   const [resending, setResending] = useState(false)
+  const [codeCopied, setCodeCopied] = useState(false)
+
   const elapsedDays = getElapsedDays(request.created_at)
   const elapsedTimeColor = elapsedDays >= 3 ? 'text-red-600 font-medium' : 'text-purple-600'
-  
   const hasUnrespondedGMs = request.gm_responses?.some(r => !hasGmResponded(r))
-  const isWaitingStatus = request.status === 'pending' || request.status === 'pending_gm' || request.status === 'pending_store'
+  const isWaitingStatus = ['pending', 'pending_gm', 'pending_store'].includes(request.status)
 
   const handleResend = async () => {
     if (!onResendDiscordNotification || resending) return
     setResending(true)
-    // ブラウザに描画を先に済ませてもらう（INP対策）
     await new Promise(resolve => setTimeout(resolve, 0))
-    try {
-      await onResendDiscordNotification(request)
-    } finally {
-      setResending(false)
-    }
+    try { await onResendDiscordNotification(request) }
+    finally { setResending(false) }
   }
-  
+
+  const handleCopyCode = async () => {
+    if (!request.invite_code) return
+    await navigator.clipboard.writeText(request.invite_code).catch(() => null)
+    setCodeCopied(true)
+    setTimeout(() => setCodeCopied(false), 2000)
+  }
+
   return (
-    <Card className={cn(getCardClassName(request.status), "shadow-none")}>
+    <Card className={cn(getCardClassName(request.status), 'shadow-none')}>
       <CardHeader className="pb-2">
-        {/* ── 1行目: タイトル + ステータス ── */}
+        {/* ── タイトル + ステータス ── */}
         <div className="flex items-start justify-between gap-2">
           <CardTitle className="text-base leading-snug">{request.scenario_title}</CardTitle>
           <StatusBadge status={request.status} />
         </div>
 
-        {/* ── 2行目: サマリー情報（スキャン用） ── */}
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-xs text-muted-foreground">
+        {/* ── サマリー1行 ── */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1.5 text-xs text-muted-foreground">
           <span>#{request.reservation_number}</span>
-          <span>
-            {request.customer_name}・{formatPrivateBookingParticipantLabel(request.participant_count, request.joined_member_count)}
-          </span>
+          <span>{request.customer_name}・{formatPrivateBookingParticipantLabel(request.participant_count, request.joined_member_count)}</span>
           <span className={elapsedTimeColor}>{getElapsedTime(request.created_at)}</span>
         </div>
 
-        {/* ── 希望店舗（折り畳み） ── */}
+        {/* ── 連絡先・招待コード ── */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5 mt-1.5 text-xs text-muted-foreground">
+          {request.customer_email && (
+            <span className="flex items-center gap-1">
+              <Mail className="w-3 h-3" />{request.customer_email}
+            </span>
+          )}
+          {request.customer_phone && (
+            <span className="flex items-center gap-1">
+              <Phone className="w-3 h-3" />{request.customer_phone}
+            </span>
+          )}
+          {request.invite_code && (
+            <button
+              onClick={handleCopyCode}
+              className="flex items-center gap-1 font-mono bg-purple-50 text-purple-700 px-1.5 py-0.5 rounded hover:bg-purple-100 transition-colors"
+              title="招待コードをコピー"
+            >
+              {request.invite_code}
+              {codeCopied
+                ? <Check className="w-3 h-3 text-green-600" />
+                : <Copy className="w-3 h-3 opacity-60" />}
+            </button>
+          )}
+        </div>
+
+        {/* ── 希望店舗 ── */}
         {request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 && (
           <div className="flex flex-wrap gap-1 mt-1.5">
-            <span className="text-xs text-muted-foreground mr-0.5">希望店舗:</span>
-            {request.candidate_datetimes.requestedStores.map((store, index) => (
-              <Badge key={index} variant="secondary" className="bg-gray-100 text-gray-700 border-0 rounded font-normal text-xs py-0">
+            <span className="text-xs text-muted-foreground mr-0.5 self-center">希望店舗:</span>
+            {request.candidate_datetimes.requestedStores.map((store, i) => (
+              <Badge key={i} variant="secondary" className="bg-gray-100 text-gray-700 border-0 rounded font-normal text-xs py-0">
                 {store.storeName}
               </Badge>
             ))}
           </div>
         )}
+
+        {/* ── 人数警告 ── */}
         {request.scenario_player_count_range &&
-          isPlannedCountOutsideScenarioRange(
-            request.participant_count,
-            request.scenario_player_count_range
-          ) && (
-            <Alert variant="default" className="mt-2 border-amber-400 bg-amber-50 py-2 text-amber-950">
-              <AlertTitle className="text-xs font-semibold text-amber-900">
-                参加予定人数がシナリオの人数帯と一致しません
-              </AlertTitle>
-              <AlertDescription className="text-xs text-amber-900/90">
-                申込は <strong>{request.participant_count}名</strong> ですが、推奨人数は{' '}
-                <strong>{formatScenarioPlayerRange(request.scenario_player_count_range)}</strong>{' '}
-                です。
-              </AlertDescription>
-            </Alert>
-          )}
+          isPlannedCountOutsideScenarioRange(request.participant_count, request.scenario_player_count_range) && (
+          <Alert variant="default" className="mt-2 border-amber-400 bg-amber-50 py-2 text-amber-950">
+            <AlertTitle className="text-xs font-semibold text-amber-900">参加予定人数がシナリオの人数帯と一致しません</AlertTitle>
+            <AlertDescription className="text-xs text-amber-900/90">
+              予定 <strong>{request.participant_count}名</strong> / 推奨 <strong>{formatScenarioPlayerRange(request.scenario_player_count_range)}</strong>
+            </AlertDescription>
+          </Alert>
+        )}
       </CardHeader>
+
       <CardContent>
         <div className="space-y-3">
-          {/* GM回答表示 */}
+          {/* ── GM回答状況 ── */}
           {request.gm_responses && request.gm_responses.length > 0 && (
             <div className="bg-purple-50 p-3 rounded-lg">
               <div className="flex items-center justify-between mb-2">
                 <h4 className="text-sm font-medium text-purple-900">GM回答状況</h4>
                 {onResendDiscordNotification && hasUnrespondedGMs && isWaitingStatus && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
+                  <Button variant="ghost" size="sm"
                     className="h-7 px-2 text-xs text-purple-700 hover:text-purple-900 hover:bg-purple-100"
-                    onClick={handleResend}
-                    disabled={resending}
+                    onClick={handleResend} disabled={resending}
                   >
-                    <RefreshCw className={cn("w-3.5 h-3.5 mr-1", resending && "animate-spin")} />
+                    <RefreshCw className={cn('w-3.5 h-3.5 mr-1', resending && 'animate-spin')} />
                     {resending ? '送信中...' : 'Discord再通知'}
                   </Button>
                 )}
@@ -171,23 +195,19 @@ export const BookingRequestCard = ({
                   const replyLabel = formatGmReplyReceivedAt(replyIso)
                   return (
                     <div key={index} className="text-sm text-purple-800">
-                      <div>
-                        {response.gm_name || 'GM名不明'}:{' '}
-                        {!responded
-                          ? <span className="text-gray-500">⏳ 未回答</span>
-                          : isGmMarkedAvailable(response) ? '✅ 出勤可能' : '❌ 出勤不可'
-                        }
-                        {responded && response.available_candidates && response.available_candidates.length > 0 && (
-                          <span className="ml-2 text-purple-600">
-                            (候補{response.available_candidates.map((idx) => idx + 1).join(', ')})
-                          </span>
-                        )}
-                        {replyLabel ? (
-                          <span className="ml-2 text-xs text-purple-600 font-normal">
-                            ・回答 {replyLabel}
-                          </span>
-                        ) : null}
-                      </div>
+                      {response.gm_name || 'GM名不明'}:{' '}
+                      {!responded
+                        ? <span className="text-gray-500">⏳ 未回答</span>
+                        : isGmMarkedAvailable(response) ? '✅ 出勤可能' : '❌ 出勤不可'
+                      }
+                      {responded && (response.available_candidates?.length ?? 0) > 0 && (
+                        <span className="ml-2 text-purple-600">
+                          (候補{response.available_candidates!.map(i => i + 1).join(', ')})
+                        </span>
+                      )}
+                      {replyLabel && (
+                        <span className="ml-2 text-xs text-purple-600">・回答 {replyLabel}</span>
+                      )}
                     </div>
                   )
                 })}
@@ -195,79 +215,73 @@ export const BookingRequestCard = ({
             </div>
           )}
 
-          {/* 候補日時表示 */}
+          {/* ── 候補日時 ── */}
           <div>
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-              候補日時
-            </p>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">候補日時</p>
             <div className="space-y-1.5">
               {request.candidate_datetimes?.candidates?.map((candidate) => {
-                // GMが回答した候補かどうかをチェック
-                const isGMSelected = request.gm_responses?.some((response) =>
-                  isGmAvailableForCandidate(response, candidate.order - 1)
-                )
-                
-                // ステータスに応じたアイコンとスタイルを決定
-                const isWaitingForGM = request.status === 'pending' || request.status === 'pending_gm'
-                const isGMResponded = request.status === 'gm_confirmed' || request.status === 'pending_store'
+                const isGMSelected = request.gm_responses?.some(r => isGmAvailableForCandidate(r, candidate.order - 1))
+                const isWaitingForGM = ['pending', 'pending_gm'].includes(request.status)
+                const isGMResponded = ['gm_confirmed', 'pending_store'].includes(request.status)
                 const isConfirmed = request.status === 'confirmed'
-                
                 return (
-                <div
-                  key={candidate.order}
-                  className={`flex items-center gap-2 px-3 py-2 rounded text-sm ${
+                  <div key={candidate.order} className={`flex items-center gap-2 px-3 py-2 rounded text-sm ${
                     isConfirmed && isGMSelected ? 'bg-green-50 border border-green-200' :
                     isGMResponded && isGMSelected ? 'bg-purple-50 border border-purple-200' :
                     isWaitingForGM ? 'bg-gray-50 border border-gray-200' :
                     'bg-gray-50 border border-gray-200 opacity-60'
-                  }`}
-                >
-                  {isConfirmed && isGMSelected ? (
-                    <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
-                  ) : isGMResponded && isGMSelected ? (
-                    <CheckCircle2 className="w-4 h-4 text-purple-600 shrink-0" />
-                  ) : isWaitingForGM ? (
-                    <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />
-                  ) : (
-                    <XCircle className="w-4 h-4 text-red-400 shrink-0" />
-                  )}
-                  <span className="text-xs text-muted-foreground shrink-0">候補{candidate.order}</span>
-                  <span className="font-medium">{formatDate(candidate.date)}</span>
-                  <span className="text-muted-foreground">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
-                </div>
+                  }`}>
+                    {isConfirmed && isGMSelected ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
+                      : isGMResponded && isGMSelected ? <CheckCircle2 className="w-4 h-4 text-purple-600 shrink-0" />
+                      : isWaitingForGM ? <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />
+                      : <XCircle className="w-4 h-4 text-red-400 shrink-0" />}
+                    <span className="text-xs text-muted-foreground shrink-0">候補{candidate.order}</span>
+                    <span className="font-medium">{formatDate(candidate.date)}</span>
+                    <span className="text-muted-foreground">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+                  </div>
                 )
               })}
             </div>
           </div>
 
-          {/* 確定済み店舗の表示 */}
+          {/* ── 確定済み店舗 ── */}
           {request.candidate_datetimes?.confirmedStore && (
-            <div className="p-3 rounded border bg-purple-50 border-purple-200">
-              <div className="text-sm">
-                <span className="text-purple-800">開催店舗: </span>
-                <span className="text-purple-900">{request.candidate_datetimes.confirmedStore.storeName}</span>
-              </div>
+            <div className="p-3 rounded border bg-purple-50 border-purple-200 text-sm">
+              <span className="text-purple-800">開催店舗: </span>
+              <span className="text-purple-900 font-medium">{request.candidate_datetimes.confirmedStore.storeName}</span>
             </div>
           )}
 
-          {/* 顧客メモ */}
+          {/* ── メモ ── */}
           {request.notes && (
-            <div className="pt-3 border-t">
-              <p className="text-sm mb-2 text-muted-foreground">お客様からのメモ</p>
-              <p className="text-sm bg-background p-3 rounded border">{request.notes}</p>
+            <div className="pt-2 border-t">
+              <p className="text-xs text-muted-foreground mb-1">お客様メモ</p>
+              <p className="text-sm bg-background p-2 rounded border">{request.notes}</p>
             </div>
           )}
 
-          {/* 詳細確認ボタン */}
-          {showActionButton && (
-            <div className="pt-3 border-t">
-              <Button
-                onClick={() => onSelectRequest(request)}
-                className="w-full"
-                variant="default"
+          {/* ── 承認・処理トグル ── */}
+          {onToggleApproval && (
+            <div className="pt-2 border-t">
+              <button
+                onClick={onToggleApproval}
+                className={cn(
+                  'w-full flex items-center justify-between px-4 py-2.5 rounded-md text-sm font-medium transition-colors',
+                  isApprovalOpen
+                    ? 'bg-purple-100 text-purple-900 hover:bg-purple-200'
+                    : 'bg-gray-900 text-white hover:bg-gray-800'
+                )}
               >
-                詳細確認・承認/却下
-              </Button>
+                <span>{isApprovalOpen ? '承認フォームを閉じる' : '承認・処理を行う'}</span>
+                {isApprovalOpen ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+              </button>
+
+              {/* ── インライン承認フォーム ── */}
+              {isApprovalOpen && inlineApprovalContent && (
+                <div className="mt-3 rounded-lg border border-purple-200 bg-purple-50/40 p-4 space-y-4">
+                  {inlineApprovalContent}
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -275,4 +289,3 @@ export const BookingRequestCard = ({
     </Card>
   )
 }
-

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -242,41 +242,40 @@ export const BookingRequestCard = ({
                           : 'border-gray-200 bg-gray-50'
                       )}
                     >
-                      {/* 1行目：アイコン + 日付 + 時間 */}
-                      <div className="flex items-center gap-2">
+                      {/* 1行目：アイコン + 日付 + 時間 + 店舗バッジ */}
+                      <div className="flex items-center gap-2 flex-wrap">
                         {isConfirmed && isGMAvailable
                           ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
                           : isThisSelected
                           ? <CheckCircle2 className="w-4 h-4 text-purple-500 shrink-0" />
                           : <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />}
                         <span className="font-medium">{formatDate(candidate.date)}</span>
-                        <span className="text-muted-foreground text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+                        <span className="text-muted-foreground text-xs whitespace-nowrap">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+                        {availableStores && availableStores.length === 0 && (
+                          <span className="text-xs text-red-500">空き店舗なし</span>
+                        )}
+                        {availableStores && availableStores.length > 0 && (
+                          <>
+                            {availableStores.slice(0, 4).map(s => (
+                              <span key={s.id} className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200 whitespace-nowrap">
+                                {s.short_name || s.name}
+                              </span>
+                            ))}
+                            {availableStores.length > 4 && (
+                              <span className="text-xs text-gray-400">+{availableStores.length - 4}</span>
+                            )}
+                          </>
+                        )}
                       </div>
 
-                      {/* 2行目：GMバッジ + 店舗バッジ（storesPerCandidateが渡された時 or GMバッジがある時） */}
-                      {(availableGMs.length > 0 || storesPerCandidate !== undefined) && (
-                        <div className="flex flex-wrap items-center gap-1 mt-1.5 pl-6">
+                      {/* 2行目：GMバッジ（対応可能GMがいる時のみ） */}
+                      {availableGMs.length > 0 && (
+                        <div className="flex flex-wrap items-center gap-1 mt-1 pl-6">
                           {availableGMs.map((gm, i) => (
                             <span key={i} className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 font-medium">
                               {gm.gm_name?.slice(0, 4) ?? 'GM'}
                             </span>
                           ))}
-                          {availableStores && availableStores.length > 0 && (
-                            <>
-                              {availableGMs.length > 0 && <span className="text-gray-300 text-xs">|</span>}
-                              {availableStores.slice(0, 4).map(s => (
-                                <span key={s.id} className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200">
-                                  {s.short_name || s.name}
-                                </span>
-                              ))}
-                              {availableStores.length > 4 && (
-                                <span className="text-xs text-gray-400">+{availableStores.length - 4}</span>
-                              )}
-                            </>
-                          )}
-                          {availableStores && availableStores.length === 0 && (
-                            <span className="text-xs text-red-500">空き店舗なし</span>
-                          )}
                         </div>
                       )}
                     </div>

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -4,8 +4,8 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
-  Calendar, Clock, CheckCircle2, XCircle, CircleDashed,
-  RefreshCw, ChevronDown, ChevronUp, Copy, Check, Mail, Phone
+  CheckCircle2, CircleDashed,
+  RefreshCw, Copy, Check, Mail, Phone
 } from 'lucide-react'
 import { StatusBadge } from './StatusBadge'
 import {
@@ -69,17 +69,17 @@ interface BookingRequest {
 interface BookingRequestCardProps {
   request: BookingRequest
   onResendDiscordNotification?: (request: { id: string; scenario_title: string }) => Promise<void>
-  // インライン承認
-  isApprovalOpen?: boolean
-  onToggleApproval?: () => void
-  inlineApprovalContent?: React.ReactNode
+  // 候補日クリックで承認モードへ
+  selectedCandidateOrder?: number | null
+  onSelectCandidate?: (req: BookingRequest, order: number) => void
+  inlineApprovalContent?: React.ReactNode  // 選択中候補行の直下に挿入
 }
 
 export const BookingRequestCard = ({
   request,
   onResendDiscordNotification,
-  isApprovalOpen = false,
-  onToggleApproval,
+  selectedCandidateOrder,
+  onSelectCandidate,
   inlineApprovalContent,
 }: BookingRequestCardProps) => {
   const [resending, setResending] = useState(false)
@@ -207,28 +207,63 @@ export const BookingRequestCard = ({
             </div>
           )}
 
-          {/* ── 候補日時 ── */}
+          {/* ── 候補日時（クリックで選択 → 直下にプルダウン展開） ── */}
           <div>
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">候補日時</p>
-            <div className="space-y-1.5">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1.5">
+              候補日時{onSelectCandidate ? <span className="ml-1 font-normal normal-case text-purple-600">（タップして承認処理）</span> : ''}
+            </p>
+            <div className="space-y-1">
               {request.candidate_datetimes?.candidates?.map((candidate) => {
-                const isGMSelected = request.gm_responses?.some(r => isGmAvailableForCandidate(r, candidate.order - 1))
-                const isWaitingForGM = ['pending', 'pending_gm'].includes(request.status)
-                const isGMResponded = ['gm_confirmed', 'pending_store'].includes(request.status)
+                const isGMAvailable = request.gm_responses?.some(r => isGmAvailableForCandidate(r, candidate.order - 1))
+                const availableGMs = request.gm_responses?.filter(r => isGmAvailableForCandidate(r, candidate.order - 1)) ?? []
                 const isConfirmed = request.status === 'confirmed'
+                const isThisSelected = selectedCandidateOrder === candidate.order
+                const clickable = !!onSelectCandidate
+
                 return (
-                  <div key={candidate.order} className={`flex items-center gap-2 px-3 py-2 rounded text-sm ${
-                    isConfirmed && isGMSelected ? 'bg-green-50 border border-green-200' :
-                    isGMResponded && isGMSelected ? 'bg-purple-50 border border-purple-200' :
-                    isWaitingForGM ? 'bg-gray-50 border border-gray-200' :
-                    'bg-gray-50 border border-gray-200 opacity-60'
-                  }`}>
-                    {isConfirmed && isGMSelected ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
-                      : isGMResponded && isGMSelected ? <CheckCircle2 className="w-4 h-4 text-purple-600 shrink-0" />
-                      : isWaitingForGM ? <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />
-                      : <XCircle className="w-4 h-4 text-red-400 shrink-0" />}
-                    <span className="font-medium">{formatDate(candidate.date)}</span>
-                    <span className="text-muted-foreground text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+                  <div key={candidate.order}>
+                    {/* 候補行 */}
+                    <div
+                      onClick={() => clickable && onSelectCandidate(request, candidate.order)}
+                      className={cn(
+                        'flex items-center gap-2 px-3 py-2 rounded text-sm border transition-colors',
+                        clickable ? 'cursor-pointer' : '',
+                        isThisSelected
+                          ? 'border-purple-400 bg-purple-50 rounded-b-none'
+                          : isConfirmed && isGMAvailable
+                          ? 'border-green-200 bg-green-50'
+                          : clickable
+                          ? 'border-gray-200 bg-gray-50 hover:border-purple-300 hover:bg-purple-50/40'
+                          : 'border-gray-200 bg-gray-50'
+                      )}
+                    >
+                      {isConfirmed && isGMAvailable
+                        ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
+                        : isThisSelected
+                        ? <CheckCircle2 className="w-4 h-4 text-purple-500 shrink-0" />
+                        : <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />}
+
+                      <span className="font-medium">{formatDate(candidate.date)}</span>
+                      <span className="text-muted-foreground text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+
+                      {/* 対応可能GMバッジ */}
+                      {availableGMs.length > 0 && (
+                        <div className="flex items-center gap-1 ml-auto flex-wrap">
+                          {availableGMs.map((gm, i) => (
+                            <span key={i} className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 font-medium">
+                              {gm.gm_name?.slice(0, 3) ?? 'GM'}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* 選択時：店舗・GMプルダウンを直下展開 */}
+                    {isThisSelected && inlineApprovalContent && (
+                      <div className="border border-t-0 border-purple-300 rounded-b-md bg-purple-50/50 px-3 py-3">
+                        {inlineApprovalContent}
+                      </div>
+                    )}
                   </div>
                 )
               })}
@@ -251,30 +286,6 @@ export const BookingRequestCard = ({
             </div>
           )}
 
-          {/* ── 承認・処理トグル ── */}
-          {onToggleApproval && (
-            <div className="pt-2 border-t">
-              <button
-                onClick={onToggleApproval}
-                className={cn(
-                  'w-full flex items-center justify-between px-4 py-2.5 rounded-md text-sm font-medium transition-colors',
-                  isApprovalOpen
-                    ? 'bg-purple-100 text-purple-900 hover:bg-purple-200'
-                    : 'bg-gray-900 text-white hover:bg-gray-800'
-                )}
-              >
-                <span>{isApprovalOpen ? '承認フォームを閉じる' : '承認・処理を行う'}</span>
-                {isApprovalOpen ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-              </button>
-
-              {/* ── インライン承認フォーム ── */}
-              {isApprovalOpen && inlineApprovalContent && (
-                <div className="mt-3 rounded-lg border border-purple-200 bg-purple-50/40 p-4 space-y-4">
-                  {inlineApprovalContent}
-                </div>
-              )}
-            </div>
-          )}
         </div>
       </CardContent>
     </Card>

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -73,6 +73,7 @@ interface BookingRequestCardProps {
   selectedCandidateOrder?: number | null
   onSelectCandidate?: (req: BookingRequest, order: number) => void
   inlineApprovalContent?: React.ReactNode
+  cardActionsContent?: React.ReactNode
   // 候補ごとの空き店舗（承認モード時のみ渡す）
   storesPerCandidate?: Record<number, Array<{ id: string; name: string; short_name?: string }>>
 }
@@ -83,6 +84,7 @@ export const BookingRequestCard = ({
   selectedCandidateOrder,
   onSelectCandidate,
   inlineApprovalContent,
+  cardActionsContent,
   storesPerCandidate,
 }: BookingRequestCardProps) => {
   const [resending, setResending] = useState(false)
@@ -110,7 +112,7 @@ export const BookingRequestCard = ({
 
   return (
     <Card className={cn(getCardClassName(request.status), 'shadow-none')}>
-      <CardHeader className="pb-2">
+      <CardHeader className="pt-3 pb-2 space-y-0">
         {/* ── タイトル + ステータス ── */}
         <div className="flex items-start justify-between gap-2">
           <CardTitle className="text-base leading-snug">{request.scenario_title}</CardTitle>
@@ -151,16 +153,25 @@ export const BookingRequestCard = ({
         </div>
 
         {/* ── 希望店舗 ── */}
-        {request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-1.5">
-            <span className="text-xs text-muted-foreground mr-0.5 self-center">希望店舗:</span>
-            {request.candidate_datetimes.requestedStores.map((store, i) => (
-              <Badge key={i} variant="secondary" className="bg-gray-100 text-gray-700 border-0 rounded font-normal text-xs py-0">
-                {store.storeName}
-              </Badge>
-            ))}
-          </div>
-        )}
+        {request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 && (() => {
+          // storesPerCandidate から storeId → short_name のルックアップを構築
+          const shortNameById: Record<string, string> = {}
+          if (storesPerCandidate) {
+            Object.values(storesPerCandidate).forEach(list =>
+              list.forEach(s => { if (!shortNameById[s.id]) shortNameById[s.id] = s.short_name || s.name })
+            )
+          }
+          return (
+            <div className="flex flex-wrap items-center gap-1 mt-1">
+              <span className="text-xs text-muted-foreground shrink-0">希望店舗:</span>
+              {request.candidate_datetimes!.requestedStores!.map((store, i) => (
+                <span key={i} className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200 whitespace-nowrap">
+                  {shortNameById[store.storeId] || store.storeName}
+                </span>
+              ))}
+            </div>
+          )
+        })()}
 
         {/* ── 人数警告 ── */}
         {request.scenario_player_count_range &&
@@ -174,7 +185,7 @@ export const BookingRequestCard = ({
         )}
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="md:pt-0">
         <div className="space-y-3">
           {/* ── GM回答状況 ── */}
           {request.gm_responses && request.gm_responses.length > 0 && (
@@ -309,6 +320,13 @@ export const BookingRequestCard = ({
           )}
 
         </div>
+
+        {/* ── カード下部アクション（承認・却下） ── */}
+        {cardActionsContent && (
+          <div className="mt-3 pt-3 border-t border-gray-200">
+            {cardActionsContent}
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -253,8 +253,8 @@ export const BookingRequestCard = ({
                         <span className="text-muted-foreground text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
                       </div>
 
-                      {/* 2行目：GMバッジ + 店舗バッジ（データがある時のみ） */}
-                      {(availableGMs.length > 0 || availableStores) && (
+                      {/* 2行目：GMバッジ + 店舗バッジ（storesPerCandidateが渡された時 or GMバッジがある時） */}
+                      {(availableGMs.length > 0 || storesPerCandidate !== undefined) && (
                         <div className="flex flex-wrap items-center gap-1 mt-1.5 pl-6">
                           {availableGMs.map((gm, i) => (
                             <span key={i} className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 font-medium">

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -100,53 +100,49 @@ export const BookingRequestCard = ({
   
   return (
     <Card className={cn(getCardClassName(request.status), "shadow-none")}>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-base">{request.scenario_title}</CardTitle>
+      <CardHeader className="pb-2">
+        {/* ── 1行目: タイトル + ステータス ── */}
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base leading-snug">{request.scenario_title}</CardTitle>
           <StatusBadge status={request.status} />
         </div>
-        <div className="text-xs text-muted-foreground space-y-1 mt-2">
-          <div>予約番号: {request.reservation_number}</div>
-          <div className="flex items-center gap-2">
-            <span>申込日時: {formatDateTime(request.created_at)}</span>
-            <span className={elapsedTimeColor}>({getElapsedTime(request.created_at)})</span>
-          </div>
-          <div>
-            お客様: {request.customer_name}（
-            {formatPrivateBookingParticipantLabel(request.participant_count, request.joined_member_count)}）
-          </div>
-          {request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 && (
-            <div className="flex items-center gap-2 flex-wrap">
-              <span>希望店舗:</span>
-              {request.candidate_datetimes.requestedStores.map((store, index) => (
-                <Badge key={index} variant="secondary" className="bg-gray-100 text-gray-800 border-0 rounded-[2px] font-normal text-xs">
-                  {store.storeName}
-                </Badge>
-              ))}
-            </div>
-          )}
-          {(!request.candidate_datetimes?.requestedStores || request.candidate_datetimes.requestedStores.length === 0) && (
-            <div className="text-purple-600 text-sm">
-              希望店舗: 全ての店舗（顧客希望）
-            </div>
-          )}
-          {request.scenario_player_count_range &&
-            isPlannedCountOutsideScenarioRange(
-              request.participant_count,
-              request.scenario_player_count_range
-            ) && (
-              <Alert variant="default" className="mt-2 border-amber-400 bg-amber-50 py-2 text-amber-950">
-                <AlertTitle className="text-xs font-semibold text-amber-900">
-                  参加予定人数がシナリオの人数帯と一致しません
-                </AlertTitle>
-                <AlertDescription className="text-xs text-amber-900/90">
-                  申込は <strong>{request.participant_count}名</strong> ですが、作品の推奨人数は{' '}
-                  <strong>{formatScenarioPlayerRange(request.scenario_player_count_range)}</strong>{' '}
-                  です。別作品の申込・人数の取り違えがないかご確認ください。
-                </AlertDescription>
-              </Alert>
-            )}
+
+        {/* ── 2行目: サマリー情報（スキャン用） ── */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-xs text-muted-foreground">
+          <span>#{request.reservation_number}</span>
+          <span>
+            {request.customer_name}・{formatPrivateBookingParticipantLabel(request.participant_count, request.joined_member_count)}
+          </span>
+          <span className={elapsedTimeColor}>{getElapsedTime(request.created_at)}</span>
         </div>
+
+        {/* ── 希望店舗（折り畳み） ── */}
+        {request.candidate_datetimes?.requestedStores && request.candidate_datetimes.requestedStores.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1.5">
+            <span className="text-xs text-muted-foreground mr-0.5">希望店舗:</span>
+            {request.candidate_datetimes.requestedStores.map((store, index) => (
+              <Badge key={index} variant="secondary" className="bg-gray-100 text-gray-700 border-0 rounded font-normal text-xs py-0">
+                {store.storeName}
+              </Badge>
+            ))}
+          </div>
+        )}
+        {request.scenario_player_count_range &&
+          isPlannedCountOutsideScenarioRange(
+            request.participant_count,
+            request.scenario_player_count_range
+          ) && (
+            <Alert variant="default" className="mt-2 border-amber-400 bg-amber-50 py-2 text-amber-950">
+              <AlertTitle className="text-xs font-semibold text-amber-900">
+                参加予定人数がシナリオの人数帯と一致しません
+              </AlertTitle>
+              <AlertDescription className="text-xs text-amber-900/90">
+                申込は <strong>{request.participant_count}名</strong> ですが、推奨人数は{' '}
+                <strong>{formatScenarioPlayerRange(request.scenario_player_count_range)}</strong>{' '}
+                です。
+              </AlertDescription>
+            </Alert>
+          )}
       </CardHeader>
       <CardContent>
         <div className="space-y-3">
@@ -201,24 +197,10 @@ export const BookingRequestCard = ({
 
           {/* 候補日時表示 */}
           <div>
-            <p className="text-sm font-medium mb-2 text-purple-800">
-              お客様希望候補日時
-              {request.status === 'confirmed' ? '（確定済み）' : 
-               (request.status === 'gm_confirmed' || request.status === 'pending_store') ? '（GM回答済み・店舗確認待ち）' : 
-               (request.status === 'pending' || request.status === 'pending_gm') ? '（GM回答待ち）' :
-               ''}
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+              候補日時
             </p>
-            {(request.status === 'pending' || request.status === 'pending_gm') && (
-              <p className="text-xs text-gray-500 mb-2">
-                ○ = GMからの回答待ち
-              </p>
-            )}
-            {(request.status === 'gm_confirmed' || request.status === 'pending_store' || request.status === 'confirmed') && (
-              <p className="text-xs text-purple-600 mb-2">
-                ✓ = GMが出勤可能と回答 ・ ✗ = 出勤不可
-              </p>
-            )}
-            <div className="space-y-2">
+            <div className="space-y-1.5">
               {request.candidate_datetimes?.candidates?.map((candidate) => {
                 // GMが回答した候補かどうかをチェック
                 const isGMSelected = request.gm_responses?.some((response) =>
@@ -233,37 +215,25 @@ export const BookingRequestCard = ({
                 return (
                 <div
                   key={candidate.order}
-                  className={`flex items-center gap-3 p-3 rounded border ${
-                    isConfirmed && isGMSelected ? 'bg-green-50 border-green-300' :
-                    isGMResponded && isGMSelected ? 'bg-purple-50 border-purple-300' :
-                    isWaitingForGM ? 'bg-gray-50 border-gray-200' :
-                    'bg-gray-50 border-gray-300'
+                  className={`flex items-center gap-2 px-3 py-2 rounded text-sm ${
+                    isConfirmed && isGMSelected ? 'bg-green-50 border border-green-200' :
+                    isGMResponded && isGMSelected ? 'bg-purple-50 border border-purple-200' :
+                    isWaitingForGM ? 'bg-gray-50 border border-gray-200' :
+                    'bg-gray-50 border border-gray-200 opacity-60'
                   }`}
                 >
                   {isConfirmed && isGMSelected ? (
-                    <CheckCircle2 className="w-5 h-5 text-green-600" />
+                    <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
                   ) : isGMResponded && isGMSelected ? (
-                    <CheckCircle2 className="w-5 h-5 text-purple-600" />
+                    <CheckCircle2 className="w-4 h-4 text-purple-600 shrink-0" />
                   ) : isWaitingForGM ? (
-                    <CircleDashed className="w-5 h-5 text-gray-400" />
+                    <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />
                   ) : (
-                    <XCircle className="w-5 h-5 text-red-600" />
+                    <XCircle className="w-4 h-4 text-red-400 shrink-0" />
                   )}
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3">
-                      <Badge variant="secondary" className="bg-gray-100 text-gray-800 border-0 rounded-[2px] font-normal">
-                        候補{candidate.order}
-                      </Badge>
-                      <div className="flex items-center gap-2 text-sm">
-                        <Calendar className="w-4 h-4 text-muted-foreground" />
-                        <span className="">{formatDate(candidate.date)}</span>
-                      </div>
-                      <div className="flex items-center gap-2 text-sm">
-                        <Clock className="w-4 h-4 text-muted-foreground" />
-                        <span>{candidate.timeSlot} {candidate.startTime} - {candidate.endTime}</span>
-                      </div>
-                    </div>
-                  </div>
+                  <span className="text-xs text-muted-foreground shrink-0">候補{candidate.order}</span>
+                  <span className="font-medium">{formatDate(candidate.date)}</span>
+                  <span className="text-muted-foreground">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
                 </div>
                 )
               })}

--- a/src/pages/PrivateBookingManagement/components/CandidateDateSelector.tsx
+++ b/src/pages/PrivateBookingManagement/components/CandidateDateSelector.tsx
@@ -1,4 +1,4 @@
-import { Calendar, Clock, XCircle, CheckCircle2, MapPin } from 'lucide-react'
+import { Calendar } from 'lucide-react'
 import { formatJapanCalendarDateLabel } from '@/lib/japanCalendarDate'
 import { isGmAvailableForCandidate } from '../utils/gmAvailabilityStatus'
 
@@ -17,13 +17,14 @@ interface Candidate {
 interface ConflictInfo {
   storeDateConflicts: Set<string>
   gmDateConflicts: Set<string>
+  existingEvents?: Array<{ storeId: string; date: string; startTime: string; endTime: string; scenario: string }>
 }
 
 interface GMResponse {
   gm_id: string
   gm_name: string
   response_status: 'available' | 'unavailable' | string
-  available_candidates: number[] // 0始まりのインデックス
+  available_candidates: number[]
   avatar_color?: string | null
   responded_at?: string | null
 }
@@ -32,6 +33,13 @@ interface Store {
   id: string
   name: string
   short_name?: string
+  region?: string
+}
+
+interface GMSelectOption {
+  gm: { id: string; name?: string }
+  isGMDisabled: boolean
+  label: string
 }
 
 interface CandidateDateSelectorProps {
@@ -39,28 +47,21 @@ interface CandidateDateSelectorProps {
   selectedCandidateOrder: number | null
   selectedStoreId: string
   selectedGMId: string
+  selectedSubGmId?: string
   conflictInfo: ConflictInfo
   onSelectCandidate: (order: number) => void
-  gmSelectedCandidates?: number[] // GM確認済み・確定済みの場合の選択候補
-  gmResponses?: GMResponse[] // 全GMの回答情報
-  isReadOnly?: boolean // 閲覧専用モード（GM確認済み・確定済み）
-  isConfirmed?: boolean // 確定済みフラグ（緑色表示用）
-  stores?: Store[] // シナリオ対応店舗リスト（空き店舗表示用）
+  onSelectStore: (storeId: string) => void
+  onSelectGM: (gmId: string) => void
+  onSelectSubGM?: (gmId: string) => void
+  gmSelectOptions: GMSelectOption[]
+  stores: Store[]
+  requiredGmCount?: number
+  gmSelectedCandidates?: number[]
+  gmResponses?: GMResponse[]
+  isReadOnly?: boolean
+  isConfirmed?: boolean
 }
 
-/**
- * 候補日時選択コンポーネント
- */
-// GMの名前を省略形で表示（スケジュールページと同じスタイル）
-const getShortName = (name: string): string => {
-  if (!name) return '?'
-  // 2文字以下ならそのまま
-  if (name.length <= 2) return name
-  // 3文字以上なら最初の2文字
-  return name.slice(0, 2)
-}
-
-// avatar_color（背景色）から文字色を取得するマップ（スケジュールと同じ）
 const COLOR_MAP: Record<string, string> = {
   '#EFF6FF': '#2563EB', '#F0FDF4': '#16A34A',
   '#FFFBEB': '#D97706', '#FEF2F2': '#DC2626',
@@ -68,42 +69,24 @@ const COLOR_MAP: Record<string, string> = {
   '#ECFEFF': '#0891B2', '#F7FEE7': '#65A30D',
 }
 
-// スタッフの色からスタイルを取得
-const getGMBadgeStyle = (avatarColor?: string | null, name?: string): { bgColor: string, textColor: string } => {
+const getGMBadgeStyle = (avatarColor?: string | null, name?: string) => {
   if (avatarColor && COLOR_MAP[avatarColor]) {
-    return {
-      bgColor: avatarColor,
-      textColor: COLOR_MAP[avatarColor]
-    }
+    return { bgColor: avatarColor, textColor: COLOR_MAP[avatarColor] }
   }
-  // avatar_color未設定の場合は名前からハッシュ値を計算して色を決定
-  const AVATAR_TEXT_COLORS = [
-    '#2563EB', '#16A34A', '#D97706', '#DC2626', '#7C3AED', '#DB2777', '#0891B2', '#65A30D'
-  ]
-  const AVATAR_BG_COLORS = [
-    '#EFF6FF', '#F0FDF4', '#FFFBEB', '#FEF2F2', '#F5F3FF', '#FDF2F8', '#ECFEFF', '#F7FEE7'
-  ]
-  const hash = (name || '').split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
-  const colorIndex = hash % AVATAR_TEXT_COLORS.length
-  return {
-    bgColor: AVATAR_BG_COLORS[colorIndex],
-    textColor: AVATAR_TEXT_COLORS[colorIndex]
-  }
+  const COLORS = ['#2563EB','#16A34A','#D97706','#DC2626','#7C3AED','#DB2777','#0891B2','#65A30D']
+  const BGS   = ['#EFF6FF','#F0FDF4','#FFFBEB','#FEF2F2','#F5F3FF','#FDF2F8','#ECFEFF','#F7FEE7']
+  const h = (name || '').split('').reduce((a, c) => a + c.charCodeAt(0), 0)
+  return { bgColor: BGS[h % COLORS.length], textColor: COLORS[h % COLORS.length] }
 }
 
-// 時間帯を正規化する関数（「夜公演」→「夜」、「朝公演」→「午前」など）
-// 競合チェック時のキーと一致させる必要がある
-const normalizeTimeSlot = (timeSlot: string): string => {
-  // 標準ラベル（午前/午後/夜）をそのまま使用
-  if (timeSlot === '午前' || timeSlot === '午後' || timeSlot === '夜') {
-    return timeSlot
-  }
-  // 朝/昼/夜が含まれる場合は標準ラベルに変換
-  if (timeSlot.includes('朝') || timeSlot.includes('午前')) return '午前'
-  if (timeSlot.includes('昼') || timeSlot.includes('午後')) return '午後'
-  if (timeSlot.includes('夜')) return '夜'
-  // それ以外はそのまま返す
-  return timeSlot
+const getShortName = (name: string) => name?.length <= 2 ? name : name?.slice(0, 2)
+
+const normalizeTimeSlot = (ts: string) => {
+  if (['午前','午後','夜'].includes(ts)) return ts
+  if (ts.includes('朝') || ts.includes('午前')) return '午前'
+  if (ts.includes('昼') || ts.includes('午後')) return '午後'
+  if (ts.includes('夜')) return '夜'
+  return ts
 }
 
 export const CandidateDateSelector = ({
@@ -111,27 +94,29 @@ export const CandidateDateSelector = ({
   selectedCandidateOrder,
   selectedStoreId,
   selectedGMId,
+  selectedSubGmId = '',
   conflictInfo,
   onSelectCandidate,
+  onSelectStore,
+  onSelectGM,
+  onSelectSubGM,
+  gmSelectOptions,
+  stores = [],
+  requiredGmCount = 1,
   gmSelectedCandidates,
   gmResponses = [],
   isReadOnly = false,
   isConfirmed = false,
-  stores = []
 }: CandidateDateSelectorProps) => {
-  // 候補日時に対して空き店舗を計算する関数
-  const getAvailableStores = (candidate: Candidate): Store[] => {
-    if (stores.length === 0) return []
-    
-    // 時間帯を正規化（「夜公演」→「夜」など）
-    const normalizedTimeSlot = normalizeTimeSlot(candidate.timeSlot)
-    
-    return stores.filter(store => {
-      const conflictKey = `${store.id}-${candidate.date}-${normalizedTimeSlot}`
-      const hasConflict = conflictInfo.storeDateConflicts.has(conflictKey)
-      return !hasConflict
-    })
+
+  const getAvailableStores = (candidate: Candidate) => {
+    const norm = normalizeTimeSlot(candidate.timeSlot)
+    return stores.filter(s => !conflictInfo.storeDateConflicts.has(`${s.id}-${candidate.date}-${norm}`))
   }
+
+  const getAvailableGMsForCandidate = (candidate: Candidate) =>
+    gmResponses.filter(gm => isGmAvailableForCandidate(gm, candidate.order - 1))
+
   return (
     <div>
       <h3 className="mb-2 flex items-center gap-2 text-sm font-medium text-purple-800">
@@ -141,94 +126,158 @@ export const CandidateDateSelector = ({
       <div className="space-y-1.5">
         {candidates.map((candidate) => {
           const isSelected = selectedCandidateOrder === candidate.order
-          const isGMSelected = gmSelectedCandidates && gmSelectedCandidates.includes(candidate.order)
-          const availableStoresForCandidate = getAvailableStores(candidate)
-          const hasNoAvailableStore = stores.length > 0 && availableStoresForCandidate.length === 0
-          const gmConflictKey = selectedGMId ? `${selectedGMId}-${candidate.date}-${candidate.timeSlot}` : null
-          const hasGMConflict = gmConflictKey && conflictInfo.gmDateConflicts.has(gmConflictKey)
-          const hasConflict = hasNoAvailableStore
-          const isDisabledInReadOnlyMode = isReadOnly && !isSelected
-          const isConfirmedAndSelected = isConfirmed && isSelected
-          const availableGMs = gmResponses.filter(gm => isGmAvailableForCandidate(gm, candidate.order - 1))
+          const availableStores = getAvailableStores(candidate)
+          const availableGMs = getAvailableGMsForCandidate(candidate)
+          const hasNoStore = stores.length > 0 && availableStores.length === 0
+          const isDisabled = hasNoStore || (isReadOnly && !isSelected)
+
+          // 選択中候補で使えるGMオプション（available_candidatesにこの候補が含まれるもの）
+          const filteredGMOptions = gmSelectOptions.filter(({ gm }) =>
+            availableGMs.some(ag => String(ag.gm_id) === String(gm.id))
+          )
+          // 使えるGMがいない場合は全GMを表示（未回答GMも含む）
+          const gmOptionsToShow = filteredGMOptions.length > 0 ? filteredGMOptions : gmSelectOptions
 
           return (
-            <div
-              key={candidate.order}
-              onClick={() => !hasConflict && !isReadOnly && onSelectCandidate(candidate.order)}
-              className={`flex items-center gap-2 px-3 py-2 rounded border transition-all text-sm ${
-                hasConflict
-                  ? 'border-red-200 bg-red-50 opacity-60 cursor-not-allowed'
-                  : isDisabledInReadOnlyMode
-                  ? 'bg-gray-50 border-gray-200 cursor-default opacity-50'
-                  : isConfirmedAndSelected
-                  ? 'border-green-400 bg-green-50 cursor-default'
-                  : isSelected
-                  ? 'border-purple-400 bg-purple-50 cursor-pointer'
-                  : 'border-gray-200 bg-background hover:border-purple-300 cursor-pointer'
-              }`}
-            >
-              {/* ラジオアイコン */}
-              <div className={`w-4 h-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
-                hasConflict ? 'border-red-400 bg-red-400'
-                : isConfirmedAndSelected ? 'border-green-500 bg-green-500'
-                : isSelected ? 'border-purple-500 bg-purple-500'
-                : 'border-gray-300'
-              }`}>
-                {hasConflict ? <XCircle className="w-3 h-3 text-white" />
-                  : isSelected ? <CheckCircle2 className="w-3 h-3 text-white" />
-                  : null}
-              </div>
-
-              {/* 日付・時間 */}
-              <span className="font-medium whitespace-nowrap">{formatCandidateDate(candidate.date)}</span>
-              <span className="text-muted-foreground whitespace-nowrap text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
-
-              {/* GMバッジ */}
-              {gmResponses.length > 0 && (
-                <div className="flex items-center gap-1 flex-wrap">
-                  {availableGMs.length === 0
-                    ? <span className="text-xs text-gray-400">GM回答なし</span>
-                    : availableGMs.map(gm => {
-                        const c = getGMBadgeStyle(gm.avatar_color, gm.gm_name)
-                        return (
-                          <span key={gm.gm_id}
-                            className="text-xs px-1.5 py-0.5 rounded border font-medium"
-                            style={{ backgroundColor: c.bgColor, color: c.textColor, borderColor: c.textColor + '40' }}
-                            title={gm.gm_name}
-                          >
-                            {getShortName(gm.gm_name)}
-                          </span>
-                        )
-                      })
-                  }
+            <div key={candidate.order}>
+              {/* ── 候補行 ── */}
+              <div
+                onClick={() => !isDisabled && !isReadOnly && onSelectCandidate(candidate.order)}
+                className={`flex items-center gap-2 px-3 py-2 rounded border transition-all text-sm ${
+                  hasNoStore
+                    ? 'border-red-200 bg-red-50 opacity-60 cursor-not-allowed'
+                    : isDisabled
+                    ? 'bg-gray-50 border-gray-200 cursor-default opacity-50'
+                    : isSelected && isConfirmed
+                    ? 'border-green-400 bg-green-50 cursor-default'
+                    : isSelected
+                    ? 'border-purple-400 bg-purple-50 cursor-pointer'
+                    : 'border-gray-200 bg-background hover:border-purple-300 cursor-pointer'
+                }`}
+              >
+                {/* ラジオ */}
+                <div className={`w-4 h-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+                  hasNoStore ? 'border-red-400 bg-red-400'
+                  : isSelected && isConfirmed ? 'border-green-500 bg-green-500'
+                  : isSelected ? 'border-purple-500 bg-purple-500'
+                  : 'border-gray-300'
+                }`}>
+                  {isSelected && <div className="w-1.5 h-1.5 rounded-full bg-white" />}
                 </div>
-              )}
 
-              {/* 空き店舗 */}
-              {stores.length > 0 && (
+                {/* 日付・時間 */}
+                <span className="font-medium whitespace-nowrap">{formatCandidateDate(candidate.date)}</span>
+                <span className="text-muted-foreground whitespace-nowrap text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+
+                {/* 対応可能GM */}
+                {availableGMs.length > 0 && (
+                  <div className="flex items-center gap-1 flex-wrap">
+                    {availableGMs.map(gm => {
+                      const c = getGMBadgeStyle(gm.avatar_color, gm.gm_name)
+                      return (
+                        <span key={gm.gm_id}
+                          className="text-xs px-1.5 py-0.5 rounded border font-medium"
+                          style={{ backgroundColor: c.bgColor, color: c.textColor, borderColor: c.textColor + '40' }}
+                        >
+                          {getShortName(gm.gm_name)}
+                        </span>
+                      )
+                    })}
+                  </div>
+                )}
+
+                {/* 空き店舗 */}
                 <div className="flex items-center gap-1 flex-wrap ml-auto">
-                  <MapPin className="w-3 h-3 text-gray-400 shrink-0" />
-                  {availableStoresForCandidate.length === 0
+                  {hasNoStore
                     ? <span className="text-xs text-red-500">空き店舗なし</span>
-                    : availableStoresForCandidate.length === stores.length
-                    ? <span className="text-xs text-green-600">全店舗空き</span>
-                    : availableStoresForCandidate.slice(0, 3).map(s => (
-                        <span key={s.id} className="text-xs px-1 py-0.5 rounded bg-gray-100 text-gray-700 border border-gray-200 whitespace-nowrap" title={s.name}>
+                    : availableStores.length === stores.length
+                    ? <span className="text-xs text-gray-400">全店舗空き</span>
+                    : availableStores.slice(0, 3).map(s => (
+                        <span key={s.id} className="text-xs px-1 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200 whitespace-nowrap">
                           {s.short_name || s.name}
                         </span>
                       ))
                   }
-                  {availableStoresForCandidate.length > 3 && (
-                    <span className="text-xs text-gray-500">+{availableStoresForCandidate.length - 3}</span>
+                  {availableStores.length > 3 && stores.length !== availableStores.length && (
+                    <span className="text-xs text-gray-400">+{availableStores.length - 3}</span>
                   )}
                 </div>
-              )}
+              </div>
 
-              {/* 警告テキスト */}
-              {(hasGMConflict || (isSelected && !isGMSelected && gmSelectedCandidates?.length)) && (
-                <span className="text-xs text-orange-600 whitespace-nowrap ml-1">
-                  {hasGMConflict ? '⚠️ GMに予定あり' : '⚠️ GM未回答'}
-                </span>
+              {/* ── 選択時：店舗・GMプルダウン ── */}
+              {isSelected && !isReadOnly && (
+                <div className="mx-1 px-3 py-3 border border-t-0 border-purple-200 rounded-b-md bg-purple-50/60 space-y-2">
+                  {/* 店舗 */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-purple-700 font-medium shrink-0 w-12">店舗</span>
+                    <select
+                      className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
+                      value={selectedStoreId}
+                      onChange={e => onSelectStore(e.target.value)}
+                    >
+                      <option value="">選択してください</option>
+                      {availableStores.map(s => {
+                        const reqStores = [] as string[] // requestedStores は親から渡す必要があるが簡略化
+                        const ev = (conflictInfo.existingEvents || []).find(e =>
+                          e.storeId === s.id && e.date === candidate.date &&
+                          candidate.startTime < e.endTime && candidate.endTime > e.startTime
+                        )
+                        return (
+                          <option key={s.id} value={s.id}>
+                            {s.name}{s.region ? ` (${s.region})` : ''}{ev ? ` ⚠️${ev.scenario}` : ''}
+                          </option>
+                        )
+                      })}
+                    </select>
+                  </div>
+
+                  {/* GM（メイン） */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-purple-700 font-medium shrink-0 w-12">
+                      {requiredGmCount >= 2 ? 'メインGM' : 'GM'}
+                    </span>
+                    <select
+                      className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
+                      value={selectedGMId}
+                      onChange={e => {
+                        onSelectGM(e.target.value)
+                        if (selectedSubGmId === e.target.value) onSelectSubGM?.('')
+                      }}
+                    >
+                      <option value="">選択してください</option>
+                      {gmOptionsToShow.map(({ gm, isGMDisabled, label }) => (
+                        <option key={gm.id} value={gm.id}
+                          disabled={isGMDisabled || (requiredGmCount >= 2 && gm.id === selectedSubGmId)}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* サブGM（2GM以上のシナリオ） */}
+                  {requiredGmCount >= 2 && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-purple-700 font-medium shrink-0 w-12">サブGM</span>
+                      <select
+                        className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
+                        value={selectedSubGmId}
+                        onChange={e => onSelectSubGM?.(e.target.value)}
+                      >
+                        <option value="">選択してください</option>
+                        {gmOptionsToShow.map(({ gm, isGMDisabled, label }) => (
+                          <option key={gm.id} value={gm.id}
+                            disabled={isGMDisabled || gm.id === selectedGMId}>
+                            {label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+
+                  {filteredGMOptions.length === 0 && gmResponses.length > 0 && (
+                    <p className="text-xs text-amber-600">⚠️ この日時に対応可能と回答したGMがいません</p>
+                  )}
+                </div>
               )}
             </div>
           )
@@ -237,4 +286,3 @@ export const CandidateDateSelector = ({
     </div>
   )
 }
-

--- a/src/pages/PrivateBookingManagement/components/CandidateDateSelector.tsx
+++ b/src/pages/PrivateBookingManagement/components/CandidateDateSelector.tsx
@@ -138,140 +138,98 @@ export const CandidateDateSelector = ({
         <Calendar className="w-4 h-4" />
         開催日時を選択
       </h3>
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         {candidates.map((candidate) => {
           const isSelected = selectedCandidateOrder === candidate.order
-          // GMが選択した候補かどうか
           const isGMSelected = gmSelectedCandidates && gmSelectedCandidates.includes(candidate.order)
-
-          // この日時に競合があるかチェック
-          // 空き店舗があるかどうかで判定（選択店舗ではなく全体の空き状況）
           const availableStoresForCandidate = getAvailableStores(candidate)
           const hasNoAvailableStore = stores.length > 0 && availableStoresForCandidate.length === 0
-          
-          // 選択されたGMの競合チェック
           const gmConflictKey = selectedGMId ? `${selectedGMId}-${candidate.date}-${candidate.timeSlot}` : null
           const hasGMConflict = gmConflictKey && conflictInfo.gmDateConflicts.has(gmConflictKey)
-          
-          // 空き店舗がない場合のみ競合とみなす
           const hasConflict = hasNoAvailableStore
-
-          // 閲覧専用モード（確定済み）で未選択の候補はdisabled表示
           const isDisabledInReadOnlyMode = isReadOnly && !isSelected
-          // 確定済みかつ選択された候補は緑色で表示
           const isConfirmedAndSelected = isConfirmed && isSelected
+          const availableGMs = gmResponses.filter(gm => isGmAvailableForCandidate(gm, candidate.order - 1))
 
           return (
             <div
               key={candidate.order}
               onClick={() => !hasConflict && !isReadOnly && onSelectCandidate(candidate.order)}
-              className={`flex items-center gap-3 p-3 rounded border-2 transition-all ${
+              className={`flex items-center gap-2 px-3 py-2 rounded border transition-all text-sm ${
                 hasConflict
                   ? 'border-red-200 bg-red-50 opacity-60 cursor-not-allowed'
                   : isDisabledInReadOnlyMode
-                  ? 'bg-gray-50 border-gray-200 cursor-default opacity-60'
+                  ? 'bg-gray-50 border-gray-200 cursor-default opacity-50'
                   : isConfirmedAndSelected
-                  ? 'border-green-500 bg-green-50 cursor-default'
+                  ? 'border-green-400 bg-green-50 cursor-default'
                   : isSelected
-                  ? 'border-purple-500 bg-purple-50 cursor-pointer'
+                  ? 'border-purple-400 bg-purple-50 cursor-pointer'
                   : 'border-gray-200 bg-background hover:border-purple-300 cursor-pointer'
               }`}
             >
-              <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
-                hasConflict
-                  ? 'border-red-500 bg-red-500'
-                  : isConfirmedAndSelected
-                  ? 'border-green-500 bg-green-500'
-                  : isSelected
-                  ? 'border-purple-500 bg-purple-500'
-                  : 'border-gray-300'
+              {/* ラジオアイコン */}
+              <div className={`w-4 h-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+                hasConflict ? 'border-red-400 bg-red-400'
+                : isConfirmedAndSelected ? 'border-green-500 bg-green-500'
+                : isSelected ? 'border-purple-500 bg-purple-500'
+                : 'border-gray-300'
               }`}>
-                {hasConflict ? (
-                  <XCircle className="w-4 h-4 text-white" />
-                ) : isSelected ? (
-                  <CheckCircle2 className="w-4 h-4 text-white" />
-                ) : null}
+                {hasConflict ? <XCircle className="w-3 h-3 text-white" />
+                  : isSelected ? <CheckCircle2 className="w-3 h-3 text-white" />
+                  : null}
               </div>
-              <div className="flex-1">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="font-medium">候補{candidate.order}</span>
-                  {/* この候補に対応可能なGMのバッジを表示 */}
-                  {gmResponses.length > 0 && (
-                    <div className="flex items-center gap-1 flex-wrap">
-                      {gmResponses
-                        .filter((gm) => isGmAvailableForCandidate(gm, candidate.order - 1))
-                        .map((gm) => {
-                          const colors = getGMBadgeStyle(gm.avatar_color, gm.gm_name)
-                          return (
-                            <span
-                              key={gm.gm_id}
-                              className="text-xs px-1.5 py-0.5 rounded border font-medium"
-                              style={{ 
-                                backgroundColor: colors.bgColor, 
-                                color: colors.textColor,
-                                borderColor: colors.textColor + '40' // 25% opacity
-                              }}
-                              title={`GM: ${gm.gm_name}`}
-                            >
-                              {getShortName(gm.gm_name)}
-                            </span>
-                          )
-                        })
-                      }
-                      {gmResponses.filter((gm) => isGmAvailableForCandidate(gm, candidate.order - 1))
-                        .length === 0 && (
-                        <span className="text-xs text-gray-400">GM回答なし</span>
-                      )}
-                    </div>
-                  )}
+
+              {/* 日付・時間 */}
+              <span className="font-medium whitespace-nowrap">{formatCandidateDate(candidate.date)}</span>
+              <span className="text-muted-foreground whitespace-nowrap text-xs">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+
+              {/* GMバッジ */}
+              {gmResponses.length > 0 && (
+                <div className="flex items-center gap-1 flex-wrap">
+                  {availableGMs.length === 0
+                    ? <span className="text-xs text-gray-400">GM回答なし</span>
+                    : availableGMs.map(gm => {
+                        const c = getGMBadgeStyle(gm.avatar_color, gm.gm_name)
+                        return (
+                          <span key={gm.gm_id}
+                            className="text-xs px-1.5 py-0.5 rounded border font-medium"
+                            style={{ backgroundColor: c.bgColor, color: c.textColor, borderColor: c.textColor + '40' }}
+                            title={gm.gm_name}
+                          >
+                            {getShortName(gm.gm_name)}
+                          </span>
+                        )
+                      })
+                  }
                 </div>
-                {/* 空き店舗の表示 */}
-                {stores.length > 0 && (
-                  <div className="flex items-center gap-1 mt-1 flex-wrap">
-                    <MapPin className="w-3 h-3 text-gray-400" />
-                    {availableStoresForCandidate.length === 0 ? (
-                      <span className="text-xs text-red-500">空き店舗なし</span>
-                    ) : availableStoresForCandidate.length === stores.length ? (
-                      <span className="text-xs text-green-600">全店舗空き</span>
-                    ) : (
-                      availableStoresForCandidate.map(store => (
-                        <span
-                          key={store.id}
-                          className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-700 border border-gray-200"
-                          title={store.name}
-                        >
-                          {store.short_name || store.name}
+              )}
+
+              {/* 空き店舗 */}
+              {stores.length > 0 && (
+                <div className="flex items-center gap-1 flex-wrap ml-auto">
+                  <MapPin className="w-3 h-3 text-gray-400 shrink-0" />
+                  {availableStoresForCandidate.length === 0
+                    ? <span className="text-xs text-red-500">空き店舗なし</span>
+                    : availableStoresForCandidate.length === stores.length
+                    ? <span className="text-xs text-green-600">全店舗空き</span>
+                    : availableStoresForCandidate.slice(0, 3).map(s => (
+                        <span key={s.id} className="text-xs px-1 py-0.5 rounded bg-gray-100 text-gray-700 border border-gray-200 whitespace-nowrap" title={s.name}>
+                          {s.short_name || s.name}
                         </span>
                       ))
-                    )}
-                  </div>
-                )}
-                <div className="flex items-center gap-3 text-xs text-muted-foreground mt-1">
-                  <div className="flex items-center gap-1">
-                    <Calendar className="w-3 h-3" />
-                    <span>{formatCandidateDate(candidate.date)}</span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <Clock className="w-3 h-3" />
-                    <span>{candidate.timeSlot} {candidate.startTime} - {candidate.endTime}</span>
-                  </div>
+                  }
+                  {availableStoresForCandidate.length > 3 && (
+                    <span className="text-xs text-gray-500">+{availableStoresForCandidate.length - 3}</span>
+                  )}
                 </div>
-                {hasConflict && (
-                  <div className="text-xs text-red-600 mt-1">
-                    空き店舗なし
-                  </div>
-                )}
-                {!hasConflict && hasGMConflict && (
-                  <div className="text-xs text-orange-600 mt-1">
-                    選択中のGMに予定あり（他のGMを選択可能）
-                  </div>
-                )}
-                {isSelected && !isGMSelected && gmSelectedCandidates && gmSelectedCandidates.length > 0 && (
-                  <div className="text-xs text-orange-600 mt-1">
-                    ⚠️ GMが未回答の候補です
-                  </div>
-                )}
-              </div>
+              )}
+
+              {/* 警告テキスト */}
+              {(hasGMConflict || (isSelected && !isGMSelected && gmSelectedCandidates?.length)) && (
+                <span className="text-xs text-orange-600 whitespace-nowrap ml-1">
+                  {hasGMConflict ? '⚠️ GMに予定あり' : '⚠️ GM未回答'}
+                </span>
+              )}
             </div>
           )
         })}

--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -243,354 +243,160 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
 
       logger.log('貸切承認RPC成功:', { requestId, scheduleEventId })
 
-      // 承認で作成されたスケジュールイベントを履歴に記録
-      if (scheduleEventId && organizationId) {
-        const gmIds = requiredGm >= 2 && selectedSubGmId
-          ? [selectedGMId, selectedSubGmId]
-          : [selectedGMId]
-        await createEventHistory(
-          scheduleEventId as string,
-          organizationId,
-          'create',
-          null,
-          {
-            scenario: cleanScenarioTitle,
-            date: selectedDateYmd,
-            store_id: selectedStoreId,
-            start_time: selectedCandidate.startTime,
-            end_time: selectedEndTime,
-            gms: gmIds,
-            reservation_name: selectedRequest?.customer_name || '',
-          },
-          {
-            date: selectedDateYmd,
-            storeId: selectedStoreId,
-            timeSlot: selectedCandidate.timeSlot || null,
-          },
-          { notes: '貸切予約承認により作成' }
-        )
-      }
+      // ✅ RPC成功後すぐに画面を更新（通知・メール・ログはバックグラウンドで実行）
+      onSuccess()
 
-      // 通知・メールは DB に実際に作成された公演日（schedule_events.date）を優先（クライアント保持の候補とズレないようにする）
-      let notifyEventDate = selectedDateYmd
-      let notifyStartTime = selectedCandidate.startTime
-      let notifyEndTime = selectedEndTime
-      if (scheduleEventId) {
-        const { data: seRow, error: seErr } = await supabase
-          .from('schedule_events')
-          .select('date, start_time, end_time')
-          .eq('id', scheduleEventId as string)
-          .single()
-        if (seErr) {
-          logger.error('承認後スケジュール取得エラー（通知は候補日時を使用）:', seErr)
-        } else if (seRow?.date != null && seRow.date !== '') {
-          const fromRow = normalizeToJapanCalendarYmd(String(seRow.date))
+      // バックグラウンド処理（awaitしない）
+      ;(async () => {
+        // schedule_events の確定日時と予約料金情報を並列取得
+        const [seResult, reservationResult] = await Promise.all([
+          scheduleEventId
+            ? supabase.from('schedule_events').select('date, start_time, end_time').eq('id', scheduleEventId as string).single()
+            : Promise.resolve({ data: null, error: null }),
+          supabase.from('reservations').select('total_price, final_price, customer_email, customer_name, reservation_number, customer_notes, private_group_id').eq('id', requestId).single()
+        ])
+
+        let notifyEventDate = selectedDateYmd
+        let notifyStartTime = selectedCandidate.startTime
+        let notifyEndTime = selectedEndTime
+        if (seResult.data?.date != null && seResult.data.date !== '') {
+          const fromRow = normalizeToJapanCalendarYmd(String(seResult.data.date))
           if (fromRow) notifyEventDate = fromRow
-          if (seRow.start_time) {
-            notifyStartTime = String(seRow.start_time).slice(0, 5)
-          }
-          if (seRow.end_time) {
-            notifyEndTime = String(seRow.end_time).slice(0, 5)
-          }
-        }
-      }
-
-      // 貸切予約確定メールを送信
-      try {
-        // 承認後の予約データを取得（total_priceを含む）
-        const { data: updatedReservation, error: reservationError } = await supabase
-          .from('reservations')
-          .select('total_price, final_price, customer_email, customer_name, reservation_number, customer_notes')
-          .eq('id', requestId)
-          .single()
-
-        if (reservationError) {
-          logger.error('予約データ取得エラー:', reservationError)
+          if (seResult.data.start_time) notifyStartTime = String(seResult.data.start_time).slice(0, 5)
+          if (seResult.data.end_time) notifyEndTime = String(seResult.data.end_time).slice(0, 5)
         }
 
-        const customerEmail = selectedRequest?.customer_email || updatedReservation?.customer_email
-        const customerName = selectedRequest?.customer_name
-        if (customerEmail && customerName) {
-          const selectedStore = stores.find(s => s.id === selectedStoreId)
-          const storeAddress = selectedStore?.address || undefined
-          const priceToUse = updatedReservation?.final_price || updatedReservation?.total_price || 0
+        const updatedReservation = reservationResult.data
+        const storeName = stores.find(s => s.id === selectedStoreId)?.name || ''
+        const gmIds = requiredGm >= 2 && selectedSubGmId ? [selectedGMId, selectedSubGmId] : [selectedGMId]
 
-          const { error: emailInvokeError } = await supabase.functions.invoke('send-private-booking-confirmation', {
-            body: {
-              organizationId,
-              storeId: selectedStoreId,
-              reservationId: requestId,
-              customerEmail,
-              customerName,
-              scenarioTitle: selectedRequest?.scenario_title || '',
-              eventDate: notifyEventDate,
-              startTime: notifyStartTime,
-              endTime: notifyEndTime,
-              storeName: stores.find(s => s.id === selectedStoreId)?.name || '',
-              storeAddress,
-              participantCount: selectedRequest?.participant_count || 0,
-              totalPrice: priceToUse,
-              reservationNumber: selectedRequest?.reservation_number || updatedReservation?.reservation_number || '',
-              notes: selectedRequest?.notes || updatedReservation?.customer_notes || undefined
-            }
-          })
-          if (emailInvokeError) {
-            logger.error('貸切予約確定メール送信エラー:', emailInvokeError)
-          } else {
-            logger.log('貸切予約確定メール送信成功:', customerEmail)
-          }
-        }
-      } catch (emailError) {
-        logger.error('メール送信エラー:', emailError)
-        // メール送信失敗しても承認処理は続行
-      }
+        // イベント履歴・確定メール・GM通知・グループ処理を並列実行
+        await Promise.all([
+          // イベント履歴
+          scheduleEventId && organizationId
+            ? createEventHistory(scheduleEventId as string, organizationId, 'create', null, {
+                scenario: cleanScenarioTitle, date: selectedDateYmd, store_id: selectedStoreId,
+                start_time: selectedCandidate.startTime, end_time: selectedEndTime, gms: gmIds,
+                reservation_name: selectedRequest?.customer_name || '',
+              }, { date: selectedDateYmd, storeId: selectedStoreId, timeSlot: selectedCandidate.timeSlot || null },
+              { notes: '貸切予約承認により作成' }).catch(e => logger.error('createEventHistory error:', e))
+            : Promise.resolve(),
 
-      // GMへの確定通知を送信（Discord / メール）— 2名必要ならメイン・サブ両方へ
-      try {
-        const gmIdsToNotify: string[] =
-          requiredGm >= 2 && selectedSubGmId ? [selectedGMId, selectedSubGmId] : [selectedGMId]
-
-        const { data: notifyStaffRows, error: notifyStaffError } = await supabase
-          .from('staff')
-          .select('id, name, email, discord_channel_id, discord_user_id')
-          .in('id', gmIdsToNotify)
-
-        if (notifyStaffError) {
-          logger.error('GM通知用スタッフ取得エラー:', notifyStaffError)
-        } else {
-          const storeName = stores.find(s => s.id === selectedStoreId)?.name || ''
-          logger.log('GM確定通知開始:', { 
-            gmCount: notifyStaffRows?.length || 0, 
-            gmNames: notifyStaffRows?.map(r => r.name) || [] 
-          })
-          
-          for (const row of notifyStaffRows || []) {
-            if (!row?.id) continue
-            
-            logger.log('GM個別通知開始:', {
-              gmId: row.id,
-              gmName: row.name,
-              hasEmail: !!row.email,
-              hasDiscordChannel: !!row.discord_channel_id,
-              hasDiscordUserId: !!row.discord_user_id
+          // カスタマー確定メール
+          (async () => {
+            const customerEmail = selectedRequest?.customer_email || updatedReservation?.customer_email
+            const customerName = selectedRequest?.customer_name
+            if (!customerEmail || !customerName) return
+            const selectedStore = stores.find(s => s.id === selectedStoreId)
+            const priceToUse = updatedReservation?.final_price || updatedReservation?.total_price || 0
+            const { error: emailErr } = await supabase.functions.invoke('send-private-booking-confirmation', {
+              body: {
+                organizationId, storeId: selectedStoreId, reservationId: requestId,
+                customerEmail, customerName, scenarioTitle: selectedRequest?.scenario_title || '',
+                eventDate: notifyEventDate, startTime: notifyStartTime, endTime: notifyEndTime,
+                storeName, storeAddress: selectedStore?.address || undefined,
+                participantCount: selectedRequest?.participant_count || 0, totalPrice: priceToUse,
+                reservationNumber: selectedRequest?.reservation_number || updatedReservation?.reservation_number || '',
+                notes: selectedRequest?.notes || updatedReservation?.customer_notes || undefined
+              }
             })
-            
-            const { data: notifyResult, error: notifyFnError } = await supabase.functions.invoke(
-              'notify-gm-private-booking-confirmed',
-              {
-                body: {
-                  organizationId,
-                  gmId: row.id,
-                  gmName: row.name,
-                  gmEmail: row.email,
+            if (emailErr) logger.error('貸切予約確定メール送信エラー:', emailErr)
+            else logger.log('貸切予約確定メール送信成功:', customerEmail)
+          })(),
+
+          // GM確定通知（複数GMも並列）
+          (async () => {
+            const { data: notifyStaffRows, error: staffErr } = await supabase
+              .from('staff').select('id, name, email, discord_channel_id, discord_user_id').in('id', gmIds)
+            if (staffErr) { logger.error('GM通知用スタッフ取得エラー:', staffErr); return }
+            await Promise.all((notifyStaffRows || []).map(async row => {
+              if (!row?.id) return
+              const { data: notifyResult, error: notifyFnError } = await supabase.functions.invoke(
+                'notify-gm-private-booking-confirmed',
+                { body: {
+                  organizationId, gmId: row.id, gmName: row.name, gmEmail: row.email,
                   gmDiscordChannelId: row.discord_channel_id ?? undefined,
                   gmDiscordUserId: row.discord_user_id ?? undefined,
                   scenarioTitle: selectedRequest?.scenario_title || '',
-                  eventDate: notifyEventDate,
-                  startTime: notifyStartTime,
-                  endTime: notifyEndTime,
-                  storeName,
-                  customerName: selectedRequest?.customer_name || '',
-                  participantCount: selectedRequest?.participant_count || 0,
-                  reservationId: requestId,
-                },
-              }
-            )
-            
-            if (notifyFnError) {
-              logger.error('GM確定通知Edge Functionエラー:', {
-                gmName: row.name,
-                error: notifyFnError,
-                errorDetails: JSON.stringify(notifyFnError, null, 2)
-              })
-              showToast.warning(`${row.name} への確定通知の送信に失敗しました。手動でご連絡ください。`)
-            } else {
-              logger.log('GM確定通知リクエスト完了:', {
-                gmName: row.name,
-                results: notifyResult?.results || 'no_details'
-              })
-              // Discord が全方法で失敗していた場合も警告
-              if (notifyResult?.results?.discord === 'failed') {
+                  eventDate: notifyEventDate, startTime: notifyStartTime, endTime: notifyEndTime,
+                  storeName, customerName: selectedRequest?.customer_name || '',
+                  participantCount: selectedRequest?.participant_count || 0, reservationId: requestId,
+                }}
+              )
+              if (notifyFnError) {
+                logger.error('GM確定通知エラー:', { gmName: row.name, error: notifyFnError })
+                showToast.warning(`${row.name} への確定通知の送信に失敗しました。手動でご連絡ください。`)
+              } else if (notifyResult?.results?.discord === 'failed') {
                 showToast.warning(`${row.name} へのDiscord通知が失敗しました。メール通知または手動連絡をご確認ください。`)
               }
-            }
-          }
-          
-          logger.log('GM確定通知処理完了:', {
-            totalGMs: gmIdsToNotify.length,
-            processedGMs: notifyStaffRows?.length || 0
-          })
-        }
-      } catch (gmNotifyError) {
-        logger.error('GM通知送信処理エラー:', {
-          error: gmNotifyError,
-          requestId,
-          scenarioTitle: selectedRequest?.scenario_title,
-          selectedGMId,
-          selectedSubGmId: requiredGm >= 2 ? selectedSubGmId : null
-        })
-        // GM通知失敗しても承認処理は続行（ユーザーには成功として返す）
-        // ただし、この時点でログには詳細なエラー情報が記録される
-      }
+            }))
+          })(),
 
-      // グループチャットに日程確定のシステムメッセージを送信
-      try {
-        // 予約に紐づくグループIDを取得
-        const { data: reservation, error: reservationQueryError } = await supabase
-          .from('reservations')
-          .select('private_group_id')
-          .eq('id', requestId)
-          .single()
-        
-        logger.log('予約のグループID取得結果:', { requestId, private_group_id: reservation?.private_group_id, error: reservationQueryError })
+          // グループステータス更新・確定メッセージ・アンケート通知
+          (async () => {
+            const groupId = updatedReservation?.private_group_id
+            if (!groupId) return
+            logger.log('予約のグループID:', { requestId, groupId })
 
-        if (reservation?.private_group_id) {
-          // グループのステータスを confirmed に更新
-          try {
-            await updatePrivateGroupStatus(reservation.private_group_id, 'confirmed')
-            logger.log('グループステータスをconfirmedに更新:', reservation.private_group_id)
-          } catch (groupUpdateError) {
-            logger.error('グループステータス更新エラー:', groupUpdateError)
-          }
+            await updatePrivateGroupStatus(groupId, 'confirmed').catch(e => logger.error('グループステータス更新エラー:', e))
 
-          // 主催者のメンバーIDを取得
-          const { data: organizerMember } = await supabase
-            .from('private_group_members')
-            .select('id')
-            .eq('group_id', reservation.private_group_id)
-            .eq('is_organizer', true)
-            .single()
+            const [organizerResult, msgSettingsResult] = await Promise.all([
+              supabase.from('private_group_members').select('id').eq('group_id', groupId).eq('is_organizer', true).single(),
+              supabase.from('global_settings').select(GLOBAL_SETTINGS_MSG_SELECT.SCHEDULE_CONFIRMED).eq('organization_id', organizationId).maybeSingle()
+            ])
+            const organizerMember = organizerResult.data
+            if (!organizerMember) return
 
-          if (organizerMember) {
-            // 設定からメッセージ文言を取得
-            const { data: msgSettings } = await supabase
-              .from('global_settings')
-              .select(GLOBAL_SETTINGS_MSG_SELECT.SCHEDULE_CONFIRMED)
-              .eq('organization_id', organizationId)
-              .maybeSingle()
-            
-            // 日程確定のシステムメッセージ
-            const confirmedMessage = JSON.stringify({
-              type: 'system',
-              action: 'schedule_confirmed',
-              confirmedDate: notifyEventDate,
-              confirmedTimeSlot: selectedCandidate.timeSlot || `${notifyStartTime}〜${notifyEndTime}`,
-              storeName: stores.find(s => s.id === selectedStoreId)?.name || '',
-              // 設定されたメッセージ文言を含める
-              title: msgSettings?.system_msg_schedule_confirmed_title || '日程が確定いたしました',
-              body: msgSettings?.system_msg_schedule_confirmed_body || 'ご予約ありがとうございます。当日のご来店をお待ちしております。'
-            })
-
+            const msgSettings = msgSettingsResult.data
             await supabase.from('private_group_messages').insert({
-              group_id: reservation.private_group_id,
+              group_id: groupId,
               member_id: organizerMember.id,
-              message: confirmedMessage
+              message: JSON.stringify({
+                type: 'system', action: 'schedule_confirmed',
+                confirmedDate: notifyEventDate,
+                confirmedTimeSlot: selectedCandidate.timeSlot || `${notifyStartTime}〜${notifyEndTime}`,
+                storeName,
+                title: msgSettings?.system_msg_schedule_confirmed_title || '日程が確定いたしました',
+                body: msgSettings?.system_msg_schedule_confirmed_body || 'ご予約ありがとうございます。当日のご来店をお待ちしております。'
+              })
             })
-
-            // 事前配役アンケートが有効な場合の通知
-            // survey_enabled=true かつキャラクターあり → 事前配役シナリオ（pre-reading通知のみ、配役方法選択は客側で行う）
-            // survey_enabled=true かつキャラクターなし → 即座にアンケート通知を送信
-            const scenarioMasterId = selectedRequest?.scenario_master_id
-            logger.log('📋 事前配役アンケート通知チェック:', {
-              scenarioMasterId,
-              organizationId,
-              hasScenarioMasterId: !!selectedRequest?.scenario_master_id,
-            })
-
-            if (scenarioMasterId) {
-              const { data: orgScenarioData, error: orgScenarioError } = await supabase
-                .from('organization_scenarios_with_master')
-                .select('survey_enabled, survey_deadline_days, characters')
-                .eq('scenario_master_id', scenarioMasterId)
-                .eq('organization_id', organizationId)
-                .maybeSingle()
-
-              logger.log('📋 organization_scenarios取得結果:', { orgScenarioData, orgScenarioError })
-
-              const hasPlayableCharacters = Array.isArray(orgScenarioData?.characters) && orgScenarioData.characters.some((c: any) => !c.is_npc)
-
-              if (orgScenarioData?.survey_enabled) {
-                if (hasPlayableCharacters) {
-                  // 事前配役シナリオ: グループ全員の参加を促す通知を送信
-                  const { data: globalSettings } = await supabase
-                    .from('global_settings')
-                    .select('pre_reading_notice_message')
-                    .eq('organization_id', organizationId)
-                    .maybeSingle()
-
-                  const preReadingMessage = globalSettings?.pre_reading_notice_message ||
-                    '【ご確認ください】\n\nこのシナリオには事前配役アンケートがございます。\n\n公演日までに参加者全員がこのグループに参加している必要があります。まだ参加されていない方がいらっしゃいましたら、招待リンクを共有してグループへの参加をお願いいたします。\n\nご不明点がございましたら、店舗までお問い合わせください。'
-
-                  await supabase.from('private_group_messages').insert({
-                    group_id: reservation.private_group_id,
-                    member_id: organizerMember.id,
-                    message: JSON.stringify({ type: 'system', action: 'pre_reading_notice', message: preReadingMessage })
-                  })
-                  logger.log('📋 事前配役シナリオ: pre_reading_notice送信成功')
-
-                  // カスタマーへメール通知
-                  const surveyCustomerEmail = selectedRequest?.customer_email
-                  if (surveyCustomerEmail) {
-                    await sendEmail({
-                      to: surveyCustomerEmail,
-                      subject: '【事前配役アンケートのご案内】',
-                      body: preReadingMessage,
-                    })
-                    logger.log('📋 事前配役通知メール送信成功:', surveyCustomerEmail)
-                  }
-                } else {
-                  // キャラクターなし: 即座にアンケート通知を送信
-                  const confirmedCandidate = selectedRequest.candidate_datetimes?.candidates?.find(
-                    (c: any) => c.order === selectedCandidateOrder
-                  )
-                  let deadlineText = ''
-                  if (confirmedCandidate?.date && orgScenarioData.survey_deadline_days !== undefined) {
-                    const perfDate = new Date(confirmedCandidate.date + 'T00:00:00+09:00')
-                    perfDate.setDate(perfDate.getDate() - orgScenarioData.survey_deadline_days)
-                    deadlineText = `\n\n回答期限: ${perfDate.getMonth() + 1}月${perfDate.getDate()}日まで`
-                  }
-
-                  const surveyMessage = `【事前配役アンケートのご協力のお願い】\n\nこちらの公演では事前配役アンケートへのご回答をお願いしております。\n\n上記の「日程を確認・回答する」ボタンからアンケートにお答えください。${deadlineText}\n\nご不明点がございましたら、お気軽にお問い合わせください。`
-
-                  const { error: surveyMsgError } = await supabase.from('private_group_messages').insert({
-                    group_id: reservation.private_group_id,
-                    member_id: organizerMember.id,
-                    message: JSON.stringify({ type: 'system', action: 'survey_notice', message: surveyMessage })
-                  })
-
-                  if (surveyMsgError) {
-                    logger.error('📋 アンケート通知送信エラー:', surveyMsgError)
-                  } else {
-                    logger.log('📋 アンケート通知送信成功')
-
-                    // カスタマーへメール通知
-                    const surveyCustomerEmail = selectedRequest?.customer_email
-                    if (surveyCustomerEmail) {
-                      await sendEmail({
-                        to: surveyCustomerEmail,
-                        subject: '【事前配役アンケートのご案内】',
-                        body: surveyMessage,
-                      })
-                      logger.log('📋 アンケート通知メール送信成功:', surveyCustomerEmail)
-                    }
-                  }
-                }
-              } else {
-                logger.log('📋 事前配役アンケートが無効のためスキップ:', { survey_enabled: orgScenarioData?.survey_enabled })
-              }
-            } else {
-              logger.log('📋 scenario_master_idがないためアンケート通知スキップ')
-            }
-
             logger.log('グループチャットに日程確定メッセージ送信成功')
-          }
-        }
-      } catch (msgError) {
-        logger.error('グループメッセージ送信エラー:', msgError)
-        // メッセージ送信失敗しても承認処理は続行
-      }
 
-      onSuccess()
+            // アンケート通知
+            const scenarioMasterId = selectedRequest?.scenario_master_id
+            if (!scenarioMasterId) return
+            const { data: orgScenarioData } = await supabase
+              .from('organization_scenarios_with_master')
+              .select('survey_enabled, survey_deadline_days, characters')
+              .eq('scenario_master_id', scenarioMasterId).eq('organization_id', organizationId).maybeSingle()
+            if (!orgScenarioData?.survey_enabled) return
+
+            const hasPlayableCharacters = Array.isArray(orgScenarioData.characters) && orgScenarioData.characters.some((c: any) => !c.is_npc)
+            if (hasPlayableCharacters) {
+              const { data: globalSettings } = await supabase.from('global_settings').select('pre_reading_notice_message').eq('organization_id', organizationId).maybeSingle()
+              const preReadingMessage = globalSettings?.pre_reading_notice_message || '【ご確認ください】\n\nこのシナリオには事前配役アンケートがございます。\n\n公演日までに参加者全員がこのグループに参加している必要があります。まだ参加されていない方がいらっしゃいましたら、招待リンクを共有してグループへの参加をお願いいたします。\n\nご不明点がございましたら、店舗までお問い合わせください。'
+              await Promise.all([
+                supabase.from('private_group_messages').insert({ group_id: groupId, member_id: organizerMember.id, message: JSON.stringify({ type: 'system', action: 'pre_reading_notice', message: preReadingMessage }) }),
+                selectedRequest?.customer_email ? sendEmail({ to: selectedRequest.customer_email, subject: '【事前配役アンケートのご案内】', body: preReadingMessage }) : Promise.resolve()
+              ])
+            } else {
+              const confirmedCandidate = selectedRequest?.candidate_datetimes?.candidates?.find((c: any) => c.order === selectedCandidateOrder)
+              let deadlineText = ''
+              if (confirmedCandidate?.date && orgScenarioData.survey_deadline_days !== undefined) {
+                const perfDate = new Date(confirmedCandidate.date + 'T00:00:00+09:00')
+                perfDate.setDate(perfDate.getDate() - orgScenarioData.survey_deadline_days)
+                deadlineText = `\n\n回答期限: ${perfDate.getMonth() + 1}月${perfDate.getDate()}日まで`
+              }
+              const surveyMessage = `【事前配役アンケートのご協力のお願い】\n\nこちらの公演では事前配役アンケートへのご回答をお願いしております。\n\n上記の「日程を確認・回答する」ボタンからアンケートにお答えください。${deadlineText}\n\nご不明点がございましたら、お気軽にお問い合わせください。`
+              await Promise.all([
+                supabase.from('private_group_messages').insert({ group_id: groupId, member_id: organizerMember.id, message: JSON.stringify({ type: 'system', action: 'survey_notice', message: surveyMessage }) }),
+                selectedRequest?.customer_email ? sendEmail({ to: selectedRequest.customer_email, subject: '【事前配役アンケートのご案内】', body: surveyMessage }) : Promise.resolve()
+              ])
+            }
+          })()
+        ])
+      })().catch(err => logger.error('バックグラウンド承認処理エラー:', err))
+
       return { success: true }
     } catch (error) {
       logger.error('承認エラー:', error)

--- a/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
@@ -183,6 +183,7 @@ export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps
         }
       }
 
+      // ── バッチ取得 ① シナリオ情報（duration含む）──────────────────────────────
       const masterIdsForGmCount = [
         ...new Set(
           reservationsList
@@ -194,143 +195,114 @@ export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps
       ] as string[]
       const gmCountByMasterId = new Map<string, number>()
       const playerRangeByMasterId = new Map<string, { min: number; max: number }>()
+      const scenarioTimingByMasterId = new Map<string, { duration: number; weekend_duration: number | null; extra_preparation_time: number; private_booking_time_slots?: unknown }>()
+
       if (masterIdsForGmCount.length > 0) {
         const { data: viewRows } = await supabase
           .from('organization_scenarios_with_master')
-          .select('scenario_master_id, gm_count, player_count_min, player_count_max')
+          .select('scenario_master_id, gm_count, player_count_min, player_count_max, duration, weekend_duration, extra_preparation_time, private_booking_time_slots')
           .eq('organization_id', orgId)
           .in('scenario_master_id', masterIdsForGmCount)
 
         for (const row of viewRows || []) {
           if (!row.scenario_master_id) continue
-          gmCountByMasterId.set(
-            row.scenario_master_id,
-            resolveStaffProfileGmSlotCount({ gm_count: row.gm_count })
-          )
+          gmCountByMasterId.set(row.scenario_master_id, resolveStaffProfileGmSlotCount({ gm_count: row.gm_count }))
           const pMin = row.player_count_min
           const pMax = row.player_count_max
-          if (
-            typeof pMin === 'number' &&
-            typeof pMax === 'number' &&
-            pMin > 0 &&
-            pMax >= pMin
-          ) {
-            playerRangeByMasterId.set(row.scenario_master_id, {
-              min: pMin,
-              max: pMax,
+          if (typeof pMin === 'number' && typeof pMax === 'number' && pMin > 0 && pMax >= pMin) {
+            playerRangeByMasterId.set(row.scenario_master_id, { min: pMin, max: pMax })
+          }
+          if (typeof row.duration === 'number' && row.duration > 0) {
+            scenarioTimingByMasterId.set(row.scenario_master_id, {
+              duration: row.duration,
+              weekend_duration: typeof row.weekend_duration === 'number' && row.weekend_duration > 0 ? row.weekend_duration : null,
+              extra_preparation_time: typeof row.extra_preparation_time === 'number' ? row.extra_preparation_time : 0,
+              private_booking_time_slots: row.private_booking_time_slots ?? null,
             })
           }
         }
       }
 
-      // 各リクエストに対してGM回答を取得
-      const formattedData: PrivateBookingRequest[] = await Promise.all(
-        reservationsList.map(async (req: any) => {
-          // GM回答を別途取得（スタッフのavatar_colorと名前も含める）
-          const { data: gmResponses } = await supabase
-            .from('gm_availability_responses')
-            .select(
-              'staff_id, gm_name, response_status, available_candidates, selected_candidate_index, notes, response_datetime, responded_at, updated_at, created_at, staff:staff_id(name, avatar_color)'
-            )
-            .eq('reservation_id', req.id)
+      // ── バッチ取得 ② GM回答（全予約まとめて1クエリ）──────────────────────────
+      const allReservationIds = reservationsList.map((r: { id: string }) => r.id)
+      const gmResponsesByReservationId = new Map<string, any[]>()
+      if (allReservationIds.length > 0) {
+        const { data: allGmResponses } = await supabase
+          .from('gm_availability_responses')
+          .select('reservation_id, staff_id, gm_name, response_status, available_candidates, selected_candidate_index, notes, response_datetime, responded_at, updated_at, created_at, staff:staff_id(name, avatar_color)')
+          .in('reservation_id', allReservationIds)
+        for (const gm of allGmResponses || []) {
+          const rid = gm.reservation_id as string
+          if (!gmResponsesByReservationId.has(rid)) gmResponsesByReservationId.set(rid, [])
+          gmResponsesByReservationId.get(rid)!.push(gm)
+        }
+      }
 
-          // GM名がnullの場合はスタッフテーブルの名前を使用。表示は回答が早い順
+      // ── バッチ取得 ③ 候補日（全グループまとめて1クエリ）──────────────────────
+      const candidateDatesByGroupId = new Map<string, any[]>()
+      if (privateGroupIds.length > 0) {
+        const { data: allCandidateDates } = await supabase
+          .from('private_group_candidate_dates')
+          .select('group_id, id, date, time_slot, start_time, end_time, status')
+          .in('group_id', privateGroupIds)
+          .order('date', { ascending: true })
+        for (const cd of allCandidateDates || []) {
+          if (cd.status === 'rejected') continue
+          const gid = cd.group_id as string
+          if (!candidateDatesByGroupId.has(gid)) candidateDatesByGroupId.set(gid, [])
+          candidateDatesByGroupId.get(gid)!.push(cd)
+        }
+      }
+
+      // ── マップ参照のみで各予約を組み立て（追加クエリなし）─────────────────────
+      const formattedData: PrivateBookingRequest[] = reservationsList.map((req: any) => {
+          const gmResponses = gmResponsesByReservationId.get(req.id) || []
           const transformedGMResponses = sortGmResponsesByReplyTime(
-            (gmResponses || []).filter((gm: any) => shouldIncludeGmResponseRow(gm)).map((gm: any) => ({
+            gmResponses.filter((gm: any) => shouldIncludeGmResponseRow(gm)).map((gm: any) => ({
               ...gm,
               gm_name: gm.gm_name || gm.staff?.name || '',
             }))
           )
-          
-          // 確定済み予約で候補日が1つしかない場合、元の候補日をprivate_group_candidate_datesから復元
+
           let candidateDatetimes = req.candidate_datetimes || { candidates: [] }
           const currentCandidates = candidateDatetimes.candidates || []
-          
-          // private_group_idがある場合、元の候補日を取得
-          let originalCandidates: any[] = []
-          if (req.private_group_id) {
-            const { data: candidateDatesData } = await supabase
-              .from('private_group_candidate_dates')
-              .select('id, date, time_slot, start_time, end_time, status')
-              .eq('group_id', req.private_group_id)
-              .order('date', { ascending: true })
+          const originalCandidates = req.private_group_id
+            ? (candidateDatesByGroupId.get(req.private_group_id) || [])
+            : []
 
-            // 店舗却下などで rejected になった候補は申請対象外（復元・表示に含めない）
-            originalCandidates = (candidateDatesData || []).filter(
-              (cd: { status?: string | null }) => cd.status !== 'rejected'
-            )
-          }
-          
-          privateBookingTrace(
-            `予約 ${req.id}: 現在の候補数=${currentCandidates.length}, 元の候補数=${originalCandidates.length}`
-          )
-          
-          // 確定済み予約のみ候補日を復元（pending 時は顧客が選択した日程だけを表示する）
           if (req.status === 'confirmed' && originalCandidates.length > currentCandidates.length) {
-            privateBookingTrace(`候補日を復元: ${originalCandidates.map((c: any) => c.date).join(', ')}`)
-            // 確定された候補を特定
             const confirmedCandidate = currentCandidates.find((c: any) => c.status === 'confirmed')
-            
-            // 元の候補日をcandidate_datetimes形式に変換
             const restoredCandidates = originalCandidates.map((cd: any, idx: number) => {
-              const isConfirmed = confirmedCandidate && 
-                confirmedCandidate.date === cd.date && 
+              const isConfirmed = confirmedCandidate &&
+                confirmedCandidate.date === cd.date &&
                 confirmedCandidate.timeSlot === cd.time_slot
-              
               return {
                 order: idx + 1,
                 date: cd.date,
                 timeSlot: cd.time_slot,
                 startTime: cd.start_time || confirmedCandidate?.startTime || '10:00',
                 endTime: cd.end_time || confirmedCandidate?.endTime || '13:00',
-                status: isConfirmed ? 'confirmed' : 'pending'
+                status: isConfirmed ? 'confirmed' : 'pending',
               }
             })
-            
-            candidateDatetimes = {
-              ...candidateDatetimes,
-              candidates: restoredCandidates
-            }
-          }
-          
-          // scenario_master_id のフォールバック: private_groups.scenario_master_id を使用
-          const scenarioMasterId = req.scenario_master_id || req.private_groups?.scenario_master_id
-          if (!scenarioMasterId) {
-            privateBookingTrace(
-              `予約 ${req.id}: scenario_master_id 未設定（private_groups.scenario_master_id も未設定）`
-            )
+            candidateDatetimes = { ...candidateDatetimes, candidates: restoredCandidates }
           }
 
-          let scenario_timing = await fetchScenarioTimingFromDb(supabase, {
-            organizationId: orgId,
-            scenarioLookupId: req.scenario_master_id,
-            scenarioMasterId,
-          })
-          if (
-            (!scenario_timing.duration || scenario_timing.duration <= 0) &&
-            typeof req.scenario_masters?.official_duration === 'number' &&
-            req.scenario_masters.official_duration > 0
-          ) {
-            scenario_timing = {
-              duration: req.scenario_masters.official_duration,
-              weekend_duration: scenario_timing.weekend_duration,
-              extra_preparation_time: scenario_timing.extra_preparation_time,
-            }
+          const scenarioMasterId = req.scenario_master_id || req.private_groups?.scenario_master_id
+          const cachedTiming = scenarioMasterId ? scenarioTimingByMasterId.get(scenarioMasterId) : undefined
+          let scenario_timing = cachedTiming ?? {
+            duration: typeof req.scenario_masters?.official_duration === 'number' && req.scenario_masters.official_duration > 0
+              ? req.scenario_masters.official_duration
+              : 180,
+            weekend_duration: null,
+            extra_preparation_time: 0,
           }
 
           const candidatesWithScenarioEnd = (candidateDatetimes.candidates || []).map((c: any) => ({
             ...c,
-            endTime: getPrivateBookingDisplayEndTime(
-              c.startTime,
-              c.date,
-              scenario_timing,
-              isCustomHoliday
-            ),
+            endTime: getPrivateBookingDisplayEndTime(c.startTime, c.date, scenario_timing, isCustomHoliday),
           }))
-          candidateDatetimes = {
-            ...candidateDatetimes,
-            candidates: candidatesWithScenarioEnd,
-          }
+          candidateDatetimes = { ...candidateDatetimes, candidates: candidatesWithScenarioEnd }
 
           const pgId = req.private_group_id as string | undefined | null
           const joinedN = pgId ? (joinedMemberCountByGroupId.get(pgId) ?? 0) : undefined
@@ -339,9 +311,7 @@ export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps
             id: req.id,
             reservation_number: req.reservation_number || '',
             scenario_master_id: scenarioMasterId,
-            required_gm_count: scenarioMasterId
-              ? (gmCountByMasterId.get(scenarioMasterId) ?? 1)
-              : 1,
+            required_gm_count: scenarioMasterId ? (gmCountByMasterId.get(scenarioMasterId) ?? 1) : 1,
             scenario_timing,
             scenario_title: req.scenario_masters?.title || req.title || 'シナリオ名不明',
             customer_name: req.customers?.name || '顧客名不明',
@@ -350,17 +320,14 @@ export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps
             candidate_datetimes: candidateDatetimes,
             participant_count: req.participant_count || 0,
             joined_member_count: pgId !== undefined && pgId !== null ? joinedN : undefined,
-            scenario_player_count_range: scenarioMasterId
-              ? playerRangeByMasterId.get(scenarioMasterId) ?? null
-              : null,
+            scenario_player_count_range: scenarioMasterId ? playerRangeByMasterId.get(scenarioMasterId) ?? null : null,
             notes: req.customer_notes || '',
             status: req.status,
             gm_responses: transformedGMResponses,
             created_at: req.created_at,
-            invite_code: req.private_groups?.invite_code || ''
+            invite_code: req.private_groups?.invite_code || '',
           }
         })
-      )
 
       setRequests(formattedData)
       // キャッシュを更新

--- a/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
@@ -30,10 +30,25 @@ const PRIVATE_BOOKING_LIST_STATUSES = [
 /**
  * 貸切リクエストのデータ取得を管理するフック
  */
+// モジュールレベルキャッシュ（ページ遷移で消えない、ブラウザリロードで消える）
+const cache = {
+  data: null as PrivateBookingRequest[] | null,
+  userId: null as string | null | undefined,
+  fetchedAt: 0,
+}
+const CACHE_TTL_MS = 60_000 // 60秒間はキャッシュを使う
+
 export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps) {
   const { isCustomHoliday } = useCustomHolidays()
-  const [requests, setRequests] = useState<PrivateBookingRequest[]>([])
-  const [loading, setLoading] = useState(true)
+
+  const hasFreshCache = cache.data !== null
+    && cache.userId === userId
+    && Date.now() - cache.fetchedAt < CACHE_TTL_MS
+
+  const [requests, setRequests] = useState<PrivateBookingRequest[]>(
+    hasFreshCache ? cache.data! : []
+  )
+  const [loading, setLoading] = useState(!hasFreshCache)
 
   // 月ごとにフィルタリング
   const filterByMonth = useCallback((reqs: PrivateBookingRequest[], date: Date) => {
@@ -47,15 +62,21 @@ export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps
     })
   }, [])
 
-  const loadRequests = useCallback(async () => {
+  const loadRequests = useCallback(async (force = false) => {
     try {
-      setLoading(true)
-
       // Auth 復元前に userId / role が undefined のまま走ると、誤ってスタッフ扱いになり空になる
       if (userId == null || userRole == null) {
         privateBookingTrace('ユーザー情報未確定のため取得をスキップ')
         return
       }
+
+      // キャッシュが有効ならスキップ（強制再取得でない場合）
+      if (!force && cache.data !== null && cache.userId === userId && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+        privateBookingTrace('キャッシュヒット - 取得をスキップ')
+        return
+      }
+
+      setLoading(true)
 
       // admin / license_admin は組織内の全リクエスト（RLS と organization_id で制限）
       const isOrgWideAccess = userRole === 'admin' || userRole === 'license_admin'
@@ -342,6 +363,10 @@ export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps
       )
 
       setRequests(formattedData)
+      // キャッシュを更新
+      cache.data = formattedData
+      cache.userId = userId
+      cache.fetchedAt = Date.now()
     } catch (error) {
       logger.error('貸切リクエスト取得エラー:', error)
     } finally {

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -580,14 +580,12 @@ export function PrivateBookingManagement() {
 
                         {/* 店舗・GMプルダウン（候補行クリックで開く） */}
                         {(() => {
+                          const selectedCand = req.candidate_datetimes?.candidates?.find(c => c.order === selectedCandidateOrder)
                           const candidateStores = (() => {
                             const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
                             const base = ids.length > 0 ? stores.filter(s => ids.includes(s.id)) : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
-                            // 選択中候補で空いている店舗のみ
-                            const cand = req.candidate_datetimes?.candidates?.find(c => c.order === selectedCandidateOrder)
-                            if (!cand) return base
-                            const ts = cand.timeSlot
-                            return base.filter(s => !conflictInfo.storeDateConflicts.has(`${s.id}-${cand.date}-${ts}`))
+                            if (!selectedCand) return base
+                            return base.filter(s => !conflictInfo.storeDateConflicts.has(`${s.id}-${selectedCand.date}-${selectedCand.timeSlot}`))
                           })()
                           return (
                             <div className="space-y-2">
@@ -596,9 +594,22 @@ export function PrivateBookingManagement() {
                                 <select className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
                                   value={selectedStoreId} onChange={e => setSelectedStoreId(e.target.value)}>
                                   <option value="">選択してください</option>
-                                  {candidateStores.map(s => (
-                                    <option key={s.id} value={s.id}>{s.name}{(s as any).region ? ` (${(s as any).region})` : ''}</option>
-                                  ))}
+                                  {candidateStores.map(s => {
+                                    const ev = selectedCand
+                                      ? (conflictInfo.existingEvents || []).find(e =>
+                                          e.storeId === s.id && e.date === selectedCand.date &&
+                                          (selectedCand.startTime || '') < e.endTime &&
+                                          (selectedCand.endTime || '') > e.startTime
+                                        )
+                                      : undefined
+                                    const region = (s as any).region ? ` (${(s as any).region})` : ''
+                                    const isRequested = req.candidate_datetimes?.requestedStores?.some((rs: any) => rs.storeId === s.id)
+                                    return (
+                                      <option key={s.id} value={s.id}>
+                                        {s.name}{isRequested ? ' ★' : ''}{region}{ev ? ` ⚠️ ${ev.scenario} (${ev.startTime}〜${ev.endTime})` : ''}
+                                      </option>
+                                    )
+                                  })}
                                 </select>
                               </div>
                               <div className="flex items-center gap-2">

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -189,14 +189,12 @@ export function PrivateBookingManagement() {
           const conflictKey = `${gm.id}-${selectedCandidate.date}-${selectedCandidate.timeSlot}`
           isGMDisabled = conflictInfo.gmDateConflicts.has(conflictKey)
         }
-        const gmNotes = (availableGM?.notes || '').trim()
         const tagParts: string[] = []
         if (isAssigned) tagParts.push('担当')
         if (isAvailable) tagParts.push('対応可能')
         if (isGMDisabled) tagParts.push('予約済み')
         let label = gm.name
         if (tagParts.length) label += ` [${tagParts.join('・')}]`
-        if (gmNotes) label += ` — ${gmNotes}`
         const score = (isAssigned ? 2 : 0) + (isAvailable ? 1 : 0)
         return { gm, isGMDisabled, label, score }
       })
@@ -674,23 +672,23 @@ export function PrivateBookingManagement() {
                           )
                         })()}
 
-                        {/* アクションボタン */}
-                        <ActionButtons
-                          onApprove={async () => {
-                            if (req.status === 'confirmed') {
-                              const ok = window.confirm('この予約は既に承認済みです。内容を変更しますか？\n\n変更すると、お客様に再度確定メールが送信されます。')
-                              if (!ok) return
-                            }
-                            const needTwo = (req.required_gm_count ?? 1) >= 2
-                            const result = await handleApprove(req.id, req, selectedGMId, needTwo ? selectedSubGmId : null, selectedStoreId, selectedCandidateOrder, stores)
-                            if (result && !result.success && result.error) showToast.error(getSafeErrorMessage(result.error, '処理に失敗しました'))
-                          }}
-                          onReject={() => handleRejectClick(req.id)}
-                          onCancel={() => { setSelectedRequest(null); setSelectedGMId(''); setSelectedSubGmId(''); setSelectedStoreId(''); setSelectedCandidateOrder(null) }}
-                          disabled={submitting || !selectedGMId || !selectedStoreId || !selectedCandidateOrder || ((req.required_gm_count ?? 1) >= 2 && !selectedSubGmId)}
-                          submitting={submitting}
-                        />
                       </div>
+                    ) : undefined}
+                    cardActionsContent={selectedRequest?.id === req.id && selectedCandidateOrder ? (
+                      <ActionButtons
+                        onApprove={async () => {
+                          if (req.status === 'confirmed') {
+                            const ok = window.confirm('この予約は既に承認済みです。内容を変更しますか？\n\n変更すると、お客様に再度確定メールが送信されます。')
+                            if (!ok) return
+                          }
+                          const needTwo = (req.required_gm_count ?? 1) >= 2
+                          const result = await handleApprove(req.id, req, selectedGMId, needTwo ? selectedSubGmId : null, selectedStoreId, selectedCandidateOrder, stores)
+                          if (result && !result.success && result.error) showToast.error(getSafeErrorMessage(result.error, '処理に失敗しました'))
+                        }}
+                        onReject={() => handleRejectClick(req.id)}
+                        disabled={submitting || !selectedGMId || !selectedStoreId || !selectedCandidateOrder || ((req.required_gm_count ?? 1) >= 2 && !selectedSubGmId)}
+                        submitting={submitting}
+                      />
                     ) : undefined}
                   />
                 ))}

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
@@ -14,7 +15,6 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
 import { useAuth } from '@/contexts/AuthContext'
 import { supabase } from '@/lib/supabase'
-import { useSessionState } from '@/hooks/useSessionState'
 import { useReportRouteScrollRestoration } from '@/contexts/RouteScrollRestorationContext'
 import { logger } from '@/utils/logger'
 import { getSafeErrorMessage } from '@/lib/apiErrorHandler'
@@ -49,11 +49,18 @@ const normalizeTimeSlot = (timeSlot: string): string => {
   return timeSlot
 }
 
+type TabValue = 'gm_pending' | 'store_pending' | 'rejected' | 'all' | 'groups'
+const VALID_TABS: TabValue[] = ['gm_pending', 'store_pending', 'rejected', 'all', 'groups']
+
 export function PrivateBookingManagement() {
   const { user } = useAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
 
-  // タブ状態（sessionStorageと同期）
-  const [activeTab, setActiveTab] = useSessionState<'gm_pending' | 'store_pending' | 'rejected' | 'all' | 'groups'>('privateBookingActiveTab', 'store_pending')
+  const rawTab = searchParams.get('tab')
+  const activeTab: TabValue = (VALID_TABS.includes(rawTab as TabValue) ? rawTab : 'store_pending') as TabValue
+  const setActiveTab = useCallback((tab: TabValue) => {
+    setSearchParams({ tab }, { replace: true })
+  }, [setSearchParams])
   
   // 選択状態
   const [selectedRequest, setSelectedRequest] = useState<PrivateBookingRequest | null>(null)
@@ -531,12 +538,15 @@ export function PrivateBookingManagement() {
           </div>
 
           {/* グループ一覧タブ */}
-          <TabsContent value="groups" className="mt-0">
-            <PrivateGroupList />
-          </TabsContent>
+          {activeTab === 'groups' && (
+            <div className="mt-0">
+              <PrivateGroupList />
+            </div>
+          )}
 
           {/* 予約リクエストタブ */}
-          <TabsContent value={activeTab === 'groups' ? '' : activeTab} className="mt-0">
+          {activeTab !== 'groups' && (
+          <div className="mt-0">
 
             {filteredRequests.length === 0 ? (
               <Card className="shadow-none border">
@@ -557,7 +567,8 @@ export function PrivateBookingManagement() {
                 ))}
               </div>
             )}
-          </TabsContent>
+          </div>
+          )}
         </Tabs>
 
         {/* 選択されたリクエストの詳細モーダル */}

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -115,6 +115,9 @@ export function PrivateBookingManagement() {
     loadAvailableGMs
   } = useStoreAndGMManagement()
 
+  // 全リクエストの候補日に対するグローバル競合マップ（カード表示時点から店舗バッジを出すため）
+  const [globalStoreDateConflicts, setGlobalStoreDateConflicts] = useState<Set<string>>(new Set())
+
   // Discord通知再送信ハンドラー
   const handleResendDiscordNotification = async (cardRequest: { id: string; scenario_title: string }) => {
     const request = requests.find(r => r.id === cardRequest.id)
@@ -217,6 +220,48 @@ export function PrivateBookingManagement() {
     loadStores()
     loadAllGMs()
   }, [loadRequests, loadStores, loadAllGMs])
+
+  // requests ロード後：全候補日を1クエリで取得して店舗競合マップを構築
+  useEffect(() => {
+    if (!requests.length) return
+    const allDates = [...new Set(
+      requests.flatMap(r => (r.candidate_datetimes?.candidates || []).map((c: any) => c.date))
+    )].filter(Boolean)
+    if (!allDates.length) return
+
+    supabase
+      .from('schedule_events_staff_view')
+      .select('store_id, date, start_time, end_time')
+      .in('date', allDates)
+      .eq('is_cancelled', false)
+      .then(({ data }) => {
+        if (!data) return
+        const conflictSet = new Set<string>()
+        requests.forEach(req => {
+          (req.candidate_datetimes?.candidates || []).forEach((cand: any) => {
+            data.forEach(ev => {
+              if (ev.store_id && ev.date === cand.date) {
+                const start = cand.startTime || ''
+                const end   = cand.endTime   || ''
+                const evEnd   = (ev.end_time   || '').substring(0, 5)
+                const evStart = (ev.start_time || '').substring(0, 5)
+                // 60分インターバル考慮
+                const addMin = (t: string, m: number) => {
+                  const [h, mn] = t.split(':').map(Number)
+                  const tot = h * 60 + mn + m
+                  return `${String(Math.floor(tot/60)).padStart(2,'0')}:${String(tot%60).padStart(2,'0')}`
+                }
+                if (start < addMin(evEnd, 60) && addMin(end, 60) > evStart) {
+                  const ts = cand.timeSlot
+                  conflictSet.add(`${ev.store_id}-${cand.date}-${ts}`)
+                }
+              }
+            })
+          })
+        })
+        setGlobalStoreDateConflicts(conflictSet)
+      })
+  }, [requests])
 
   // 選択されたリクエストの初期化
   useEffect(() => {
@@ -551,16 +596,22 @@ export function PrivateBookingManagement() {
                     request={req}
                     onResendDiscordNotification={handleResendDiscordNotification}
                     selectedCandidateOrder={selectedRequest?.id === req.id ? selectedCandidateOrder : null}
-                    storesPerCandidate={selectedRequest?.id === req.id ? (() => {
-                      const baseStores = (() => {
-                        const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
-                        return ids.length > 0 ? stores.filter(s => ids.includes(s.id)) : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
-                      })()
-                      return (req.candidate_datetimes?.candidates || []).reduce((acc, cand) => {
-                        acc[cand.order] = baseStores.filter(s => !conflictInfo.storeDateConflicts.has(`${s.id}-${cand.date}-${cand.timeSlot}`))
+                    storesPerCandidate={(() => {
+                      // 選択中リクエストは精密な conflictInfo（60分インターバル含む）を使用
+                      // 未選択は globalStoreDateConflicts（一括クエリ結果）を使用
+                      const useDetailedConflict = selectedRequest?.id === req.id
+                      const conflictSet = useDetailedConflict
+                        ? conflictInfo.storeDateConflicts
+                        : globalStoreDateConflicts
+                      const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
+                      const baseStores = ids.length > 0
+                        ? stores.filter(s => ids.includes(s.id))
+                        : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
+                      return (req.candidate_datetimes?.candidates || []).reduce((acc: any, cand: any) => {
+                        acc[cand.order] = baseStores.filter(s => !conflictSet.has(`${s.id}-${cand.date}-${cand.timeSlot}`))
                         return acc
                       }, {} as Record<number, typeof baseStores>)
-                    })() : undefined}
+                    })()}
                     onSelectCandidate={(clickedReq, order) => {
                       // 同じ候補を再クリック → 選択解除
                       if (selectedRequest?.id === clickedReq.id && selectedCandidateOrder === order) {

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -27,7 +27,7 @@ import { CustomerInfo } from './components/CustomerInfo'
 import { CandidateDateSelector } from './components/CandidateDateSelector'
 import { ActionButtons } from './components/ActionButtons'
 import { SurveyResponsesView } from './components/SurveyResponsesView'
-import { PrivateGroupList } from './components/PrivateGroupList'
+
 
 // 分離されたフック
 import type { PrivateBookingRequest } from './hooks/usePrivateBookingData'
@@ -49,8 +49,8 @@ const normalizeTimeSlot = (timeSlot: string): string => {
   return timeSlot
 }
 
-type TabValue = 'gm_pending' | 'store_pending' | 'rejected' | 'all' | 'groups'
-const VALID_TABS: TabValue[] = ['gm_pending', 'store_pending', 'rejected', 'all', 'groups']
+type TabValue = 'gm_pending' | 'store_pending' | 'rejected' | 'all'
+const VALID_TABS: TabValue[] = ['gm_pending', 'store_pending', 'rejected', 'all']
 
 export function PrivateBookingManagement() {
   const { user } = useAuth()
@@ -501,18 +501,16 @@ export function PrivateBookingManagement() {
           description="貸切予約リクエストの承認・却下・店舗調整を行います"
         />
 
-        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as 'gm_pending' | 'store_pending' | 'rejected' | 'all' | 'groups')}>
+        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabValue)}>
           <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-3 mb-4">
             <TabsList className="w-full sm:w-auto flex-wrap">
               <TabsTrigger value="gm_pending" className="flex-1 sm:flex-initial text-xs sm:text-sm">GM確認中 ({gmPendingRequests.length})</TabsTrigger>
               <TabsTrigger value="store_pending" className="flex-1 sm:flex-initial text-xs sm:text-sm">店舗承認待ち ({storePendingRequests.length})</TabsTrigger>
               <TabsTrigger value="rejected" className="flex-1 sm:flex-initial text-xs sm:text-sm">却下済み ({rejectedRequests.length})</TabsTrigger>
               <TabsTrigger value="all" className="flex-1 sm:flex-initial text-xs sm:text-sm">全て ({requests.length})</TabsTrigger>
-              <TabsTrigger value="groups" className="flex-1 sm:flex-initial text-xs sm:text-sm">グループ一覧</TabsTrigger>
             </TabsList>
-            
-            {activeTab !== 'groups' && (
-              <div className="w-full sm:w-auto flex justify-center sm:justify-end gap-2">
+
+            <div className="w-full sm:w-auto flex justify-center sm:justify-end gap-2">
                 <DateRangePopover
                   startDate={dateRangeStart}
                   endDate={dateRangeEnd}
@@ -534,18 +532,9 @@ export function PrivateBookingManagement() {
                   </SelectContent>
                 </Select>
               </div>
-            )}
           </div>
 
-          {/* グループ一覧タブ */}
-          {activeTab === 'groups' && (
-            <div className="mt-0">
-              <PrivateGroupList />
-            </div>
-          )}
-
           {/* 予約リクエストタブ */}
-          {activeTab !== 'groups' && (
           <div className="mt-0">
 
             {filteredRequests.length === 0 ? (
@@ -568,7 +557,6 @@ export function PrivateBookingManagement() {
               </div>
             )}
           </div>
-          )}
         </Tabs>
 
         {/* 選択されたリクエストの詳細モーダル */}

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -265,29 +265,15 @@ export function PrivateBookingManagement() {
 
   // 選択されたリクエストの初期化
   useEffect(() => {
-    let timer: NodeJS.Timeout | undefined
-    const initializeRequest = async () => {
-      if (selectedRequest) {
-        loadAllGMs()
-        loadAvailableGMs(selectedRequest.id)
-        await loadConflictInfo(selectedRequest.id)
-        
-        // 確定店舗があればそれを選択、なければ最初の希望店舗を選択
-        if (selectedRequest.candidate_datetimes?.confirmedStore) {
-          setSelectedStoreId(selectedRequest.candidate_datetimes.confirmedStore.storeId)
-        } else if (selectedRequest.candidate_datetimes?.requestedStores && selectedRequest.candidate_datetimes.requestedStores.length > 0) {
-          setSelectedStoreId(selectedRequest.candidate_datetimes.requestedStores[0].storeId)
-        }
-        
-        // 選択可能な最初の候補を自動選択
-        timer = setTimeout(() => {
-          selectFirstAvailableCandidate()
-        }, 150)
-      }
+    if (!selectedRequest) return
+    loadAllGMs()
+    loadAvailableGMs(selectedRequest.id)
+    loadConflictInfo(selectedRequest.id)
+    // 確定店舗があればそれを選択
+    if (selectedRequest.candidate_datetimes?.confirmedStore) {
+      setSelectedStoreId(selectedRequest.candidate_datetimes.confirmedStore.storeId)
     }
-    
-    initializeRequest()
-    return () => { if (timer) clearTimeout(timer) }
+    // 候補の自動選択はしない（ユーザーが候補行を直接クリックして選択する）
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedRequest])
 
@@ -393,40 +379,6 @@ export function PrivateBookingManagement() {
     return filteredStores.filter(store => (store.region || '未分類') === selectedRegionFilter)
   }, [filteredStores, selectedRegionFilter])
 
-  // 店舗またはGMが変更されたときの競合情報更新
-  useEffect(() => {
-    let timer: NodeJS.Timeout | undefined
-    const updateConflicts = async () => {
-      if (selectedRequest) {
-        await loadConflictInfo(selectedRequest.id)
-        
-        // 選択中の候補が競合している場合は再選択
-        if (selectedCandidateOrder && selectedRequest.candidate_datetimes?.candidates) {
-          const selectedCandidate = selectedRequest.candidate_datetimes.candidates.find(
-            c => c.order === selectedCandidateOrder
-          )
-          if (selectedCandidate) {
-            const normalizedSlot = normalizeTimeSlot(selectedCandidate.timeSlot)
-            const storeConflictKey = selectedStoreId ? `${selectedStoreId}-${selectedCandidate.date}-${normalizedSlot}` : null
-            const gmConflictKey = selectedGMId ? `${selectedGMId}-${selectedCandidate.date}-${normalizedSlot}` : null
-            
-            timer = setTimeout(() => {
-              const hasStoreConflict = storeConflictKey && conflictInfo.storeDateConflicts.has(storeConflictKey)
-              const hasGMConflict = gmConflictKey && conflictInfo.gmDateConflicts.has(gmConflictKey)
-              
-              if (hasStoreConflict || hasGMConflict) {
-                selectFirstAvailableCandidate()
-              }
-            }, 100)
-          }
-        }
-      }
-    }
-    
-    updateConflicts()
-    return () => { if (timer) clearTimeout(timer) }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedStoreId, selectedGMId])
 
   // 選択可能な最初の候補日時を自動選択
   const selectFirstAvailableCandidate = () => {
@@ -597,12 +549,8 @@ export function PrivateBookingManagement() {
                     onResendDiscordNotification={handleResendDiscordNotification}
                     selectedCandidateOrder={selectedRequest?.id === req.id ? selectedCandidateOrder : null}
                     storesPerCandidate={(() => {
-                      // 選択中リクエストは精密な conflictInfo（60分インターバル含む）を使用
-                      // 未選択は globalStoreDateConflicts（一括クエリ結果）を使用
-                      const useDetailedConflict = selectedRequest?.id === req.id
-                      const conflictSet = useDetailedConflict
-                        ? conflictInfo.storeDateConflicts
-                        : globalStoreDateConflicts
+                      // カードのバッジ表示は常に globalStoreDateConflicts を使用（切り替えによるちらつきを防ぐ）
+                      const conflictSet = globalStoreDateConflicts
                       const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
                       const baseStores = ids.length > 0
                         ? stores.filter(s => ids.includes(s.id))

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -551,6 +551,16 @@ export function PrivateBookingManagement() {
                     request={req}
                     onResendDiscordNotification={handleResendDiscordNotification}
                     selectedCandidateOrder={selectedRequest?.id === req.id ? selectedCandidateOrder : null}
+                    storesPerCandidate={selectedRequest?.id === req.id ? (() => {
+                      const baseStores = (() => {
+                        const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
+                        return ids.length > 0 ? stores.filter(s => ids.includes(s.id)) : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
+                      })()
+                      return (req.candidate_datetimes?.candidates || []).reduce((acc, cand) => {
+                        acc[cand.order] = baseStores.filter(s => !conflictInfo.storeDateConflicts.has(`${s.id}-${cand.date}-${cand.timeSlot}`))
+                        return acc
+                      }, {} as Record<number, typeof baseStores>)
+                    })() : undefined}
                     onSelectCandidate={(clickedReq, order) => {
                       // 同じ候補を再クリック → 選択解除
                       if (selectedRequest?.id === clickedReq.id && selectedCandidateOrder === order) {
@@ -623,27 +633,42 @@ export function PrivateBookingManagement() {
                                   </SelectContent>
                                 </Select>
                               </div>
-                              <div className="flex items-center gap-2">
-                                <span className="text-xs text-purple-700 font-medium w-16 shrink-0">{(req.required_gm_count ?? 1) >= 2 ? 'メインGM' : 'GM'}</span>
-                                <select className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
-                                  value={selectedGMId}
-                                  onChange={e => { setSelectedGMId(e.target.value); setSelectedSubGmId(p => p === e.target.value ? '' : p) }}>
-                                  <option value="">選択してください</option>
-                                  {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
-                                    <option key={gm.id} value={gm.id} disabled={isGMDisabled || ((req.required_gm_count ?? 1) >= 2 && gm.id === selectedSubGmId)}>{label}</option>
-                                  ))}
-                                </select>
-                              </div>
-                              {(req.required_gm_count ?? 1) >= 2 && (
-                                <div className="flex items-center gap-2">
-                                  <span className="text-xs text-purple-700 font-medium w-16 shrink-0">サブGM</span>
-                                  <select className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
-                                    value={selectedSubGmId} onChange={e => setSelectedSubGmId(e.target.value)}>
-                                    <option value="">選択してください</option>
+                              {/* メインGM */}
+                              <div className="flex items-start gap-2">
+                                <span className="text-xs text-purple-700 font-medium w-16 shrink-0 pt-2">
+                                  {(req.required_gm_count ?? 1) >= 2 ? 'メインGM' : 'GM'}
+                                </span>
+                                <Select value={selectedGMId} onValueChange={v => { setSelectedGMId(v); setSelectedSubGmId(p => p === v ? '' : p) }}>
+                                  <SelectTrigger className="flex-1 text-sm h-8">
+                                    <SelectValue placeholder="選択してください" />
+                                  </SelectTrigger>
+                                  <SelectContent>
                                     {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
-                                      <option key={gm.id} value={gm.id} disabled={isGMDisabled || gm.id === selectedGMId}>{label}</option>
+                                      <SelectItem key={gm.id} value={gm.id}
+                                        disabled={isGMDisabled || ((req.required_gm_count ?? 1) >= 2 && gm.id === selectedSubGmId)}>
+                                        {label}
+                                      </SelectItem>
                                     ))}
-                                  </select>
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                              {/* サブGM */}
+                              {(req.required_gm_count ?? 1) >= 2 && (
+                                <div className="flex items-start gap-2">
+                                  <span className="text-xs text-purple-700 font-medium w-16 shrink-0 pt-2">サブGM</span>
+                                  <Select value={selectedSubGmId} onValueChange={setSelectedSubGmId}>
+                                    <SelectTrigger className="flex-1 text-sm h-8">
+                                      <SelectValue placeholder="選択してください" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
+                                        <SelectItem key={gm.id} value={gm.id}
+                                          disabled={isGMDisabled || gm.id === selectedGMId}>
+                                          {label}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
                                 </div>
                               )}
                             </div>

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -563,32 +563,34 @@ export function PrivateBookingManagement() {
                       }
                     }}
                     inlineApprovalContent={selectedRequest?.id === req.id ? (
-                      <div className="space-y-4">
+                      <div className="space-y-3">
                         {/* アンケート */}
                         <SurveyResponsesView
                           reservationId={req.id}
                           scenarioId={req.scenario_master_id || ''}
                         />
 
-                        {/* 候補日選択 */}
+                        {/* 候補日選択 + 店舗・GMプルダウン（inline） */}
                         <CandidateDateSelector
                           candidates={req.candidate_datetimes?.candidates || []}
                           selectedCandidateOrder={selectedCandidateOrder}
-                          onSelectCandidate={setSelectedCandidateOrder}
+                          onSelectCandidate={order => {
+                            setSelectedCandidateOrder(order)
+                            setSelectedStoreId('')
+                            setSelectedGMId('')
+                            setSelectedSubGmId('')
+                          }}
                           selectedStoreId={selectedStoreId}
                           selectedGMId={selectedGMId}
+                          selectedSubGmId={selectedSubGmId}
+                          onSelectStore={setSelectedStoreId}
+                          onSelectGM={v => { setSelectedGMId(v); setSelectedSubGmId(p => p === v ? '' : p) }}
+                          onSelectSubGM={setSelectedSubGmId}
+                          gmSelectOptions={gmSelectOptions}
                           conflictInfo={conflictInfo}
-                          gmSelectedCandidates={(() => {
-                            if (!availableGMs.length) return undefined
-                            const r = selectedGMId
-                              ? availableGMs.find(r => String(r.gm_id) === String(selectedGMId))
-                              : availableGMs.find(r => isGmMarkedAvailable(r))
-                            const ac = r?.available_candidates
-                            return ac?.length ? ac.map((i: number) => i + 1) : undefined
-                          })()}
                           gmResponses={availableGMs}
-                          isReadOnly={false}
                           isConfirmed={req.status === 'confirmed'}
+                          requiredGmCount={req.required_gm_count ?? 1}
                           stores={(() => {
                             const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
                             return ids.length > 0
@@ -596,124 +598,6 @@ export function PrivateBookingManagement() {
                               : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
                           })()}
                         />
-
-                        {/* 店舗選択 */}
-                        <div>
-                          <h3 className="mb-2 flex items-center gap-2 text-sm font-medium text-purple-800">
-                            <MapPin className="w-4 h-4" />開催店舗の選択
-                          </h3>
-                          <div className="flex gap-2 mb-2 flex-wrap">
-                            <button type="button" onClick={() => setSelectedRegionFilter('all')}
-                              className={`px-2 py-1 text-xs rounded border transition-colors ${selectedRegionFilter === 'all' ? 'bg-purple-600 text-white border-purple-600' : 'bg-background border-gray-300 hover:border-purple-400'}`}>
-                              全て
-                            </button>
-                            {storesByRegion.sortedRegions.map(region => (
-                              <button key={region} type="button" onClick={() => setSelectedRegionFilter(region)}
-                                className={`px-2 py-1 text-xs rounded border transition-colors ${selectedRegionFilter === region ? 'bg-purple-600 text-white border-purple-600' : 'bg-background border-gray-300 hover:border-purple-400'}`}>
-                                {region} ({storesByRegion.grouped[region]?.length || 0})
-                              </button>
-                            ))}
-                          </div>
-                          <Select value={selectedStoreId} onValueChange={setSelectedStoreId}>
-                            <SelectTrigger className="w-full text-sm">
-                              <SelectValue placeholder="店舗を選択してください" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {regionFilteredStores.map(store => {
-                                const requestedStores = req.candidate_datetimes?.requestedStores || []
-                                const isRequested = requestedStores.length === 0 || requestedStores.some(rs => rs.storeId === store.id)
-                                let existingEventLabel = ''
-                                let isStoreDisabled = false
-                                if (selectedCandidateOrder && req.candidate_datetimes?.candidates) {
-                                  const sc = req.candidate_datetimes.candidates.find(c => c.order === selectedCandidateOrder)
-                                  if (sc) {
-                                    const key = `${store.id}-${sc.date}-${sc.timeSlot}`
-                                    isStoreDisabled = conflictInfo.storeDateConflicts.has(key)
-                                    const ev = (conflictInfo.existingEvents || []).find(e =>
-                                      e.storeId === store.id && e.date === sc.date &&
-                                      (sc.startTime || '') < e.endTime && (sc.endTime || '') > e.startTime
-                                    )
-                                    if (ev) existingEventLabel = ` ⚠️ ${ev.scenario} (${ev.startTime}〜${ev.endTime})`
-                                  }
-                                }
-                                return (
-                                  <SelectItem key={store.id} value={store.id} disabled={isStoreDisabled} className="whitespace-normal">
-                                    <span className="block">
-                                      {store.name}{isRequested && ' (お客様希望)'}
-                                      {selectedRegionFilter === 'all' && store.region && (
-                                        <span className="text-xs text-muted-foreground ml-1">({store.region})</span>
-                                      )}
-                                    </span>
-                                    {existingEventLabel && (
-                                      <span className="block text-xs text-orange-600 font-medium">{existingEventLabel}</span>
-                                    )}
-                                  </SelectItem>
-                                )
-                              })}
-                            </SelectContent>
-                          </Select>
-                        </div>
-
-                        {/* メモ */}
-                        {req.notes && (
-                          <div>
-                            <h3 className="mb-1 text-sm font-medium text-purple-800">お客様からのメモ</h3>
-                            <div className="p-3 bg-background rounded border text-sm whitespace-pre-wrap">{req.notes}</div>
-                          </div>
-                        )}
-
-                        {/* 複数GM注意 */}
-                        {(req.required_gm_count ?? 1) >= 2 && (
-                          <Alert className="border-amber-200 bg-amber-50/80 text-amber-950">
-                            <AlertCircle className="h-4 w-4 text-amber-700" />
-                            <AlertTitle className="text-sm font-semibold text-amber-900">
-                              必要GM数が{req.required_gm_count}人のシナリオです
-                            </AlertTitle>
-                            <AlertDescription className="text-xs text-amber-900/90 mt-1">
-                              メインGMとサブGMを2名選んで確定してください。
-                            </AlertDescription>
-                          </Alert>
-                        )}
-
-                        {/* GM選択 */}
-                        <div>
-                          <h3 className="mb-2 text-sm font-medium text-purple-800">
-                            {(req.required_gm_count ?? 1) >= 2 ? 'メインGM・サブGMをそれぞれ選択' : '担当GMを選択'}
-                          </h3>
-                          <select
-                            className="flex h-9 w-full rounded-md border border-input bg-[#F6F9FB] px-2 py-1 text-sm"
-                            value={selectedGMId}
-                            onChange={e => { const v = e.target.value; setSelectedGMId(v); setSelectedSubGmId(p => p === v ? '' : p) }}
-                          >
-                            <option value="">{(req.required_gm_count ?? 1) >= 2 ? 'メインGMを選択' : 'GMを選択してください'}</option>
-                            {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
-                              <option key={gm.id} value={gm.id}
-                                disabled={isGMDisabled || ((req.required_gm_count ?? 1) >= 2 && gm.id === selectedSubGmId)}>
-                                {label}
-                              </option>
-                            ))}
-                          </select>
-                          {(req.required_gm_count ?? 1) >= 2 && (
-                            <div className="mt-3">
-                              <select
-                                className="flex h-9 w-full rounded-md border border-input bg-[#F6F9FB] px-2 py-1 text-sm"
-                                value={selectedSubGmId}
-                                onChange={e => setSelectedSubGmId(e.target.value)}
-                              >
-                                <option value="">サブGMを選択</option>
-                                {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
-                                  <option key={gm.id} value={gm.id} disabled={isGMDisabled || gm.id === selectedGMId}>{label}</option>
-                                ))}
-                              </select>
-                            </div>
-                          )}
-                          {(assignedGMIds.length > 0 || availableGMs.length > 0) && (
-                            <div className="mt-2 text-xs text-muted-foreground">
-                              ℹ️ <span className="inline-flex items-center px-1 py-0.5 text-xs bg-purple-100 text-purple-700 rounded">担当</span> このシナリオの担当GM /{' '}
-                              <span className="inline-flex items-center px-1 py-0.5 text-xs bg-green-100 text-green-700 rounded">対応可能</span> 今回対応可能と回答したGM
-                            </div>
-                          )}
-                        </div>
 
                         {/* アクションボタン */}
                         <ActionButtons

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -589,28 +589,39 @@ export function PrivateBookingManagement() {
                           })()
                           return (
                             <div className="space-y-2">
-                              <div className="flex items-center gap-2">
-                                <span className="text-xs text-purple-700 font-medium w-16 shrink-0">店舗</span>
-                                <select className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
-                                  value={selectedStoreId} onChange={e => setSelectedStoreId(e.target.value)}>
-                                  <option value="">選択してください</option>
-                                  {candidateStores.map(s => {
-                                    const ev = selectedCand
-                                      ? (conflictInfo.existingEvents || []).find(e =>
-                                          e.storeId === s.id && e.date === selectedCand.date &&
-                                          (selectedCand.startTime || '') < e.endTime &&
-                                          (selectedCand.endTime || '') > e.startTime
-                                        )
-                                      : undefined
-                                    const region = (s as any).region ? ` (${(s as any).region})` : ''
-                                    const isRequested = req.candidate_datetimes?.requestedStores?.some((rs: any) => rs.storeId === s.id)
-                                    return (
-                                      <option key={s.id} value={s.id}>
-                                        {s.name}{isRequested ? ' ★' : ''}{region}{ev ? ` ⚠️ ${ev.scenario} (${ev.startTime}〜${ev.endTime})` : ''}
-                                      </option>
-                                    )
-                                  })}
-                                </select>
+                              <div className="flex items-start gap-2">
+                                <span className="text-xs text-purple-700 font-medium w-16 shrink-0 pt-2">店舗</span>
+                                <Select value={selectedStoreId} onValueChange={setSelectedStoreId}>
+                                  <SelectTrigger className="flex-1 text-sm h-8">
+                                    <SelectValue placeholder="選択してください" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {candidateStores.map(s => {
+                                      const ev = selectedCand
+                                        ? (conflictInfo.existingEvents || []).find(e =>
+                                            e.storeId === s.id && e.date === selectedCand.date &&
+                                            (selectedCand.startTime || '') < e.endTime &&
+                                            (selectedCand.endTime || '') > e.startTime
+                                          )
+                                        : undefined
+                                      const isRequested = req.candidate_datetimes?.requestedStores?.some((rs: any) => rs.storeId === s.id)
+                                      return (
+                                        <SelectItem key={s.id} value={s.id} className="whitespace-normal">
+                                          <span className="block">
+                                            {s.name}
+                                            {isRequested && <span className="ml-1 text-purple-600 text-xs">（お客様希望）</span>}
+                                            {(s as any).region && <span className="ml-1 text-xs text-muted-foreground">({(s as any).region})</span>}
+                                          </span>
+                                          {ev && (
+                                            <span className="block text-xs text-orange-600 font-medium mt-0.5">
+                                              ⚠️ {ev.scenario} ({ev.startTime}〜{ev.endTime})
+                                            </span>
+                                          )}
+                                        </SelectItem>
+                                      )
+                                    })}
+                                  </SelectContent>
+                                </Select>
                               </div>
                               <div className="flex items-center gap-2">
                                 <span className="text-xs text-purple-700 font-medium w-16 shrink-0">{(req.required_gm_count ?? 1) >= 2 ? 'メインGM' : 'GM'}</span>

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -549,9 +549,190 @@ export function PrivateBookingManagement() {
                   <BookingRequestCard
                     key={req.id}
                     request={req}
-                    onSelectRequest={() => setSelectedRequest(req)}
-                    showActionButton={true}
                     onResendDiscordNotification={handleResendDiscordNotification}
+                    isApprovalOpen={selectedRequest?.id === req.id}
+                    onToggleApproval={() => {
+                      if (selectedRequest?.id === req.id) {
+                        setSelectedRequest(null)
+                        setSelectedGMId('')
+                        setSelectedSubGmId('')
+                        setSelectedStoreId('')
+                        setSelectedCandidateOrder(null)
+                      } else {
+                        setSelectedRequest(req)
+                      }
+                    }}
+                    inlineApprovalContent={selectedRequest?.id === req.id ? (
+                      <div className="space-y-4">
+                        {/* アンケート */}
+                        <SurveyResponsesView
+                          reservationId={req.id}
+                          scenarioId={req.scenario_master_id || ''}
+                        />
+
+                        {/* 候補日選択 */}
+                        <CandidateDateSelector
+                          candidates={req.candidate_datetimes?.candidates || []}
+                          selectedCandidateOrder={selectedCandidateOrder}
+                          onSelectCandidate={setSelectedCandidateOrder}
+                          selectedStoreId={selectedStoreId}
+                          selectedGMId={selectedGMId}
+                          conflictInfo={conflictInfo}
+                          gmSelectedCandidates={(() => {
+                            if (!availableGMs.length) return undefined
+                            const r = selectedGMId
+                              ? availableGMs.find(r => String(r.gm_id) === String(selectedGMId))
+                              : availableGMs.find(r => isGmMarkedAvailable(r))
+                            const ac = r?.available_candidates
+                            return ac?.length ? ac.map((i: number) => i + 1) : undefined
+                          })()}
+                          gmResponses={availableGMs}
+                          isReadOnly={false}
+                          isConfirmed={req.status === 'confirmed'}
+                          stores={(() => {
+                            const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
+                            return ids.length > 0
+                              ? stores.filter(s => ids.includes(s.id))
+                              : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
+                          })()}
+                        />
+
+                        {/* 店舗選択 */}
+                        <div>
+                          <h3 className="mb-2 flex items-center gap-2 text-sm font-medium text-purple-800">
+                            <MapPin className="w-4 h-4" />開催店舗の選択
+                          </h3>
+                          <div className="flex gap-2 mb-2 flex-wrap">
+                            <button type="button" onClick={() => setSelectedRegionFilter('all')}
+                              className={`px-2 py-1 text-xs rounded border transition-colors ${selectedRegionFilter === 'all' ? 'bg-purple-600 text-white border-purple-600' : 'bg-background border-gray-300 hover:border-purple-400'}`}>
+                              全て
+                            </button>
+                            {storesByRegion.sortedRegions.map(region => (
+                              <button key={region} type="button" onClick={() => setSelectedRegionFilter(region)}
+                                className={`px-2 py-1 text-xs rounded border transition-colors ${selectedRegionFilter === region ? 'bg-purple-600 text-white border-purple-600' : 'bg-background border-gray-300 hover:border-purple-400'}`}>
+                                {region} ({storesByRegion.grouped[region]?.length || 0})
+                              </button>
+                            ))}
+                          </div>
+                          <Select value={selectedStoreId} onValueChange={setSelectedStoreId}>
+                            <SelectTrigger className="w-full text-sm">
+                              <SelectValue placeholder="店舗を選択してください" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {regionFilteredStores.map(store => {
+                                const requestedStores = req.candidate_datetimes?.requestedStores || []
+                                const isRequested = requestedStores.length === 0 || requestedStores.some(rs => rs.storeId === store.id)
+                                let existingEventLabel = ''
+                                let isStoreDisabled = false
+                                if (selectedCandidateOrder && req.candidate_datetimes?.candidates) {
+                                  const sc = req.candidate_datetimes.candidates.find(c => c.order === selectedCandidateOrder)
+                                  if (sc) {
+                                    const key = `${store.id}-${sc.date}-${sc.timeSlot}`
+                                    isStoreDisabled = conflictInfo.storeDateConflicts.has(key)
+                                    const ev = (conflictInfo.existingEvents || []).find(e =>
+                                      e.storeId === store.id && e.date === sc.date &&
+                                      (sc.startTime || '') < e.endTime && (sc.endTime || '') > e.startTime
+                                    )
+                                    if (ev) existingEventLabel = ` ⚠️ ${ev.scenario} (${ev.startTime}〜${ev.endTime})`
+                                  }
+                                }
+                                return (
+                                  <SelectItem key={store.id} value={store.id} disabled={isStoreDisabled} className="whitespace-normal">
+                                    <span className="block">
+                                      {store.name}{isRequested && ' (お客様希望)'}
+                                      {selectedRegionFilter === 'all' && store.region && (
+                                        <span className="text-xs text-muted-foreground ml-1">({store.region})</span>
+                                      )}
+                                    </span>
+                                    {existingEventLabel && (
+                                      <span className="block text-xs text-orange-600 font-medium">{existingEventLabel}</span>
+                                    )}
+                                  </SelectItem>
+                                )
+                              })}
+                            </SelectContent>
+                          </Select>
+                        </div>
+
+                        {/* メモ */}
+                        {req.notes && (
+                          <div>
+                            <h3 className="mb-1 text-sm font-medium text-purple-800">お客様からのメモ</h3>
+                            <div className="p-3 bg-background rounded border text-sm whitespace-pre-wrap">{req.notes}</div>
+                          </div>
+                        )}
+
+                        {/* 複数GM注意 */}
+                        {(req.required_gm_count ?? 1) >= 2 && (
+                          <Alert className="border-amber-200 bg-amber-50/80 text-amber-950">
+                            <AlertCircle className="h-4 w-4 text-amber-700" />
+                            <AlertTitle className="text-sm font-semibold text-amber-900">
+                              必要GM数が{req.required_gm_count}人のシナリオです
+                            </AlertTitle>
+                            <AlertDescription className="text-xs text-amber-900/90 mt-1">
+                              メインGMとサブGMを2名選んで確定してください。
+                            </AlertDescription>
+                          </Alert>
+                        )}
+
+                        {/* GM選択 */}
+                        <div>
+                          <h3 className="mb-2 text-sm font-medium text-purple-800">
+                            {(req.required_gm_count ?? 1) >= 2 ? 'メインGM・サブGMをそれぞれ選択' : '担当GMを選択'}
+                          </h3>
+                          <select
+                            className="flex h-9 w-full rounded-md border border-input bg-[#F6F9FB] px-2 py-1 text-sm"
+                            value={selectedGMId}
+                            onChange={e => { const v = e.target.value; setSelectedGMId(v); setSelectedSubGmId(p => p === v ? '' : p) }}
+                          >
+                            <option value="">{(req.required_gm_count ?? 1) >= 2 ? 'メインGMを選択' : 'GMを選択してください'}</option>
+                            {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
+                              <option key={gm.id} value={gm.id}
+                                disabled={isGMDisabled || ((req.required_gm_count ?? 1) >= 2 && gm.id === selectedSubGmId)}>
+                                {label}
+                              </option>
+                            ))}
+                          </select>
+                          {(req.required_gm_count ?? 1) >= 2 && (
+                            <div className="mt-3">
+                              <select
+                                className="flex h-9 w-full rounded-md border border-input bg-[#F6F9FB] px-2 py-1 text-sm"
+                                value={selectedSubGmId}
+                                onChange={e => setSelectedSubGmId(e.target.value)}
+                              >
+                                <option value="">サブGMを選択</option>
+                                {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
+                                  <option key={gm.id} value={gm.id} disabled={isGMDisabled || gm.id === selectedGMId}>{label}</option>
+                                ))}
+                              </select>
+                            </div>
+                          )}
+                          {(assignedGMIds.length > 0 || availableGMs.length > 0) && (
+                            <div className="mt-2 text-xs text-muted-foreground">
+                              ℹ️ <span className="inline-flex items-center px-1 py-0.5 text-xs bg-purple-100 text-purple-700 rounded">担当</span> このシナリオの担当GM /{' '}
+                              <span className="inline-flex items-center px-1 py-0.5 text-xs bg-green-100 text-green-700 rounded">対応可能</span> 今回対応可能と回答したGM
+                            </div>
+                          )}
+                        </div>
+
+                        {/* アクションボタン */}
+                        <ActionButtons
+                          onApprove={async () => {
+                            if (req.status === 'confirmed') {
+                              const ok = window.confirm('この予約は既に承認済みです。内容を変更しますか？\n\n変更すると、お客様に再度確定メールが送信されます。')
+                              if (!ok) return
+                            }
+                            const needTwo = (req.required_gm_count ?? 1) >= 2
+                            const result = await handleApprove(req.id, req, selectedGMId, needTwo ? selectedSubGmId : null, selectedStoreId, selectedCandidateOrder, stores)
+                            if (result && !result.success && result.error) showToast.error(getSafeErrorMessage(result.error, '処理に失敗しました'))
+                          }}
+                          onReject={() => handleRejectClick(req.id)}
+                          onCancel={() => { setSelectedRequest(null); setSelectedGMId(''); setSelectedSubGmId(''); setSelectedStoreId(''); setSelectedCandidateOrder(null) }}
+                          disabled={submitting || !selectedGMId || !selectedStoreId || !selectedCandidateOrder || ((req.required_gm_count ?? 1) >= 2 && !selectedSubGmId)}
+                          submitting={submitting}
+                        />
+                      </div>
+                    ) : undefined}
                   />
                 ))}
               </div>
@@ -559,315 +740,7 @@ export function PrivateBookingManagement() {
           </div>
         </Tabs>
 
-        {/* 選択されたリクエストの詳細モーダル */}
-        <Dialog 
-          open={!!selectedRequest} 
-          onOpenChange={(open) => {
-            if (!open) {
-              setSelectedRequest(null)
-              setSelectedGMId('')
-              setSelectedStoreId('')
-              setSelectedCandidateOrder(null)
-            }
-          }}
-        >
-          <DialogContent size="xl" className="flex flex-col p-0 gap-0 overflow-hidden max-h-[90vh]">
-            {/* ── 固定ヘッダー ── */}
-            <DialogHeader className="px-5 py-3 border-b shrink-0">
-              <DialogTitle className="text-base sm:text-lg pr-6">
-                {selectedRequest?.scenario_title}
-              </DialogTitle>
-            </DialogHeader>
-
-            {selectedRequest && (<>
-            {/* ── スクロール可能なコンテンツ領域 ── */}
-            <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
-              <CustomerInfo request={selectedRequest} />
-              
-              {/* アンケート回答閲覧 */}
-              <SurveyResponsesView
-                reservationId={selectedRequest.id}
-                scenarioId={selectedRequest.scenario_master_id || ''}
-              />
-              
-              <CandidateDateSelector
-                candidates={selectedRequest.candidate_datetimes?.candidates || []}
-                selectedCandidateOrder={selectedCandidateOrder}
-                onSelectCandidate={setSelectedCandidateOrder}
-                selectedStoreId={selectedStoreId}
-                selectedGMId={selectedGMId}
-                conflictInfo={conflictInfo}
-                gmSelectedCandidates={
-                  // loadAvailableGMs と同じソースで参照（一覧の gm_responses フィルタとズレないようにする）
-                  (() => {
-                    if (!availableGMs.length) return undefined
-                    const selectedGMResponse = selectedGMId
-                      ? availableGMs.find((r) => String(r.gm_id) === String(selectedGMId))
-                      : availableGMs.find((r) => isGmMarkedAvailable(r))
-                    const ac = selectedGMResponse?.available_candidates
-                    return ac?.length ? ac.map((idx: number) => idx + 1) : undefined
-                  })()
-                }
-                gmResponses={availableGMs} // 全GMの回答情報を渡す
-                isReadOnly={false} // 確定済みでも編集可能に
-                isConfirmed={selectedRequest.status === 'confirmed'}
-                stores={(() => {
-                  const requestedStoreIds = selectedRequest.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
-                  if (requestedStoreIds.length > 0) {
-                    return stores.filter(s => requestedStoreIds.includes(s.id))
-                  }
-                  return stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
-                })()}
-              />
-
-              {/* 開催店舗の選択 */}
-              <div className="pt-3 border-t">
-                <h3 className="mb-2 flex items-center gap-2 text-sm font-medium text-purple-800">
-                  <MapPin className="w-4 h-4" />
-                  開催店舗の選択
-                </h3>
-                
-                {/* 地域フィルター */}
-                <div className="flex gap-2 mb-2">
-                  <button
-                    type="button"
-                    onClick={() => setSelectedRegionFilter('all')}
-                    className={`px-2 py-1 text-xs rounded border transition-colors ${
-                      selectedRegionFilter === 'all'
-                        ? 'bg-purple-600 text-white border-purple-600'
-                        : 'bg-background border-gray-300 hover:border-purple-400'
-                    }`}
-                  >
-                    全て
-                  </button>
-                  {storesByRegion.sortedRegions.map((region) => (
-                    <button
-                      key={region}
-                      type="button"
-                      onClick={() => setSelectedRegionFilter(region)}
-                      className={`px-2 py-1 text-xs rounded border transition-colors ${
-                        selectedRegionFilter === region
-                          ? 'bg-purple-600 text-white border-purple-600'
-                          : 'bg-background border-gray-300 hover:border-purple-400'
-                      }`}
-                    >
-                      {region} ({storesByRegion.grouped[region]?.length || 0})
-                    </button>
-                  ))}
-                </div>
-                
-                <Select value={selectedStoreId} onValueChange={setSelectedStoreId}>
-                  <SelectTrigger className="w-full text-sm">
-                    <SelectValue placeholder="店舗を選択してください" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {regionFilteredStores.map((store) => {
-                      const requestedStores = selectedRequest.candidate_datetimes?.requestedStores || []
-                      const isAllStoresRequested = requestedStores.length === 0
-                      const isRequested = isAllStoresRequested || requestedStores.some(rs => rs.storeId === store.id)
-                      
-                      // 選択した候補日時でこの店舗の既存イベントを取得
-                      let existingEventLabel = ''
-                      let isStoreDisabled = false
-                      if (selectedCandidateOrder && selectedRequest.candidate_datetimes?.candidates) {
-                        const selectedCandidate = selectedRequest.candidate_datetimes.candidates.find(
-                          (c: any) => c.order === selectedCandidateOrder
-                        )
-                        if (selectedCandidate) {
-                          const conflictKey = `${store.id}-${selectedCandidate.date}-${selectedCandidate.timeSlot}`
-                          isStoreDisabled = conflictInfo.storeDateConflicts.has(conflictKey)
-                          
-                          // 既存イベントの詳細を取得（時間帯の重複チェック）
-                          const eventsForStore = (conflictInfo.existingEvents || []).filter(e => 
-                            e.storeId === store.id && e.date === selectedCandidate.date
-                          )
-                          
-                          // 時間帯の重複をチェック
-                          const existingEvent = eventsForStore.find(e => {
-                            const candidateStart = selectedCandidate.startTime || ''
-                            const candidateEnd = selectedCandidate.endTime || ''
-                            const overlaps = candidateStart < e.endTime && candidateEnd > e.startTime
-                            return overlaps
-                          })
-                          
-                          if (existingEvent) {
-                            existingEventLabel = ` ⚠️ ${existingEvent.scenario} (${existingEvent.startTime}〜${existingEvent.endTime})`
-                          }
-                        }
-                      }
-                      
-                      return (
-                        <SelectItem 
-                          key={store.id} 
-                          value={store.id}
-                          disabled={isStoreDisabled}
-                          className="whitespace-normal"
-                        >
-                          <span className="block">
-                            {store.name}
-                            {isRequested && ' (お客様希望)'}
-                            {selectedRegionFilter === 'all' && store.region && (
-                              <span className="text-xs text-muted-foreground ml-1">({store.region})</span>
-                            )}
-                          </span>
-                          {existingEventLabel && (
-                            <span className="block text-xs text-orange-600 font-medium">
-                              {existingEventLabel}
-                            </span>
-                          )}
-                        </SelectItem>
-                      )
-                    })}
-                  </SelectContent>
-                </Select>
-                <div className="mt-2 text-xs text-muted-foreground">
-                  {selectedRequest.candidate_datetimes?.requestedStores?.length === 0 ? (
-                    <span>ℹ️ お客様は全ての店舗を希望しています</span>
-                  ) : (selectedRequest.candidate_datetimes?.requestedStores?.length ?? 0) > 0 ? (
-                    <span>ℹ️ (お客様希望) の店舗がお客様の希望店舗です / ⚠️ は既存公演</span>
-                  ) : null}
-                </div>
-              </div>
-
-              {/* 顧客メモ */}
-              {selectedRequest.notes && (
-                <div>
-                  <h3 className="mb-2 text-sm font-medium text-purple-800">お客様からのメモ</h3>
-                  <div className="p-3 bg-background rounded-lg border">
-                    <p className="text-sm whitespace-pre-wrap">{selectedRequest.notes}</p>
-                  </div>
-                </div>
-              )}
-
-              {(selectedRequest.required_gm_count ?? 1) >= 2 && (
-                <Alert className="border-amber-200 bg-amber-50/80 text-amber-950">
-                  <AlertCircle className="h-4 w-4 text-amber-700" />
-                  <AlertTitle className="text-sm font-semibold text-amber-900">
-                    必要GM数が{selectedRequest.required_gm_count}人のシナリオです
-                  </AlertTitle>
-                  <AlertDescription className="text-xs text-amber-900/90 mt-1 space-y-1">
-                    <p>
-                      GM確認では、同一候補に対して必要人数が揃い、メイン／サブの両方を担えるスタッフが含まれるまで「店舗確認待ち」に上がりません（サブのみの人だけでは足りません）。
-                    </p>
-                    <p>
-                      承認時は、下のプルダウンでメインGMとサブGMの2名を選んで確定してください。公演のスケジュールには両名が登録されます。
-                    </p>
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              {/* 担当GMの選択（ネイティブ select: 候補が多いときも OS 標準のスクロールで全件表示） */}
-              <div className="pt-3 border-t">
-                <h3 className="mb-2 text-sm font-medium text-purple-800">
-                  {(selectedRequest.required_gm_count ?? 1) >= 2
-                    ? 'メインGM・サブGMをそれぞれ選択してください'
-                    : '担当GMを選択してください'}
-                </h3>
-                <label htmlFor="private-booking-gm-select" className="sr-only">
-                  メインGM
-                </label>
-                <select
-                  id="private-booking-gm-select"
-                  className="flex h-9 w-full rounded-md border border-input bg-[#F6F9FB] px-2 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0"
-                  value={selectedGMId}
-                  onChange={(e) => {
-                    const v = e.target.value
-                    setSelectedGMId(v)
-                    setSelectedSubGmId((prev) => (prev === v ? '' : prev))
-                  }}
-                >
-                  <option value="">
-                    {(selectedRequest.required_gm_count ?? 1) >= 2 ? 'メインGMを選択' : 'GMを選択してください'}
-                  </option>
-                  {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
-                    <option
-                      key={gm.id}
-                      value={gm.id}
-                      disabled={
-                        isGMDisabled ||
-                        ((selectedRequest.required_gm_count ?? 1) >= 2 && gm.id === selectedSubGmId)
-                      }
-                    >
-                      {label}
-                    </option>
-                  ))}
-                </select>
-                {(selectedRequest.required_gm_count ?? 1) >= 2 && (
-                  <div className="mt-4">
-                    <label htmlFor="private-booking-sub-gm-select" className="sr-only">
-                      サブGM
-                    </label>
-                    <select
-                      id="private-booking-sub-gm-select"
-                      className="flex h-9 w-full rounded-md border border-input bg-[#F6F9FB] px-2 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0"
-                      value={selectedSubGmId}
-                      onChange={(e) => setSelectedSubGmId(e.target.value)}
-                    >
-                      <option value="">サブGMを選択</option>
-                      {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
-                        <option
-                          key={gm.id}
-                          value={gm.id}
-                          disabled={isGMDisabled || gm.id === selectedGMId}
-                        >
-                          {label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                )}
-                {(assignedGMIds.length > 0 || availableGMs.length > 0) && (
-                  <div className="mt-2 text-xs text-muted-foreground">
-                    ℹ️ <span className="inline-flex items-center px-1 py-0.5 text-xs bg-purple-100 text-purple-700 rounded">担当</span> このシナリオの担当GM / <span className="inline-flex items-center px-1 py-0.5 text-xs bg-green-100 text-green-700 rounded">対応可能</span> 今回対応可能と回答したGM
-                  </div>
-                )}
-              </div>
-
-            </div>
-
-            {/* ── 固定フッター（承認ボタンは常に表示） ── */}
-            <div className="shrink-0 border-t bg-background px-5 py-3">
-              <ActionButtons
-                onApprove={async () => {
-                  if (selectedRequest.status === 'confirmed') {
-                    const confirmed = window.confirm('この予約は既に承認済みです。内容を変更しますか？\n\n変更すると、お客様に再度確定メールが送信されます。')
-                    if (!confirmed) return
-                  }
-                  const needTwoGms = (selectedRequest.required_gm_count ?? 1) >= 2
-                  const result = await handleApprove(
-                    selectedRequest.id,
-                    selectedRequest,
-                    selectedGMId,
-                    needTwoGms ? selectedSubGmId : null,
-                    selectedStoreId,
-                    selectedCandidateOrder,
-                    stores
-                  )
-                  if (result && !result.success && result.error) {
-                    showToast.error(getSafeErrorMessage(result.error, '処理に失敗しました'))
-                  }
-                }}
-                onReject={() => handleRejectClick(selectedRequest.id)}
-                onCancel={() => {
-                  setSelectedRequest(null)
-                  setSelectedGMId('')
-                  setSelectedSubGmId('')
-                  setSelectedStoreId('')
-                  setSelectedCandidateOrder(null)
-                }}
-                disabled={
-                  submitting ||
-                  !selectedGMId ||
-                  !selectedStoreId ||
-                  !selectedCandidateOrder ||
-                  ((selectedRequest.required_gm_count ?? 1) >= 2 && !selectedSubGmId)
-                }
-                submitting={submitting}
-              />
-            </div>
-            </>)}
-          </DialogContent>
-        </Dialog>
+        {/* 削除：承認ダイアログはカードのインライン展開に移行 */}
 
         {/* 却下ダイアログ */}
         <Dialog open={showRejectDialog} onOpenChange={(open) => !open && handleRejectCancel()}>

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -550,19 +550,27 @@ export function PrivateBookingManagement() {
                     key={req.id}
                     request={req}
                     onResendDiscordNotification={handleResendDiscordNotification}
-                    isApprovalOpen={selectedRequest?.id === req.id}
-                    onToggleApproval={() => {
-                      if (selectedRequest?.id === req.id) {
+                    selectedCandidateOrder={selectedRequest?.id === req.id ? selectedCandidateOrder : null}
+                    onSelectCandidate={(clickedReq, order) => {
+                      // 同じ候補を再クリック → 選択解除
+                      if (selectedRequest?.id === clickedReq.id && selectedCandidateOrder === order) {
                         setSelectedRequest(null)
                         setSelectedGMId('')
                         setSelectedSubGmId('')
                         setSelectedStoreId('')
                         setSelectedCandidateOrder(null)
-                      } else {
-                        setSelectedRequest(req)
+                        return
                       }
+                      // 別のリクエストを選択
+                      if (selectedRequest?.id !== clickedReq.id) {
+                        setSelectedGMId('')
+                        setSelectedSubGmId('')
+                        setSelectedStoreId('')
+                        setSelectedRequest(clickedReq as any)
+                      }
+                      setSelectedCandidateOrder(order)
                     }}
-                    inlineApprovalContent={selectedRequest?.id === req.id ? (
+                    inlineApprovalContent={selectedRequest?.id === req.id && selectedCandidateOrder ? (
                       <div className="space-y-3">
                         {/* アンケート */}
                         <SurveyResponsesView
@@ -570,34 +578,55 @@ export function PrivateBookingManagement() {
                           scenarioId={req.scenario_master_id || ''}
                         />
 
-                        {/* 候補日選択 + 店舗・GMプルダウン（inline） */}
-                        <CandidateDateSelector
-                          candidates={req.candidate_datetimes?.candidates || []}
-                          selectedCandidateOrder={selectedCandidateOrder}
-                          onSelectCandidate={order => {
-                            setSelectedCandidateOrder(order)
-                            setSelectedStoreId('')
-                            setSelectedGMId('')
-                            setSelectedSubGmId('')
-                          }}
-                          selectedStoreId={selectedStoreId}
-                          selectedGMId={selectedGMId}
-                          selectedSubGmId={selectedSubGmId}
-                          onSelectStore={setSelectedStoreId}
-                          onSelectGM={v => { setSelectedGMId(v); setSelectedSubGmId(p => p === v ? '' : p) }}
-                          onSelectSubGM={setSelectedSubGmId}
-                          gmSelectOptions={gmSelectOptions}
-                          conflictInfo={conflictInfo}
-                          gmResponses={availableGMs}
-                          isConfirmed={req.status === 'confirmed'}
-                          requiredGmCount={req.required_gm_count ?? 1}
-                          stores={(() => {
+                        {/* 店舗・GMプルダウン（候補行クリックで開く） */}
+                        {(() => {
+                          const candidateStores = (() => {
                             const ids = req.candidate_datetimes?.requestedStores?.map((s: any) => s.storeId) || []
-                            return ids.length > 0
-                              ? stores.filter(s => ids.includes(s.id))
-                              : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
-                          })()}
-                        />
+                            const base = ids.length > 0 ? stores.filter(s => ids.includes(s.id)) : stores.filter(s => s.ownership_type !== 'office' && !s.is_temporary)
+                            // 選択中候補で空いている店舗のみ
+                            const cand = req.candidate_datetimes?.candidates?.find(c => c.order === selectedCandidateOrder)
+                            if (!cand) return base
+                            const ts = cand.timeSlot
+                            return base.filter(s => !conflictInfo.storeDateConflicts.has(`${s.id}-${cand.date}-${ts}`))
+                          })()
+                          return (
+                            <div className="space-y-2">
+                              <div className="flex items-center gap-2">
+                                <span className="text-xs text-purple-700 font-medium w-16 shrink-0">店舗</span>
+                                <select className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
+                                  value={selectedStoreId} onChange={e => setSelectedStoreId(e.target.value)}>
+                                  <option value="">選択してください</option>
+                                  {candidateStores.map(s => (
+                                    <option key={s.id} value={s.id}>{s.name}{(s as any).region ? ` (${(s as any).region})` : ''}</option>
+                                  ))}
+                                </select>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <span className="text-xs text-purple-700 font-medium w-16 shrink-0">{(req.required_gm_count ?? 1) >= 2 ? 'メインGM' : 'GM'}</span>
+                                <select className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
+                                  value={selectedGMId}
+                                  onChange={e => { setSelectedGMId(e.target.value); setSelectedSubGmId(p => p === e.target.value ? '' : p) }}>
+                                  <option value="">選択してください</option>
+                                  {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
+                                    <option key={gm.id} value={gm.id} disabled={isGMDisabled || ((req.required_gm_count ?? 1) >= 2 && gm.id === selectedSubGmId)}>{label}</option>
+                                  ))}
+                                </select>
+                              </div>
+                              {(req.required_gm_count ?? 1) >= 2 && (
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs text-purple-700 font-medium w-16 shrink-0">サブGM</span>
+                                  <select className="flex-1 h-8 rounded border border-input bg-background px-2 text-sm"
+                                    value={selectedSubGmId} onChange={e => setSelectedSubGmId(e.target.value)}>
+                                    <option value="">選択してください</option>
+                                    {gmSelectOptions.map(({ gm, isGMDisabled, label }) => (
+                                      <option key={gm.id} value={gm.id} disabled={isGMDisabled || gm.id === selectedGMId}>{label}</option>
+                                    ))}
+                                  </select>
+                                </div>
+                              )}
+                            </div>
+                          )
+                        })()}
 
                         {/* アクションボタン */}
                         <ActionButtons

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -571,12 +571,17 @@ export function PrivateBookingManagement() {
             }
           }}
         >
-          <DialogContent size="lg" className="max-h-[90vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle className="text-base sm:text-lg pr-6">リクエスト詳細 - {selectedRequest?.scenario_title}</DialogTitle>
+          <DialogContent size="xl" className="flex flex-col p-0 gap-0 overflow-hidden max-h-[90vh]">
+            {/* ── 固定ヘッダー ── */}
+            <DialogHeader className="px-5 py-3 border-b shrink-0">
+              <DialogTitle className="text-base sm:text-lg pr-6">
+                {selectedRequest?.scenario_title}
+              </DialogTitle>
             </DialogHeader>
-            {selectedRequest && (
-              <div className="space-y-3">
+
+            {selectedRequest && (<>
+            {/* ── スクロール可能なコンテンツ領域 ── */}
+            <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
               <CustomerInfo request={selectedRequest} />
               
               {/* アンケート回答閲覧 */}
@@ -818,48 +823,49 @@ export function PrivateBookingManagement() {
                 )}
               </div>
 
-              <div className="pt-3 border-t">
-                <ActionButtons
-                  onApprove={async () => {
-                    // 既に確定済みの場合のみ確認ダイアログを表示（gm_confirmedはGM回答済みだが未承認のため除外）
-                    if (selectedRequest.status === 'confirmed') {
-                      const confirmed = window.confirm('この予約は既に承認済みです。内容を変更しますか？\n\n変更すると、お客様に再度確定メールが送信されます。')
-                      if (!confirmed) return
-                    }
-                    const needTwoGms = (selectedRequest.required_gm_count ?? 1) >= 2
-                    const result = await handleApprove(
-                      selectedRequest.id,
-                      selectedRequest,
-                      selectedGMId,
-                      needTwoGms ? selectedSubGmId : null,
-                      selectedStoreId,
-                      selectedCandidateOrder,
-                      stores
-                    )
-                    if (result && !result.success && result.error) {
-                      showToast.error(getSafeErrorMessage(result.error, '処理に失敗しました'))
-                    }
-                  }}
-                  onReject={() => handleRejectClick(selectedRequest.id)}
-                  onCancel={() => {
-                    setSelectedRequest(null)
-                    setSelectedGMId('')
-                    setSelectedSubGmId('')
-                    setSelectedStoreId('')
-                    setSelectedCandidateOrder(null)
-                  }}
-                  disabled={
-                    submitting ||
-                    !selectedGMId ||
-                    !selectedStoreId ||
-                    !selectedCandidateOrder ||
-                    ((selectedRequest.required_gm_count ?? 1) >= 2 && !selectedSubGmId)
-                  }
-                  submitting={submitting}
-                />
-              </div>
             </div>
-            )}
+
+            {/* ── 固定フッター（承認ボタンは常に表示） ── */}
+            <div className="shrink-0 border-t bg-background px-5 py-3">
+              <ActionButtons
+                onApprove={async () => {
+                  if (selectedRequest.status === 'confirmed') {
+                    const confirmed = window.confirm('この予約は既に承認済みです。内容を変更しますか？\n\n変更すると、お客様に再度確定メールが送信されます。')
+                    if (!confirmed) return
+                  }
+                  const needTwoGms = (selectedRequest.required_gm_count ?? 1) >= 2
+                  const result = await handleApprove(
+                    selectedRequest.id,
+                    selectedRequest,
+                    selectedGMId,
+                    needTwoGms ? selectedSubGmId : null,
+                    selectedStoreId,
+                    selectedCandidateOrder,
+                    stores
+                  )
+                  if (result && !result.success && result.error) {
+                    showToast.error(getSafeErrorMessage(result.error, '処理に失敗しました'))
+                  }
+                }}
+                onReject={() => handleRejectClick(selectedRequest.id)}
+                onCancel={() => {
+                  setSelectedRequest(null)
+                  setSelectedGMId('')
+                  setSelectedSubGmId('')
+                  setSelectedStoreId('')
+                  setSelectedCandidateOrder(null)
+                }}
+                disabled={
+                  submitting ||
+                  !selectedGMId ||
+                  !selectedStoreId ||
+                  !selectedCandidateOrder ||
+                  ((selectedRequest.required_gm_count ?? 1) >= 2 && !selectedSubGmId)
+                }
+                submitting={submitting}
+              />
+            </div>
+            </>)}
           </DialogContent>
         </Dialog>
 

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -9,18 +9,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { Button } from '@/components/ui/button'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { PageHeader } from '@/components/layout/PageHeader'
-import { UnifiedSidebar, SidebarMenuItem } from '@/components/layout/UnifiedSidebar'
 import { AlertCircle, Calendar, CheckCircle, Clock, Settings, MapPin, Users } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
-// サイドバーのメニュー項目定義
-const PRIVATE_BOOKING_MENU_ITEMS: SidebarMenuItem[] = [
-  { id: 'booking-list', label: '貸切確認一覧', icon: Calendar },
-  { id: 'groups', label: 'グループ一覧', icon: Users },
-  { id: 'pending', label: '承認待ち', icon: Clock },
-  { id: 'approved', label: '承認済み', icon: CheckCircle },
-  { id: 'settings', label: '設定', icon: Settings }
-]
 import { useAuth } from '@/contexts/AuthContext'
 import { supabase } from '@/lib/supabase'
 import { useSessionState } from '@/hooks/useSessionState'
@@ -60,19 +51,9 @@ const normalizeTimeSlot = (timeSlot: string): string => {
 
 export function PrivateBookingManagement() {
   const { user } = useAuth()
-  const [sidebarActiveTab, setSidebarActiveTab] = useState('booking-list')
-  
+
   // タブ状態（sessionStorageと同期）
   const [activeTab, setActiveTab] = useSessionState<'gm_pending' | 'store_pending' | 'rejected' | 'all' | 'groups'>('privateBookingActiveTab', 'store_pending')
-  
-  // タブとサイドバーを同期
-  useEffect(() => {
-    if (activeTab === 'groups') {
-      setSidebarActiveTab('groups')
-    } else {
-      setSidebarActiveTab('booking-list')
-    }
-  }, [activeTab])
   
   // 選択状態
   const [selectedRequest, setSelectedRequest] = useState<PrivateBookingRequest | null>(null)
@@ -484,15 +465,6 @@ export function PrivateBookingManagement() {
     return (
       <AppLayout
         currentPage="private-booking"
-        sidebar={
-          <UnifiedSidebar
-            title="貸切確認"
-            mode="list"
-            menuItems={PRIVATE_BOOKING_MENU_ITEMS}
-            activeTab={sidebarActiveTab}
-            onTabChange={setSidebarActiveTab}
-          />
-        }
         maxWidth="max-w-[1440px]"
         containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
         stickyLayout={true}
@@ -507,22 +479,6 @@ export function PrivateBookingManagement() {
   return (
     <AppLayout
       currentPage="private-booking"
-      sidebar={
-        <UnifiedSidebar
-          title="貸切確認"
-          mode="list"
-          menuItems={PRIVATE_BOOKING_MENU_ITEMS}
-          activeTab={sidebarActiveTab}
-          onTabChange={(tab) => {
-            setSidebarActiveTab(tab)
-            if (tab === 'groups') {
-              setActiveTab('groups')
-            } else if (tab === 'booking-list') {
-              setActiveTab('all')
-            }
-          }}
-        />
-      }
       maxWidth="max-w-[1440px]"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}

--- a/src/pages/PrivateBookingManagement/utils/bookingFormatters.ts
+++ b/src/pages/PrivateBookingManagement/utils/bookingFormatters.ts
@@ -126,16 +126,16 @@ export const getCardClassName = (status: string): string => {
   switch (status) {
     case 'pending':
     case 'pending_gm':
-      return 'border-purple-200 bg-purple-50/30'
+      return 'border-l-4 border-l-purple-400 border-purple-200 bg-purple-50/30'
     case 'gm_confirmed':
     case 'pending_store':
-      return 'border-purple-200 bg-purple-50/30'
+      return 'border-l-4 border-l-amber-400 border-amber-200 bg-amber-50/20'
     case 'confirmed':
-      return 'border-green-200 bg-green-50/30'
+      return 'border-l-4 border-l-green-400 border-green-200 bg-green-50/30'
     case 'cancelled':
-      return 'border-red-200 bg-red-50/30'
+      return 'border-l-4 border-l-gray-300 border-gray-200 bg-gray-50/30'
     default:
-      return ''
+      return 'border-l-4 border-l-gray-200'
   }
 }
 

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -28,10 +28,6 @@ import { ScenarioCard } from './components/ScenarioCard'
 import { Footer } from '@/components/layout/Footer'
 import { getOptimizedImageUrl } from '@/utils/imageUtils'
 
-/** DB の紹介文が空のときのデフォルト（queens-waltz） */
-const QUEENS_WALTZ_PUBLIC_BOOKING_HERO_FALLBACK =
-  '都内（大久保、高田馬場、大塚）に4店舗、埼玉に1店舗を運営するマーダーミステリー専門店クインズワルツ。160種類以上のマーダーミステリーシナリオをご用意しています。あなたの気に入る物語がきっと見つかる！'
-
 const DEFAULT_PUBLIC_BOOKING_HERO =
   'リアルな謎解き体験。あなたは事件の真相を暴けるか？'
 
@@ -94,11 +90,8 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
   } = useBookingData(organizationSlug)
 
   const heroDescription = useMemo(() => {
-    const fromDb = organizationPublicBookingHeroDescription?.trim()
-    if (fromDb) return fromDb
-    if (organizationSlug === 'queens-waltz') return QUEENS_WALTZ_PUBLIC_BOOKING_HERO_FALLBACK
-    return DEFAULT_PUBLIC_BOOKING_HERO
-  }, [organizationPublicBookingHeroDescription, organizationSlug])
+    return organizationPublicBookingHeroDescription?.trim() || DEFAULT_PUBLIC_BOOKING_HERO
+  }, [organizationPublicBookingHeroDescription])
   
   useReportRouteScrollRestoration('public-booking-top', {
     isLoading,

--- a/src/pages/SalesManagement/index.tsx
+++ b/src/pages/SalesManagement/index.tsx
@@ -1,22 +1,7 @@
 import React, { useEffect, lazy, Suspense } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { useLocalState } from '@/hooks/useLocalState'
-import { UnifiedSidebar, SidebarMenuItem } from '@/components/layout/UnifiedSidebar'
-import { TrendingUp, BarChart, BarChart3, FileText, Store, ShoppingBag, Users, CalendarCheck } from 'lucide-react'
-
-// サイドバーのメニュー項目定義
-const SALES_MENU_ITEMS: SidebarMenuItem[] = [
-  { id: 'sales-overview', label: '売上概要', icon: TrendingUp, description: '売上サマリーを表示' },
-  { id: 'annual-analysis', label: '年間分析', icon: BarChart3, description: '年間推移・成長率' },
-  { id: 'scenario-performance', label: 'シナリオ別', icon: BarChart, description: 'シナリオ別売上' },
-  { id: 'open-event-analysis', label: '公演分析', icon: CalendarCheck, description: 'オープン公演の満席率・満席日数' },
-  { id: 'external-sales', label: '外部売上', icon: ShoppingBag, description: 'BOOTH・他店公演' },
-  { id: 'misc-transactions', label: '雑収支管理', icon: FileText, description: '公演外の収支を管理' },
-  { id: 'franchise-sales', label: 'フランチャイズ', icon: Store, description: 'FC店舗の売上' },
-  { id: 'staff-salary-report', label: 'スタッフ報酬', icon: Users, description: 'スタッフ別報酬レポート' },
-  { id: 'salary-calculation', label: '給与計算', icon: FileText, description: 'スタッフ給与計算' }
-]
-// 作者レポートはライセンス管理に移動
 import { useSalesData } from './hooks/useSalesData'
 
 // chart.jsを使うコンポーネントは遅延ロード（初期バンドルサイズ削減）
@@ -33,8 +18,8 @@ const OpenEventAnalysis = lazy(() => import('./components/OpenEventAnalysis').th
  * 売上管理メインページ
  */
 const SalesManagement: React.FC = () => {
-  // タブ・店舗選択をlocalStorageで永続化（ブラウザを閉じても維持）
-  const [activeTab, setActiveTab] = useLocalState('salesActiveTab', 'overview')
+  const [searchParams] = useSearchParams()
+  const activeTab = searchParams.get('tab') || 'overview'
   const [selectedStoreIds, setSelectedStoreIds] = useLocalState<string[]>('salesSelectedStoreIds', [])
   
   // データ取得フック
@@ -192,15 +177,6 @@ const SalesManagement: React.FC = () => {
   return (
     <AppLayout
       currentPage="sales"
-      sidebar={
-        <UnifiedSidebar
-          title="売上管理"
-          mode="list"
-          menuItems={SALES_MENU_ITEMS}
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-        />
-      }
       maxWidth="max-w-[1440px]"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}

--- a/src/pages/ScenarioMasterAdmin/ScenarioMasterEdit.tsx
+++ b/src/pages/ScenarioMasterAdmin/ScenarioMasterEdit.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Header } from '@/components/layout/Header'
-import { NavigationBar } from '@/components/layout/NavigationBar'
+import { AdminSidebar } from '@/components/layout/AdminSidebar'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -428,11 +428,11 @@ export function ScenarioMasterEdit() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
-      <NavigationBar />
-
-      <div className="max-w-5xl mx-auto px-4 py-8">
+      <div className="flex flex-1">
+        <AdminSidebar />
+        <div className="flex-1 max-w-5xl mx-auto px-4 py-8">
         {/* ヘッダー */}
         <div className="flex items-center justify-between mb-8">
           <div className="flex items-center gap-4">
@@ -792,6 +792,7 @@ export function ScenarioMasterEdit() {
               </div>
             </div>
           </div>
+        </div>
         </div>
       </div>
     </div>

--- a/src/pages/ScenarioMatcher.tsx
+++ b/src/pages/ScenarioMatcher.tsx
@@ -4,6 +4,7 @@ import { showToast } from '@/utils/toast'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
 import { useOrganization } from '@/hooks/useOrganization'
+import { AppLayout } from '@/components/layout/AppLayout'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -222,7 +223,13 @@ export function ScenarioMatcher() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <AppLayout
+      currentPage="scenario-matcher"
+      maxWidth="max-w-[1440px]"
+      containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
+      stickyLayout={true}
+    >
+    <div className="space-y-6">
       <div className="max-w-6xl mx-auto">
         <Card className="p-8">
           <h1 className="text-lg mb-4">🔗 シナリオマッチングツール</h1>
@@ -371,6 +378,7 @@ export function ScenarioMatcher() {
         </Card>
       </div>
     </div>
+    </AppLayout>
   )
 }
 

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -974,24 +974,20 @@ export function ScheduleManager() {
     <AppLayout
       currentPage="schedule" 
       maxWidth="max-w-[1440px]"
-      containerPadding="px-[10px] py-4"
+      containerPadding="px-[10px] py-0"
       className="mx-auto"
       stickyLayout
     >
-      <PageHeader
-        title={
-          <div className="flex items-center gap-2">
-            <CalendarDays className="h-5 w-5 text-primary" />
-            スケジュール管理
-          </div>
-        }
-        description={`${currentDate.getFullYear()}年${currentDate.getMonth() + 1}月のスケジュールを管理`}
-      >
-        <HelpButton topic="schedule" label="スケジュール管理マニュアル" />
-      </PageHeader>
-
       {/* ツールバー（sticky） */}
       <div data-schedule-toolbar className="sticky top-0 z-40 bg-background border-b -mx-[10px] px-[10px]">
+        {/* 見出し行（sticky に含めて消えないようにする） */}
+        <div className="flex items-center gap-2 pt-2 pb-1">
+          <CalendarDays className="h-4 w-4 text-primary shrink-0" />
+          <h1 className="text-base font-bold leading-none">スケジュール管理</h1>
+          <span className="text-xs text-muted-foreground">
+            {currentDate.getFullYear()}年{currentDate.getMonth() + 1}月
+          </span>
+        </div>
         <div className="flex items-center h-12 gap-2">
           {/* 月切り替え - 連結ボタングループ */}
           <div className="flex items-center shrink-0 border border-input rounded-lg overflow-hidden bg-background">
@@ -1250,6 +1246,9 @@ export function ScheduleManager() {
           
           {/* アクションボタン - PC用連結グループ */}
           <div className="hidden sm:flex items-center h-9 border border-input rounded-lg overflow-hidden bg-background shrink-0 ml-auto">
+            <div className="h-9 w-9 flex items-center justify-center border-r border-input">
+              <HelpButton topic="schedule" label="スケジュール管理マニュアル" />
+            </div>
             <button
               onClick={() => setIsKitManagementOpen(true)}
               title="キット配置管理"

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -184,11 +184,11 @@ export function ScheduleManager() {
       })
     }
 
-    // ウィンドウリサイズ時に連続発火しないよう debounce
-    let rafId: number
+    // リサイズ時の連続発火を 50ms debounce で抑制
+    let debounceTimer: ReturnType<typeof setTimeout>
     const debouncedSync = () => {
-      cancelAnimationFrame(rafId)
-      rafId = requestAnimationFrame(syncColWidths)
+      clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(syncColWidths, 50)
     }
 
     const ro = new ResizeObserver(debouncedSync)
@@ -200,7 +200,7 @@ export function ScheduleManager() {
     return () => {
       tableScroll.removeEventListener('scroll', onScroll)
       ro.disconnect()
-      cancelAnimationFrame(rafId)
+      clearTimeout(debounceTimer)
       clearTimeout(timer)
     }
   }, [])

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -184,7 +184,14 @@ export function ScheduleManager() {
       })
     }
 
-    const ro = new ResizeObserver(syncColWidths)
+    // ウィンドウリサイズ時に連続発火しないよう debounce
+    let rafId: number
+    const debouncedSync = () => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(syncColWidths)
+    }
+
+    const ro = new ResizeObserver(debouncedSync)
     ro.observe(tableScroll)
 
     // テーブルの行が描画されるまで少し待つ
@@ -193,6 +200,7 @@ export function ScheduleManager() {
     return () => {
       tableScroll.removeEventListener('scroll', onScroll)
       ro.disconnect()
+      cancelAnimationFrame(rafId)
       clearTimeout(timer)
     }
   }, [])

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -42,6 +42,7 @@ import { StaffSettings } from './pages/StaffSettings'
 import { SystemSettings } from './pages/SystemSettings'
 import { EmailSettings } from './pages/EmailSettings'
 import { EmailDeliveryHistorySettings } from './pages/EmailDeliveryHistorySettings'
+import { EmailLogsSettings } from './pages/EmailLogsSettings'
 import { CustomerSettings } from './pages/CustomerSettings'
 import { DataManagementSettings } from './pages/DataManagementSettings'
 import { BookingNoticeSettings } from './pages/BookingNoticeSettings'
@@ -75,6 +76,7 @@ const BASE_MENU_ITEMS: SidebarMenuItem[] = [
   { id: 'staff', label: 'スタッフ設定', icon: UserCog, description: 'スタッフ管理' },
   { id: 'email', label: 'メール設定', icon: Mail, description: 'メールテンプレート' },
   { id: 'email-history', label: 'メール配信履歴', icon: Mail, description: '配信先・ステータスの確認' },
+  { id: 'email-logs', label: 'メール送信ログ', icon: Mail, description: 'アプリ長期保存ログ' },
   { id: 'notifications', label: '通知設定', icon: Bell, description: '通知の設定' },
   { id: 'booking-notice', label: '注意事項設定', icon: AlertCircle, description: '予約時の注意事項' },
   { id: 'categories', label: 'カテゴリ・作者管理', icon: Tags, description: 'カテゴリ・作者の管理' },
@@ -109,7 +111,7 @@ export function Settings() {
   }, [isLicenseManager])
 
   // 店舗セレクターを表示しないページ
-  const noStoreSelectorPages = ['organization-info', 'organization-design', 'faq', 'blog', 'tenant-management', 'general', 'salary', 'booking-notice', 'categories', 'email-history']
+  const noStoreSelectorPages = ['organization-info', 'organization-design', 'faq', 'blog', 'tenant-management', 'general', 'salary', 'booking-notice', 'categories', 'email-history', 'email-logs']
   const showStoreSelector = !noStoreSelectorPages.includes(activeTab)
 
   const renderContent = () => {
@@ -155,6 +157,8 @@ export function Settings() {
         return <EmailSettings storeId={storeId} />
       case 'email-history':
         return <EmailDeliveryHistorySettings />
+      case 'email-logs':
+        return <EmailLogsSettings />
       case 'customer':
         return <CustomerSettings storeId={storeId} />
       case 'data':

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router-dom'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { UnifiedSidebar, SidebarMenuItem } from '@/components/layout/UnifiedSidebar'
 import { 
@@ -91,18 +91,11 @@ const LICENSE_MANAGER_MENU_ITEM: SidebarMenuItem = {
 }
 
 export function Settings() {
-  const [activeTab, setActiveTab] = useSessionState('settingsActiveTab', 'organization-info')
+  const [searchParams] = useSearchParams()
+  const activeTab = searchParams.get('tab') || 'organization-info'
   const { selectedStoreId, handleStoreChange } = useSettingsStore()
   const { isLicenseManager } = useOrganization()
   const location = useLocation()
-
-  useEffect(() => {
-    const searchParams = new URLSearchParams(location.search)
-    const tab = searchParams.get('tab')
-    if (tab === 'email-history' && activeTab !== 'email-history') {
-      setActiveTab('email-history')
-    }
-  }, [location.search, activeTab, setActiveTab])
 
   // メニュー項目を動的に生成（ライセンス管理者にはテナント管理を追加）
   const menuItems = useMemo(() => {
@@ -178,16 +171,6 @@ export function Settings() {
   return (
     <AppLayout
       currentPage="settings"
-      sidebar={
-        <UnifiedSidebar
-          title="設定"
-          mode="list"
-          menuItems={menuItems}
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-          showSearch={true}
-        />
-      }
       maxWidth="max-w-[1440px]"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}

--- a/src/pages/Settings/pages/EmailLogsSettings.tsx
+++ b/src/pages/Settings/pages/EmailLogsSettings.tsx
@@ -1,0 +1,390 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { RefreshCw, Search, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react'
+import { PageHeader } from '@/components/layout/PageHeader'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { supabase } from '@/lib/supabase'
+import { logger } from '@/utils/logger'
+import { showToast } from '@/utils/toast'
+
+// ─── 型 ──────────────────────────────────────────────────────────────────────
+
+type EmailLogStatus =
+  | 'queued' | 'sent' | 'delivered' | 'opened' | 'clicked'
+  | 'bounced' | 'complained' | 'failed' | 'delivery_delayed'
+
+type EmailLogType =
+  | 'reservation_confirmed' | 'reservation_cancelled' | 'reservation_changed'
+  | 'reservation_request'  | 'reminder' | 'gm_notification' | 'staff_invitation'
+  | 'waitlist_confirmed'   | 'guest_pin' | 'performance_cancellation'
+  | 'license_report'       | 'contact_inquiry' | 'other'
+
+interface EmailLog {
+  id: string
+  organization_id: string | null
+  reservation_id: string | null
+  schedule_event_id: string | null
+  email_type: EmailLogType
+  to_email: string
+  to_name: string | null
+  subject: string
+  body_text: string | null
+  body_html: string | null
+  provider: string
+  provider_message_id: string | null
+  status: EmailLogStatus
+  error_message: string | null
+  sent_at: string | null
+  delivered_at: string | null
+  opened_at: string | null
+  bounced_at: string | null
+  complained_at: string | null
+  created_at: string
+}
+
+// ─── ラベル定義 ──────────────────────────────────────────────────────────────
+
+const STATUS_LABELS: Record<EmailLogStatus, string> = {
+  queued:           '送信待',
+  sent:             '送信済',
+  delivered:        '配信済',
+  opened:           '開封',
+  clicked:          'クリック',
+  bounced:          'バウンス',
+  complained:       '苦情',
+  failed:           '送信失敗',
+  delivery_delayed: '遅延',
+}
+
+const TYPE_LABELS: Record<EmailLogType, string> = {
+  reservation_confirmed:    '予約確認',
+  reservation_cancelled:    'キャンセル',
+  reservation_changed:      '変更確認',
+  reservation_request:      '貸切リクエスト',
+  reminder:                 'リマインド',
+  gm_notification:          'GM通知',
+  staff_invitation:         'スタッフ招待',
+  waitlist_confirmed:       'キャンセル待ち',
+  guest_pin:                'ゲストPIN',
+  performance_cancellation: '公演中止',
+  license_report:           'ライセンスレポート',
+  contact_inquiry:          'お問い合わせ',
+  other:                    'その他',
+}
+
+// ─── ヘルパー ────────────────────────────────────────────────────────────────
+
+function maskEmail(email: string): string {
+  if (!email.includes('@')) return '***'
+  const [local, domain] = email.split('@')
+  const masked = local.length > 2 ? local.slice(0, 2) + '***' : '***'
+  return `${masked}@${domain}`
+}
+
+function formatJst(value: string | null): string {
+  if (!value) return '-'
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return value
+  return new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  }).format(d)
+}
+
+function statusBadgeClass(status: EmailLogStatus): string {
+  switch (status) {
+    case 'delivered': return 'bg-green-100 text-green-800'
+    case 'opened':    return 'bg-blue-100 text-blue-800'
+    case 'clicked':   return 'bg-purple-100 text-purple-800'
+    case 'sent':      return 'bg-sky-100 text-sky-800'
+    case 'queued':    return 'bg-gray-100 text-gray-600'
+    case 'bounced':
+    case 'complained':
+    case 'failed':    return 'bg-red-100 text-red-800'
+    case 'delivery_delayed': return 'bg-yellow-100 text-yellow-800'
+    default:          return 'bg-gray-100 text-gray-600'
+  }
+}
+
+// ─── メインコンポーネント ──────────────────────────────────────────────────────
+
+export function EmailLogsSettings() {
+  const [loading, setLoading]       = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [logs, setLogs]             = useState<EmailLog[]>([])
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  // フィルター
+  const [keyword, setKeyword]         = useState('')
+  const [filterType, setFilterType]   = useState<string>('all')
+  const [filterStatus, setFilterStatus] = useState<string>('all')
+  const [dateFrom, setDateFrom]       = useState('')
+  const [dateTo, setDateTo]           = useState('')
+
+  const fetchLogs = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true)
+    else setLoading(true)
+
+    try {
+      let query = supabase
+        .from('email_logs')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .limit(200)
+
+      if (filterStatus !== 'all') {
+        query = query.eq('status', filterStatus)
+      }
+      if (filterType !== 'all') {
+        query = query.eq('email_type', filterType)
+      }
+      if (dateFrom) {
+        query = query.gte('created_at', `${dateFrom}T00:00:00+09:00`)
+      }
+      if (dateTo) {
+        query = query.lte('created_at', `${dateTo}T23:59:59+09:00`)
+      }
+
+      const { data, error } = await query
+      if (error) throw error
+      setLogs((data ?? []) as EmailLog[])
+    } catch (error) {
+      logger.error('メールログの取得エラー:', error)
+      showToast.error('メールログの取得に失敗しました')
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [filterStatus, filterType, dateFrom, dateTo])
+
+  useEffect(() => {
+    fetchLogs()
+  }, [fetchLogs])
+
+  const filteredLogs = useMemo(() => {
+    if (!keyword.trim()) return logs
+    const q = keyword.trim().toLowerCase()
+    return logs.filter((l) =>
+      l.to_email.toLowerCase().includes(q) ||
+      l.subject.toLowerCase().includes(q) ||
+      (l.to_name ?? '').toLowerCase().includes(q) ||
+      (l.provider_message_id ?? '').toLowerCase().includes(q)
+    )
+  }, [logs, keyword])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="メール送信ログ"
+        description="アプリ側で長期保存しているメール送信履歴です（Resend の保持期間に依存しません）"
+      >
+        <Button onClick={() => fetchLogs(true)} disabled={refreshing}>
+          <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+          更新
+        </Button>
+      </PageHeader>
+
+      {/* フィルター */}
+      <Card>
+        <CardHeader>
+          <CardTitle>フィルター / 検索</CardTitle>
+          <CardDescription>メールアドレス・件名・メール種別・ステータス・日付で絞り込めます</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="relative max-w-xl">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              className="pl-9"
+              placeholder="メールアドレス・件名・Message IDで検索"
+            />
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Select value={filterType} onValueChange={setFilterType}>
+              <SelectTrigger className="w-44">
+                <SelectValue placeholder="メール種別" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">すべての種別</SelectItem>
+                {(Object.entries(TYPE_LABELS) as [EmailLogType, string][]).map(([k, v]) => (
+                  <SelectItem key={k} value={k}>{v}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={filterStatus} onValueChange={setFilterStatus}>
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="ステータス" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">すべてのステータス</SelectItem>
+                {(Object.entries(STATUS_LABELS) as [EmailLogStatus, string][]).map(([k, v]) => (
+                  <SelectItem key={k} value={k}>{v}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div className="flex items-center gap-2">
+              <Input
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+                className="w-36"
+              />
+              <span className="text-sm text-muted-foreground">〜</span>
+              <Input
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+                className="w-36"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ログ一覧 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>送信ログ（最新200件）</CardTitle>
+          <CardDescription>
+            宛先は部分マスク表示。詳細を開くと件名・本文・エラー内容を確認できます。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-center py-12 text-muted-foreground">読み込み中...</div>
+          ) : filteredLogs.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">該当するログがありません</div>
+          ) : (
+            <div className="space-y-2">
+              {filteredLogs.map((log) => (
+                <div key={log.id} className="border rounded-lg bg-white overflow-hidden">
+                  {/* ヘッダー行 */}
+                  <button
+                    type="button"
+                    className="w-full text-left p-4 hover:bg-gray-50 transition-colors"
+                    onClick={() => setExpandedId(expandedId === log.id ? null : log.id)}
+                  >
+                    <div className="flex flex-wrap items-center gap-2 mb-1">
+                      <Badge className={statusBadgeClass(log.status)}>
+                        {STATUS_LABELS[log.status] ?? log.status}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs">
+                        {TYPE_LABELS[log.email_type] ?? log.email_type}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground ml-auto">
+                        {formatJst(log.created_at)}
+                      </span>
+                      {expandedId === log.id
+                        ? <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                        : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
+                    </div>
+                    <div className="space-y-0.5">
+                      <div className="text-sm">
+                        <span className="text-muted-foreground">To:</span>{' '}
+                        {maskEmail(log.to_email)}
+                        {log.to_name && (
+                          <span className="text-muted-foreground"> ({log.to_name})</span>
+                        )}
+                      </div>
+                      <div className="text-sm font-medium truncate">{log.subject}</div>
+                    </div>
+                  </button>
+
+                  {/* 詳細展開 */}
+                  {expandedId === log.id && (
+                    <div className="border-t bg-gray-50 p-4 space-y-3 text-sm">
+                      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+                        <dt className="text-muted-foreground font-medium">送信日時</dt>
+                        <dd>{formatJst(log.sent_at)}</dd>
+                        <dt className="text-muted-foreground font-medium">配信日時</dt>
+                        <dd>{formatJst(log.delivered_at)}</dd>
+                        <dt className="text-muted-foreground font-medium">開封日時</dt>
+                        <dd>{formatJst(log.opened_at)}</dd>
+                        {log.bounced_at && (
+                          <>
+                            <dt className="text-muted-foreground font-medium">バウンス日時</dt>
+                            <dd className="text-red-600">{formatJst(log.bounced_at)}</dd>
+                          </>
+                        )}
+                        {log.complained_at && (
+                          <>
+                            <dt className="text-muted-foreground font-medium">苦情日時</dt>
+                            <dd className="text-red-600">{formatJst(log.complained_at)}</dd>
+                          </>
+                        )}
+                        <dt className="text-muted-foreground font-medium">プロバイダ</dt>
+                        <dd>{log.provider}</dd>
+                        {log.provider_message_id && (
+                          <>
+                            <dt className="text-muted-foreground font-medium">Message ID</dt>
+                            <dd className="font-mono text-xs break-all">{log.provider_message_id}</dd>
+                          </>
+                        )}
+                        {log.error_message && (
+                          <>
+                            <dt className="text-muted-foreground font-medium">エラー</dt>
+                            <dd className="text-red-600 break-all">{log.error_message}</dd>
+                          </>
+                        )}
+                      </dl>
+
+                      {/* 関連リンク */}
+                      <div className="flex flex-wrap gap-2">
+                        {log.reservation_id && (
+                          <a
+                            href={`?page=reservations&id=${log.reservation_id}`}
+                            className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                          >
+                            <ExternalLink className="h-3 w-3" />
+                            予約を開く
+                          </a>
+                        )}
+                      </div>
+
+                      {/* 本文プレビュー */}
+                      {log.body_text && (
+                        <details className="mt-2">
+                          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+                            テキスト本文を表示
+                          </summary>
+                          <pre className="mt-2 p-3 bg-white border rounded text-xs whitespace-pre-wrap break-all max-h-60 overflow-y-auto">
+                            {log.body_text}
+                          </pre>
+                        </details>
+                      )}
+                      {log.body_html && (
+                        <details className="mt-2">
+                          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+                            HTML本文を表示
+                          </summary>
+                          <div
+                            className="mt-2 p-3 bg-white border rounded text-xs max-h-80 overflow-y-auto"
+                            // biome-ignore lint/security/noDangerouslySetInnerHtml: 管理者のみが閲覧するため許容
+                            dangerouslySetInnerHTML={{ __html: log.body_html }}
+                          />
+                        </details>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/pages/static/PricingPage.tsx
+++ b/src/pages/static/PricingPage.tsx
@@ -163,7 +163,7 @@ export function PricingPage() {
                   className="w-full"
                   variant={plan.buttonVariant}
                   style={plan.popular ? { backgroundColor: THEME.primary, borderRadius: 0 } : { borderRadius: 0 }}
-                  onClick={() => window.location.href = '/register'}
+                  onClick={() => window.location.href = '/start'}
                 >
                   {plan.buttonText}
                 </Button>
@@ -301,7 +301,7 @@ export function PricingPage() {
                 size="lg"
                 className="bg-white hover:bg-gray-100 px-8"
                 style={{ color: THEME.primary, borderRadius: 0 }}
-                onClick={() => window.location.href = '/register'}
+                onClick={() => window.location.href = '/start'}
               >
                 無料で始める
                 <ArrowRight className="w-5 h-5 ml-2" />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export interface Organization {
   name: string
   slug: string  // URL用識別子（例: queens-waltz, company-a）
   plan: 'free' | 'basic' | 'pro'
+  booking_site_status?: 'none' | 'pending' | 'approved'
   contact_email?: string | null
   contact_name?: string | null
   is_license_manager: boolean  // ライセンス管理会社かどうか

--- a/supabase/functions/_shared/email-logs.ts
+++ b/supabase/functions/_shared/email-logs.ts
@@ -1,0 +1,162 @@
+/**
+ * email_logs テーブルへのアクセスヘルパー
+ *
+ * 設計方針:
+ * - すべての関数はエラーをスローせず null / void を返す（送信処理をブロックしない）
+ * - PII を含む body_html / body_text は呼び出し元が渡すかどうかを選択できる
+ * - provider_message_id は Resend から返る email_id
+ */
+
+// Deno / supabase-js の型宣言（Edge Function 環境）
+// deno-lint-ignore-file no-explicit-any
+import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+export type EmailLogStatus =
+  | 'queued'
+  | 'sent'
+  | 'delivered'
+  | 'opened'
+  | 'clicked'
+  | 'bounced'
+  | 'complained'
+  | 'failed'
+  | 'delivery_delayed'
+
+export type EmailLogType =
+  | 'reservation_confirmed'
+  | 'reservation_cancelled'
+  | 'reservation_changed'
+  | 'reservation_request'
+  | 'reminder'
+  | 'gm_notification'
+  | 'staff_invitation'
+  | 'waitlist_confirmed'
+  | 'guest_pin'
+  | 'performance_cancellation'
+  | 'license_report'
+  | 'contact_inquiry'
+  | 'other'
+
+export interface EmailLogInsert {
+  organization_id?: string | null
+  reservation_id?: string | null
+  schedule_event_id?: string | null
+  customer_id?: string | null
+  email_type: EmailLogType
+  to_email: string
+  to_name?: string | null
+  subject: string
+  /** HTMLメール本文（PIIを含む場合は呼び出し元が省略可） */
+  body_html?: string | null
+  /** テキストメール本文（PIIを含む場合は呼び出し元が省略可） */
+  body_text?: string | null
+  provider?: string
+  status?: EmailLogStatus
+}
+
+export interface EmailLogUpdate {
+  status?: EmailLogStatus
+  provider_message_id?: string | null
+  error_message?: string | null
+  sent_at?: string | null
+  delivered_at?: string | null
+  opened_at?: string | null
+  bounced_at?: string | null
+  complained_at?: string | null
+}
+
+/**
+ * email_logs に新規レコードを挿入し、生成された id を返す。
+ * 失敗時は null を返す（エラーをスローしない）。
+ */
+export async function insertEmailLog(
+  supabase: SupabaseClient,
+  data: EmailLogInsert,
+): Promise<string | null> {
+  try {
+    const { data: row, error } = await supabase
+      .from('email_logs')
+      .insert({
+        organization_id:   data.organization_id   ?? null,
+        reservation_id:    data.reservation_id    ?? null,
+        schedule_event_id: data.schedule_event_id ?? null,
+        customer_id:       data.customer_id       ?? null,
+        email_type:        data.email_type,
+        to_email:          data.to_email,
+        to_name:           data.to_name           ?? null,
+        subject:           data.subject,
+        body_html:         data.body_html         ?? null,
+        body_text:         data.body_text         ?? null,
+        provider:          data.provider          ?? 'resend',
+        status:            data.status            ?? 'queued',
+      })
+      .select('id')
+      .single()
+
+    if (error) {
+      console.warn('⚠️ email_logs insert failed (non-blocking):', error.message)
+      return null
+    }
+    return (row as any)?.id ?? null
+  } catch (err: unknown) {
+    console.warn('⚠️ email_logs insert exception (non-blocking):', (err as Error).message)
+    return null
+  }
+}
+
+/**
+ * email_logs の既存レコードを id で更新する。
+ * id が null の場合や失敗した場合は何もしない（エラーをスローしない）。
+ */
+export async function updateEmailLog(
+  supabase: SupabaseClient,
+  id: string | null,
+  updates: EmailLogUpdate,
+): Promise<void> {
+  if (!id) return
+  try {
+    const { error } = await supabase
+      .from('email_logs')
+      .update(updates)
+      .eq('id', id)
+
+    if (error) {
+      console.warn('⚠️ email_logs update failed (non-blocking):', error.message)
+    }
+  } catch (err: unknown) {
+    console.warn('⚠️ email_logs update exception (non-blocking):', (err as Error).message)
+  }
+}
+
+/**
+ * Resend Webhook 用: provider_message_id でレコードを特定して更新する。
+ * 該当レコードが存在しない場合は警告ログを残すが、エラーはスローしない。
+ */
+export async function updateEmailLogByProviderId(
+  supabase: SupabaseClient,
+  providerId: string,
+  updates: EmailLogUpdate,
+): Promise<void> {
+  try {
+    const { data: rows, error } = await supabase
+      .from('email_logs')
+      .update(updates)
+      .eq('provider_message_id', providerId)
+      .select('id')
+
+    if (error) {
+      console.warn('⚠️ email_logs updateByProviderId failed:', error.message)
+      return
+    }
+
+    if (!rows || rows.length === 0) {
+      // ログ未作成（古い送信など）は警告のみ
+      console.warn('⚠️ email_logs: no record found for provider_message_id', providerId)
+    }
+  } catch (err: unknown) {
+    console.warn(
+      '⚠️ email_logs updateByProviderId exception (non-blocking):',
+      (err as Error).message,
+    )
+  }
+}

--- a/supabase/functions/check-performance-cancellation/index.ts
+++ b/supabase/functions/check-performance-cancellation/index.ts
@@ -10,6 +10,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getCorsHeaders, verifyAuth, errorResponse, sanitizeErrorMessage, timingSafeEqualString, getServiceRoleKey, isCronOrServiceRoleCall, maskEmail } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 import { getEmailSettings, getDiscordSettings, sendDiscordNotificationWithRetry, getStoreEmailSettings, replaceTemplateVariables } from '../_shared/organization-settings.ts'
 
 interface CheckRequest {
@@ -470,6 +471,15 @@ ${emailSettings.senderName}
     `
   }
 
+  const emailSubject = `【公演中止のお知らせ】${event.scenario} - ${event.date}`
+  const emailLogId = await insertEmailLog(supabase, {
+    organization_id: event.organization_id ?? null,
+    email_type:      'performance_cancellation',
+    to_email:        customerEmail,
+    subject:         emailSubject,
+    status:          'queued',
+  })
+
   const response = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
@@ -479,7 +489,7 @@ ${emailSettings.senderName}
     body: JSON.stringify({
       from: `${emailSettings.senderName} <${emailSettings.senderEmail}>`,
       to: [customerEmail],
-      subject: `【公演中止のお知らせ】${event.scenario} - ${event.date}`,
+      subject: emailSubject,
       html: finalHtml,
       text: finalText,
     }),
@@ -487,8 +497,19 @@ ${emailSettings.senderName}
 
   if (!response.ok) {
     const errorData = await response.json()
+    await updateEmailLog(supabase, emailLogId, {
+      status: 'failed',
+      error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+    })
     throw new Error(`Resend API error: ${JSON.stringify(errorData)}`)
   }
+
+  const resendResult = await response.json()
+  await updateEmailLog(supabase, emailLogId, {
+    status: 'sent',
+    provider_message_id: resendResult?.id ?? null,
+    sent_at: new Date().toISOString(),
+  })
 }
 
 /**

--- a/supabase/functions/invite-staff/index.ts
+++ b/supabase/functions/invite-staff/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings } from '../_shared/organization-settings.ts'
 import { getCorsHeaders, maskEmail, maskName, sanitizeErrorMessage, getAnonKey, getServiceRoleKey } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
 const SUPABASE_SERVICE_ROLE_KEY = getServiceRoleKey()
@@ -443,6 +444,15 @@ serve(async (req) => {
         </p>
       `
 
+      const emailLogId = await insertEmailLog(supabase, {
+        organization_id: organizationId ?? null,
+        email_type:      'staff_invitation',
+        to_email:        email,
+        to_name:         name ?? null,
+        subject:         emailSubject,
+        status:          'queued',
+      })
+
       try {
         const emailResponse = await fetch('https://api.resend.com/emails', {
           method: 'POST',
@@ -462,13 +472,27 @@ serve(async (req) => {
           emailError = `Resend API error (${emailResponse.status})`
           const errorBody = await emailResponse.text()
           console.error('❌ Resend error:', emailError, errorBody)
+          await updateEmailLog(supabase, emailLogId, {
+            status: 'failed',
+            error_message: sanitizeErrorMessage(emailError),
+          })
         } else {
+          const emailResult = await emailResponse.json()
           emailSent = true
           console.log('✅ Invitation email sent to:', maskEmail(email))
+          await updateEmailLog(supabase, emailLogId, {
+            status: 'sent',
+            provider_message_id: emailResult?.id ?? null,
+            sent_at: new Date().toISOString(),
+          })
         }
       } catch (err: any) {
         emailError = err?.message || 'メール送信中に予期しないエラーが発生しました'
         console.error('❌ Failed to send email:', emailError)
+        await updateEmailLog(supabase, emailLogId, {
+          status: 'failed',
+          error_message: sanitizeErrorMessage(emailError),
+        })
       }
     }
 

--- a/supabase/functions/notify-gm-private-booking-confirmed/index.ts
+++ b/supabase/functions/notify-gm-private-booking-confirmed/index.ts
@@ -3,7 +3,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getDiscordSettings, getEmailSettings } from '../_shared/organization-settings.ts'
-import { errorResponse, getCorsHeaders, getServiceRoleKey, verifyAuth } from '../_shared/security.ts'
+import { errorResponse, getCorsHeaders, getServiceRoleKey, verifyAuth, sanitizeErrorMessage } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
 const SUPABASE_SERVICE_ROLE_KEY = getServiceRoleKey()
@@ -366,6 +367,16 @@ ${data.gmName} さん
 このメールは貸切予約確定時にGMへ自動送信されています
           `
 
+          const gmEmailSubject = `【GM担当確定】${data.scenarioTitle} - ${formattedDate}`
+          const gmEmailLogId = await insertEmailLog(supabase, {
+            organization_id: data.organizationId ?? null,
+            email_type:      'gm_notification',
+            to_email:        data.gmEmail,
+            to_name:         data.gmName ?? null,
+            subject:         gmEmailSubject,
+            status:          'queued',
+          })
+
           const response = await fetch('https://api.resend.com/emails', {
             method: 'POST',
             headers: {
@@ -375,17 +386,27 @@ ${data.gmName} さん
             body: JSON.stringify({
               from: `${senderName} <${senderEmail}>`,
               to: [data.gmEmail],
-              subject: `【GM担当確定】${data.scenarioTitle} - ${formattedDate}`,
+              subject: gmEmailSubject,
               html: emailHtml,
               text: emailText,
             }),
           })
 
           if (response.ok) {
+            const gmEmailResult = await response.json()
             console.log('✅ メール通知送信成功:', data.gmEmail)
+            await updateEmailLog(supabase, gmEmailLogId, {
+              status: 'sent',
+              provider_message_id: gmEmailResult?.id ?? null,
+              sent_at: new Date().toISOString(),
+            })
           } else {
             const errorText = await response.text()
             console.error('❌ メール通知送信失敗:', errorText)
+            await updateEmailLog(supabase, gmEmailLogId, {
+              status: 'failed',
+              error_message: sanitizeErrorMessage(errorText),
+            })
           }
         }
       } catch (emailError) {

--- a/supabase/functions/notify-waitlist/index.ts
+++ b/supabase/functions/notify-waitlist/index.ts
@@ -10,7 +10,8 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getEmailTemplates, getStoreEmailSettings } from '../_shared/organization-settings.ts'
-import { getCorsHeaders, verifyAuth, errorResponse, sanitizeErrorMessage, checkRateLimit, getClientIP, rateLimitResponse } from '../_shared/security.ts'
+import { getCorsHeaders, verifyAuth, errorResponse, sanitizeErrorMessage, checkRateLimit, getClientIP, rateLimitResponse, getServiceRoleKey } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface NotifyWaitlistRequest {
   organizationId: string
@@ -490,6 +491,17 @@ ${emailTemplates.footer}
         finalText = emailText
       }
 
+      const waitlistEmailSubject = `【空席のお知らせ】${data.scenarioTitle} - ${formatDate(data.eventDate)}`
+      const waitlistEmailLogId = await insertEmailLog(serviceClient, {
+        organization_id:   data.organizationId ?? null,
+        schedule_event_id: data.scheduleEventId ?? null,
+        email_type:        'waitlist_confirmed',
+        to_email:          entry.customer_email,
+        to_name:           entry.customer_name ?? null,
+        subject:           waitlistEmailSubject,
+        status:            'queued',
+      })
+
       try {
         const resendResponse = await fetch('https://api.resend.com/emails', {
           method: 'POST',
@@ -500,7 +512,7 @@ ${emailTemplates.footer}
           body: JSON.stringify({
             from: `${companyName} <${senderEmail}>`,
             to: [entry.customer_email],
-            subject: `【空席のお知らせ】${data.scenarioTitle} - ${formatDate(data.eventDate)}`,
+            subject: waitlistEmailSubject,
             html: finalHtml,
             text: finalText,
             reply_to: companyEmail || undefined,
@@ -510,8 +522,19 @@ ${emailTemplates.footer}
         if (!resendResponse.ok) {
           const errorData = await resendResponse.json()
           console.error('Resend API error for', entry.customer_email, ':', errorData)
+          await updateEmailLog(serviceClient, waitlistEmailLogId, {
+            status: 'failed',
+            error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+          })
           return { success: false, entryId: entry.id, error: errorData }
         }
+
+        const waitlistEmailResult = await resendResponse.json()
+        await updateEmailLog(serviceClient, waitlistEmailLogId, {
+          status: 'sent',
+          provider_message_id: waitlistEmailResult?.id ?? null,
+          sent_at: new Date().toISOString(),
+        })
 
         // 🔒 SEC-P0-03: ステータス更新はRPCで既に完了済み
         // fetch_and_lock_waitlist_entries でアトミックに更新されているため、ここでの更新は不要
@@ -520,6 +543,10 @@ ${emailTemplates.footer}
         return { success: true, entryId: entry.id }
       } catch (err) {
         console.error('Email send error for', entry.customer_email, ':', err)
+        await updateEmailLog(serviceClient, waitlistEmailLogId, {
+          status: 'failed',
+          error_message: sanitizeErrorMessage(err?.message ?? String(err)),
+        })
         return { success: false, entryId: entry.id, error: err.message }
       }
     })

--- a/supabase/functions/process-booking-email-queue/index.ts
+++ b/supabase/functions/process-booking-email-queue/index.ts
@@ -16,6 +16,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings } from '../_shared/organization-settings.ts'
 import { getCorsHeaders, verifyAuth, errorResponse, sanitizeErrorMessage, timingSafeEqualString, getServiceRoleKey, isCronOrServiceRoleCall } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface QueueItem {
   id: string
@@ -320,6 +321,17 @@ ${item.customer_name} 様
 MMQ
     `
 
+    const queueEmailSubject = `【予約完了】${item.scenario_title} - ${formatDate(item.event_date)}`
+    const queueEmailLogId = await insertEmailLog(supabase, {
+      organization_id: item.organization_id ?? null,
+      reservation_id:  item.reservation_id ?? null,
+      email_type:      'reservation_confirmed',
+      to_email:        item.customer_email,
+      to_name:         item.customer_name ?? null,
+      subject:         queueEmailSubject,
+      status:          'queued',
+    })
+
     // Resend APIでメール送信
     const response = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -330,7 +342,7 @@ MMQ
       body: JSON.stringify({
         from: `${emailSettings.senderName} <${emailSettings.senderEmail}>`,
         to: [item.customer_email],
-        subject: `【予約完了】${item.scenario_title} - ${formatDate(item.event_date)}`,
+        subject: queueEmailSubject,
         html: emailHtml,
         text: emailText,
       }),
@@ -338,9 +350,19 @@ MMQ
 
     if (!response.ok) {
       const errorData = await response.json()
+      await updateEmailLog(supabase, queueEmailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       return { success: false, error: JSON.stringify(errorData) }
     }
 
+    const queueEmailResult = await response.json()
+    await updateEmailLog(supabase, queueEmailLogId, {
+      status: 'sent',
+      provider_message_id: queueEmailResult?.id ?? null,
+      sent_at: new Date().toISOString(),
+    })
     return { success: true }
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : String(error) }

--- a/supabase/functions/process-waitlist-queue/index.ts
+++ b/supabase/functions/process-waitlist-queue/index.ts
@@ -17,6 +17,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings } from '../_shared/organization-settings.ts'
 import { getCorsHeaders, errorResponse, sanitizeErrorMessage, timingSafeEqualString, getServiceRoleKey, isCronOrServiceRoleCall, maskEmail } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface QueueEntry {
   id: string
@@ -435,6 +436,16 @@ MMQ
 このメールは自動送信されています
   `
 
+  const pWqEmailSubject = `【空席のお知らせ】${queueEntry.scenario_title} - ${formatDate(queueEntry.event_date)}`
+  const pWqEmailLogId = await insertEmailLog(serviceClient, {
+    organization_id: queueEntry.organization_id ?? null,
+    email_type:      'waitlist_confirmed',
+    to_email:        waitlistEntry.customer_email,
+    to_name:         waitlistEntry.customer_name ?? null,
+    subject:         pWqEmailSubject,
+    status:          'queued',
+  })
+
   try {
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -445,7 +456,7 @@ MMQ
       body: JSON.stringify({
         from: `${senderName} <${senderEmail}>`,
         to: [waitlistEntry.customer_email],
-        subject: `【空席のお知らせ】${queueEntry.scenario_title} - ${formatDate(queueEntry.event_date)}`,
+        subject: pWqEmailSubject,
         html: emailHtml,
         text: emailText,
       }),
@@ -454,14 +465,25 @@ MMQ
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error for', maskEmail(waitlistEntry.customer_email), ':', errorData)
+      await updateEmailLog(serviceClient, pWqEmailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       return { success: false, entryId: waitlistEntry.id, error: JSON.stringify(errorData) }
     }
+
+    const pWqEmailResult = await resendResponse.json()
+    await updateEmailLog(serviceClient, pWqEmailLogId, {
+      status: 'sent',
+      provider_message_id: pWqEmailResult?.id ?? null,
+      sent_at: new Date().toISOString(),
+    })
 
     // ステータスを「notified」に更新し、期限を設定
     const { error: updateError } = await serviceClient
       .from('waitlist')
-      .update({ 
-        status: 'notified', 
+      .update({
+        status: 'notified',
         notified_at: new Date().toISOString(),
         expires_at: expiresAt
       })
@@ -475,6 +497,10 @@ MMQ
     return { success: true, entryId: waitlistEntry.id }
   } catch (err) {
     console.error('❌ Email send error for', maskEmail(waitlistEntry.customer_email), ':', err)
+    await updateEmailLog(serviceClient, pWqEmailLogId, {
+      status: 'failed',
+      error_message: sanitizeErrorMessage(err?.message ?? String(err)),
+    })
     return { success: false, entryId: waitlistEntry.id, error: err.message }
   }
 }

--- a/supabase/functions/resend-webhook/index.ts
+++ b/supabase/functions/resend-webhook/index.ts
@@ -1,5 +1,8 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { Webhook } from 'npm:svix@1.61.0'
+import { getServiceRoleKey } from '../_shared/security.ts'
+import { updateEmailLogByProviderId, type EmailLogStatus, type EmailLogUpdate } from '../_shared/email-logs.ts'
 
 type ResendEventPayload = {
   type?: string
@@ -9,6 +12,34 @@ type ResendEventPayload = {
     from?: string
     to?: string[] | string
     subject?: string
+  }
+}
+
+// Resend イベント種別 → email_logs ステータス/タイムスタンプへのマッピング
+function buildLogUpdate(
+  eventType: string,
+  eventTime: string | undefined,
+): EmailLogUpdate | null {
+  const ts = eventTime ?? new Date().toISOString()
+
+  switch (eventType) {
+    case 'email.delivered':
+      return { status: 'delivered' as EmailLogStatus, delivered_at: ts }
+    case 'email.opened':
+      return { status: 'opened' as EmailLogStatus, opened_at: ts }
+    case 'email.clicked':
+      return { status: 'clicked' as EmailLogStatus }
+    case 'email.bounced':
+      return { status: 'bounced' as EmailLogStatus, bounced_at: ts }
+    case 'email.complained':
+      return { status: 'complained' as EmailLogStatus, complained_at: ts }
+    case 'email.delivery_delayed':
+      return { status: 'delivery_delayed' as EmailLogStatus }
+    case 'email.failed':
+      return { status: 'failed' as EmailLogStatus }
+    default:
+      // sent など未マップのイベントは更新しない
+      return null
   }
 }
 
@@ -37,7 +68,7 @@ serve(async (req: Request) => {
   const rawPayload = await req.text()
 
   const svixHeaders = {
-    'svix-id': req.headers.get('svix-id') ?? '',
+    'svix-id':        req.headers.get('svix-id')        ?? '',
     'svix-timestamp': req.headers.get('svix-timestamp') ?? '',
     'svix-signature': req.headers.get('svix-signature') ?? '',
   }
@@ -50,17 +81,33 @@ serve(async (req: Request) => {
     const webhook = new Webhook(signingSecret)
     const event = webhook.verify(rawPayload, svixHeaders) as ResendEventPayload
 
-    // Keep only metadata logs to avoid leaking full message content.
+    const eventType = event?.type ?? 'unknown'
+    const emailId   = event?.data?.email_id ?? null
+
+    // メタデータのみをログ（PII 漏洩防止）
     console.log('✅ Resend webhook received', {
-      type: event?.type ?? 'unknown',
-      email_id: event?.data?.email_id ?? null,
+      type:       eventType,
+      email_id:   emailId,
       created_at: event?.created_at ?? null,
-      to_count: Array.isArray(event?.data?.to)
+      to_count:   Array.isArray(event?.data?.to)
         ? event?.data?.to.length
-        : event?.data?.to
-          ? 1
-          : 0,
+        : event?.data?.to ? 1 : 0,
     })
+
+    // email_logs を更新
+    if (emailId) {
+      const logUpdate = buildLogUpdate(eventType, event?.created_at)
+      if (logUpdate) {
+        const supabase = createClient(
+          Deno.env.get('SUPABASE_URL') ?? '',
+          getServiceRoleKey(),
+        )
+        await updateEmailLogByProviderId(supabase, emailId, logUpdate)
+      }
+    } else {
+      // email_id が取れない場合は警告のみ（ペイロード全体は保存しない）
+      console.warn('⚠️ Resend webhook: email_id not found in payload, type=', eventType)
+    }
 
     return jsonResponse({ received: true }, 200)
   } catch (error) {

--- a/supabase/functions/send-author-report/index.ts
+++ b/supabase/functions/send-author-report/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings } from '../_shared/organization-settings.ts'
 import { getServiceRoleKey, getCorsHeaders, maskEmail, sanitizeErrorMessage, verifyAuth, errorResponse } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface AuthorReportRequest {
   organizationId?: string  // マルチテナント対応
@@ -152,6 +153,17 @@ MMQ
 このメールは自動送信されています
 ご不明な点がございましたら、お気軽にお問い合わせください`
 
+    const emailSubject = `【${year}年${month}月】ライセンス料レポート - ${authorName}`
+
+    const emailLogId = await insertEmailLog(supabaseAdmin, {
+      organization_id: organizationId ?? null,
+      email_type:      'license_report',
+      to_email:        to,
+      to_name:         authorName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIを使ってプレーンテキストメール送信
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -165,7 +177,7 @@ MMQ
         to: [to],
         // 自社メールアドレスに送信確認コピーを送る
         ...(replyToEmail ? { bcc: [replyToEmail] } : {}),
-        subject: `【${year}年${month}月】ライセンス料レポート - ${authorName}`,
+        subject: emailSubject,
         text: customTextBody || emailText,
       }),
     })
@@ -173,10 +185,19 @@ MMQ
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(supabaseAdmin, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
     const result = await resendResponse.json()
+    await updateEmailLog(supabaseAdmin, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
     console.log('Author report email sent successfully:', {
       messageId: result.id,
       to: to,

--- a/supabase/functions/send-booking-change-confirmation/index.ts
+++ b/supabase/functions/send-booking-change-confirmation/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getStoreEmailSettings } from '../_shared/organization-settings.ts'
 import { getAnonKey, getServiceRoleKey, getCorsHeaders, maskEmail, maskName, verifyAuth, errorResponse, sanitizeErrorMessage } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface BookingChangeRequest {
   organizationId?: string  // マルチテナント対応
@@ -363,11 +364,23 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
       finalText = emailText
     }
 
+    const emailSubject = `【予約内容変更】${changeData.scenarioTitle} - ${changeData.reservationNumber}${companyName ? ` | ${companyName}` : ''}`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: resolvedOrganizationId ?? null,
+      reservation_id:  changeData.reservationId,
+      email_type:      'reservation_changed',
+      to_email:        changeData.customerEmail,
+      to_name:         changeData.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIを使ってメール送信
     const emailPayload: Record<string, unknown> = {
       from: `${companyName} <${senderEmail}>`,
       to: [changeData.customerEmail],
-      subject: `【予約内容変更】${changeData.scenarioTitle} - ${changeData.reservationNumber}${companyName ? ` | ${companyName}` : ''}`,
+      subject: emailSubject,
       html: finalHtml,
       text: finalText,
     }
@@ -389,11 +402,20 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
     const result = await resendResponse.json()
     console.log('Email sent successfully:', result)
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     return new Response(
       JSON.stringify({ 

--- a/supabase/functions/send-booking-confirmation/index.ts
+++ b/supabase/functions/send-booking-confirmation/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getStoreEmailSettings } from '../_shared/organization-settings.ts'
 import { getAnonKey, getServiceRoleKey, getCorsHeaders, maskEmail, maskName, verifyAuth, errorResponse, sanitizeErrorMessage } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface BookingConfirmationRequest {
   reservationId: string
@@ -379,11 +380,24 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
       finalText = emailText
     }
 
+    const emailSubject = `【予約完了】${bookingData.scenarioTitle} - ${formatDate(bookingData.eventDate)}${companyName ? ` | ${companyName}` : ''}`
+
+    // email_logs に送信前エントリを作成
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: resolvedOrganizationId ?? null,
+      reservation_id:  bookingData.reservationId,
+      email_type:      'reservation_confirmed',
+      to_email:        bookingData.customerEmail,
+      to_name:         bookingData.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIを使ってメール送信
     const emailPayload: Record<string, unknown> = {
       from: `${companyName} <${senderEmail}>`,
       to: [bookingData.customerEmail],
-      subject: `【予約完了】${bookingData.scenarioTitle} - ${formatDate(bookingData.eventDate)}${companyName ? ` | ${companyName}` : ''}`,
+      subject: emailSubject,
       html: finalHtml,
       text: finalText,
     }
@@ -404,6 +418,10 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       // キューがあれば pending に戻してリトライできるようにする
       if (resolvedOrganizationId) {
         try {
@@ -425,6 +443,11 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
 
     const result = await resendResponse.json()
     console.log('✅ Email sent successfully to:', maskEmail(bookingData.customerEmail))
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     // キューを completed に更新（以後の二重送信を防ぐ）
     if (resolvedOrganizationId) {

--- a/supabase/functions/send-cancellation-confirmation/index.ts
+++ b/supabase/functions/send-cancellation-confirmation/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getStoreEmailSettings, replaceTemplateVariables } from '../_shared/organization-settings.ts'
 import { getAnonKey, getServiceRoleKey, getCorsHeaders, maskEmail, maskName, verifyAuth, errorResponse, sanitizeErrorMessage } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface CancellationRequest {
   organizationId?: string  // マルチテナント対応
@@ -388,12 +389,24 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
     }
 
     // Resend APIを使ってメール送信
+    const emailSubject = isStoreCancellation
+      ? `【公演中止】${cancellationData.scenarioTitle} - ${formatDate(cancellationData.eventDate)}${companyName ? ` | ${companyName}` : ''}`
+      : `【予約キャンセル】${cancellationData.scenarioTitle} - ${formatDate(cancellationData.eventDate)}${companyName ? ` | ${companyName}` : ''}`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: resolvedOrganizationId ?? null,
+      reservation_id:  cancellationData.reservationId,
+      email_type:      'reservation_cancelled',
+      to_email:        cancellationData.customerEmail,
+      to_name:         cancellationData.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     const emailPayload: Record<string, unknown> = {
       from: `${companyName} <${senderEmail}>`,
       to: [cancellationData.customerEmail],
-      subject: isStoreCancellation 
-        ? `【公演中止】${cancellationData.scenarioTitle} - ${formatDate(cancellationData.eventDate)}${companyName ? ` | ${companyName}` : ''}`
-        : `【予約キャンセル】${cancellationData.scenarioTitle} - ${formatDate(cancellationData.eventDate)}${companyName ? ` | ${companyName}` : ''}`,
+      subject: emailSubject,
       html: finalHtml,
       text: finalText,
     }
@@ -415,11 +428,20 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
     const result = await resendResponse.json()
     console.log('Email sent successfully:', result)
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     // user_notifications にキャンセル通知を挿入（Service Role で RLS をバイパス）
     if (reservation.customer_id) {

--- a/supabase/functions/send-contact-inquiry/index.ts
+++ b/supabase/functions/send-contact-inquiry/index.ts
@@ -8,6 +8,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getCorsHeaders, maskEmail, maskName, sanitizeErrorMessage, checkRateLimit, getClientIP, rateLimitResponse, getServiceRoleKey } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface ContactInquiryRequest {
   organizationId?: string
@@ -248,6 +249,20 @@ ${message}
     `
 
     // Resend APIでメール送信（組織の問い合わせ先へ）
+    const inquiryEmailSubject = `【お問い合わせ】${typeLabel}${subject ? `: ${subject}` : ''}`
+    const emailLogServiceClient = serviceRoleKey && supabaseUrl
+      ? createClient(supabaseUrl, serviceRoleKey)
+      : null
+    const emailLogId = emailLogServiceClient
+      ? await insertEmailLog(emailLogServiceClient, {
+          organization_id: organizationId ?? null,
+          email_type:      'contact_inquiry',
+          to_email:        toEmail,
+          subject:         inquiryEmailSubject,
+          status:          'queued',
+        })
+      : null
+
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: {
@@ -258,7 +273,7 @@ ${message}
         from: `MMQ予約システム <${fromEmail}>`,
         to: [toEmail],
         reply_to: email,
-        subject: `【お問い合わせ】${typeLabel}${subject ? `: ${subject}` : ''}`,
+        subject: inquiryEmailSubject,
         html: emailHtml,
         text: emailText,
       }),
@@ -267,7 +282,12 @@ ${message}
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
-
+      if (emailLogServiceClient) {
+        await updateEmailLog(emailLogServiceClient, emailLogId, {
+          status: 'failed',
+          error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+        })
+      }
       if (inquiryId && serviceRoleKey && supabaseUrl) {
         const serviceClient = createClient(supabaseUrl, serviceRoleKey)
         await serviceClient
@@ -287,6 +307,13 @@ ${message}
       messageId: result.id,
       from: maskEmail(email),
     })
+    if (emailLogServiceClient) {
+      await updateEmailLog(emailLogServiceClient, emailLogId, {
+        status: 'sent',
+        provider_message_id: result.id,
+        sent_at: new Date().toISOString(),
+      })
+    }
 
     // ユーザー本人への確認メール送信
     const confirmationHtml = `

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings } from '../_shared/organization-settings.ts'
 import { getCorsHeaders, verifyAuth, errorResponse, maskEmail, sanitizeErrorMessage, getServiceRoleKey } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface EmailRequest {
   organizationId?: string  // マルチテナント対応
@@ -104,6 +105,15 @@ serve(async (req) => {
       requestedBy: maskEmail(authResult.user?.email || ''),
     })
 
+    // email_logs に送信前エントリを作成（失敗してもメール送信は続行）
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: organizationId ?? null,
+      email_type: 'other',
+      to_email: recipients[0],
+      subject,
+      status: 'queued',
+    })
+
     // Resend APIを使ってメール送信
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -122,6 +132,10 @@ serve(async (req) => {
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
@@ -129,6 +143,11 @@ serve(async (req) => {
     console.log('✅ Email sent successfully via Resend:', {
       messageId: result.id,
       recipients: recipients.length,
+    })
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
     })
 
     return new Response(

--- a/supabase/functions/send-guest-pin/index.ts
+++ b/supabase/functions/send-guest-pin/index.ts
@@ -2,6 +2,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getCorsHeaders, errorResponse, maskEmail, sanitizeErrorMessage, getServiceRoleKey } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface SendPinRequest {
   groupId: string
@@ -99,6 +100,16 @@ ${inviteUrl}
       scenarioName: scenarioName?.substring(0, 30),
     })
 
+    const emailSubject = `【${scenarioName}】グループ参加のアクセスPINのご案内`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      email_type: 'guest_pin',
+      to_email:   email,
+      to_name:    guestName ?? null,
+      subject:    emailSubject,
+      status:     'queued',
+    })
+
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: {
@@ -108,7 +119,7 @@ ${inviteUrl}
       body: JSON.stringify({
         from: `${senderName} <${senderEmail}>`,
         to: [email],
-        subject: `【${scenarioName}】グループ参加のアクセスPINのご案内`,
+        subject: emailSubject,
         text: emailBody,
       }),
     })
@@ -116,6 +127,10 @@ ${inviteUrl}
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました`)
     }
 
@@ -123,6 +138,11 @@ ${inviteUrl}
     console.log('✅ PIN email sent successfully:', {
       messageId: result.id,
       recipient: maskEmail(email),
+    })
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
     })
 
     return new Response(

--- a/supabase/functions/send-private-booking-confirmation/index.ts
+++ b/supabase/functions/send-private-booking-confirmation/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getStoreEmailSettings } from '../_shared/organization-settings.ts'
 import { getAnonKey, getServiceRoleKey, getCorsHeaders, maskEmail, maskName, verifyAuth, errorResponse, sanitizeErrorMessage } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface PrivateBookingConfirmationRequest {
   reservationId: string
@@ -342,11 +343,23 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
       finalText = emailText
     }
 
+    const emailSubject = `【貸切予約確定】${bookingData.scenarioTitle} - ${formatDate(bookingData.eventDate)}${companyName ? ` | ${companyName}` : ''}`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: resolvedOrganizationId ?? null,
+      reservation_id:  bookingData.reservationId ?? null,
+      email_type:      'reservation_confirmed',
+      to_email:        bookingData.customerEmail,
+      to_name:         bookingData.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIを使ってメール送信
     const emailPayload: Record<string, unknown> = {
       from: `${companyName} <${senderEmail}>`,
       to: [bookingData.customerEmail],
-      subject: `【貸切予約確定】${bookingData.scenarioTitle} - ${formatDate(bookingData.eventDate)}${companyName ? ` | ${companyName}` : ''}`,
+      subject: emailSubject,
       html: finalHtml,
       text: finalText,
     }
@@ -368,17 +381,26 @@ ${companyEmail ? `Email: ${companyEmail}` : ''}
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
     const result = await resendResponse.json()
     console.log('Email sent successfully:', result)
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     return new Response(
-      JSON.stringify({ 
-        success: true, 
+      JSON.stringify({
+        success: true,
         message: '貸切予約確定メールを送信しました',
-        emailId: result.id 
+        emailId: result.id
       }),
       {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/send-private-booking-rejection/index.ts
+++ b/supabase/functions/send-private-booking-rejection/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getStoreEmailSettings, replaceTemplateVariables } from '../_shared/organization-settings.ts'
 import { getAnonKey, getServiceRoleKey, getCorsHeaders, maskEmail, maskName, verifyAuth, errorResponse, sanitizeErrorMessage } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface PrivateBookingRejectionRequest {
   organizationId?: string  // マルチテナント対応
@@ -253,6 +254,18 @@ MMQ
       console.log('📧 Using custom private_rejection_template')
     }
 
+    const emailSubject = `【貸切リクエスト】${rejectionData.scenarioTitle}のお申し込みについて`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: rejectionData.organizationId ?? null,
+      reservation_id:  rejectionData.reservationId ?? null,
+      email_type:      'reservation_cancelled',
+      to_email:        rejectionData.customerEmail,
+      to_name:         rejectionData.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIを使ってメール送信
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -263,7 +276,7 @@ MMQ
       body: JSON.stringify({
         from: `${senderName} <${senderEmail}>`,
         to: [rejectionData.customerEmail],
-        subject: `【貸切リクエスト】${rejectionData.scenarioTitle}のお申し込みについて`,
+        subject: emailSubject,
         html: finalHtml,
         text: finalText,
       }),
@@ -272,17 +285,26 @@ MMQ
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
     const result = await resendResponse.json()
     console.log('Email sent successfully:', result)
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     return new Response(
-      JSON.stringify({ 
-        success: true, 
+      JSON.stringify({
+        success: true,
         message: '貸切リクエスト却下メールを送信しました',
-        emailId: result.id 
+        emailId: result.id
       }),
       {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/send-private-booking-request-confirmation/index.ts
+++ b/supabase/functions/send-private-booking-request-confirmation/index.ts
@@ -3,6 +3,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getStoreEmailSettings, replaceTemplateVariables } from '../_shared/organization-settings.ts'
 import { getAnonKey, getServiceRoleKey, getCorsHeaders, maskEmail, maskName, sanitizeErrorMessage, verifyAuth, errorResponse } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface PrivateBookingRequestConfirmationRequest {
   organizationId?: string  // マルチテナント対応
@@ -316,6 +317,18 @@ MMQ
       console.log('📧 Using custom private_request_template')
     }
 
+    const emailSubject = `【貸切予約リクエスト受付】${requestData.scenarioTitle}`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: requestData.organizationId ?? null,
+      reservation_id:  requestData.reservationId ?? null,
+      email_type:      'reservation_request',
+      to_email:        requestData.customerEmail,
+      to_name:         requestData.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIを使ってメール送信
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -326,7 +339,7 @@ MMQ
       body: JSON.stringify({
         from: `${senderName} <${senderEmail}>`,
         to: [requestData.customerEmail],
-        subject: `【貸切予約リクエスト受付】${requestData.scenarioTitle}`,
+        subject: emailSubject,
         html: finalHtml,
         text: finalText,
       }),
@@ -335,17 +348,26 @@ MMQ
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
     const result = await resendResponse.json()
     console.log('Email sent successfully:', result)
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     return new Response(
-      JSON.stringify({ 
-        success: true, 
+      JSON.stringify({
+        success: true,
         message: '貸切予約リクエスト受付確認メールを送信しました',
-        emailId: result.id 
+        emailId: result.id
       }),
       {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/send-reminder-emails/index.ts
+++ b/supabase/functions/send-reminder-emails/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getStoreEmailSettings } from '../_shared/organization-settings.ts'
 import { getAnonKey, getServiceRoleKey, getCorsHeaders, maskEmail, maskName, verifyAuth, errorResponse, sanitizeErrorMessage, isCronOrServiceRoleCall } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface ReminderEmailRequest {
   organizationId?: string  // マルチテナント対応
@@ -194,11 +195,23 @@ serve(async (req) => {
     const emailHtml = templateToHtml(appliedTemplate)
     const emailText = appliedTemplate
 
+    const emailSubject = `【リマインド】${reminderData.scenarioTitle} - ${formatDate(reminderData.eventDate)}${companyName ? ` | ${companyName}` : ''}`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: resolvedOrganizationId ?? null,
+      reservation_id:  reminderData.reservationId,
+      email_type:      'reminder',
+      to_email:        reminderData.customerEmail,
+      to_name:         reminderData.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIを使ってメール送信
     const emailPayload: Record<string, unknown> = {
       from: `${companyName} <${senderEmail}>`,
       to: [reminderData.customerEmail],
-      subject: `【リマインド】${reminderData.scenarioTitle} - ${formatDate(reminderData.eventDate)}${companyName ? ` | ${companyName}` : ''}`,
+      subject: emailSubject,
       html: emailHtml,
       text: emailText,
     }
@@ -220,11 +233,20 @@ serve(async (req) => {
     if (!resendResponse.ok) {
       const errorText = await resendResponse.text()
       console.error('Resend API error:', errorText)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(errorText),
+      })
       throw new Error(`メール送信に失敗しました: ${errorText}`)
     }
 
     const result = await resendResponse.json()
     console.log('リマインドメール送信成功:', result)
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     return new Response(
       JSON.stringify({ 

--- a/supabase/functions/send-waitlist-registration-confirmation/index.ts
+++ b/supabase/functions/send-waitlist-registration-confirmation/index.ts
@@ -8,6 +8,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { getEmailSettings, getEmailTemplates, getStoreEmailSettings } from '../_shared/organization-settings.ts'
 import { getCorsHeaders, errorResponse, sanitizeErrorMessage, getServiceRoleKey } from '../_shared/security.ts'
+import { insertEmailLog, updateEmailLog } from '../_shared/email-logs.ts'
 
 interface WaitlistRegistrationRequest {
   organizationId: string
@@ -272,6 +273,17 @@ ${emailTemplates.footer}
       finalText = emailText
     }
 
+    const emailSubject = `【キャンセル待ち登録完了】${data.scenarioTitle} - ${formatDate(data.eventDate)}`
+
+    const emailLogId = await insertEmailLog(serviceClient, {
+      organization_id: data.organizationId ?? null,
+      email_type:      'waitlist_confirmed',
+      to_email:        data.customerEmail,
+      to_name:         data.customerName ?? null,
+      subject:         emailSubject,
+      status:          'queued',
+    })
+
     // Resend APIでメール送信
     const resendResponse = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -282,7 +294,7 @@ ${emailTemplates.footer}
       body: JSON.stringify({
         from: `${companyName} <${senderEmail}>`,
         to: [data.customerEmail],
-        subject: `【キャンセル待ち登録完了】${data.scenarioTitle} - ${formatDate(data.eventDate)}`,
+        subject: emailSubject,
         html: finalHtml,
         text: finalText,
         reply_to: companyEmail || replyToEmail || undefined,
@@ -292,11 +304,20 @@ ${emailTemplates.footer}
     if (!resendResponse.ok) {
       const errorData = await resendResponse.json()
       console.error('Resend API error:', errorData)
+      await updateEmailLog(serviceClient, emailLogId, {
+        status: 'failed',
+        error_message: sanitizeErrorMessage(JSON.stringify(errorData)),
+      })
       throw new Error(`メール送信に失敗しました: ${JSON.stringify(errorData)}`)
     }
 
     const result = await resendResponse.json()
     console.log('✅ Waitlist registration email sent:', result.id)
+    await updateEmailLog(serviceClient, emailLogId, {
+      status: 'sent',
+      provider_message_id: result.id,
+      sent_at: new Date().toISOString(),
+    })
 
     return new Response(
       JSON.stringify({ 

--- a/supabase/migrations/20260516030000_add_register_organization_rpc.sql
+++ b/supabase/migrations/20260516030000_add_register_organization_rpc.sql
@@ -1,0 +1,112 @@
+-- =============================================================================
+-- 組織セルフ登録用 SECURITY DEFINER RPC
+-- =============================================================================
+-- 背景:
+--   organizations テーブルの INSERT は is_admin() 必須だが、
+--   新規登録フローでは「組織がないと admin になれない」という鶏と卵の問題がある。
+--   SECURITY DEFINER 関数として定義し anon から呼び出し可能にすることで解消する。
+--
+-- セキュリティ考慮:
+--   - スラグ重複チェックをRPC内で行い、重複時は例外を返す
+--   - organizations への直接INSERT権限は引き続き anon に付与しない
+--   - レート制限は将来的に rate_limit_log テーブルで追加可能
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. 組織登録 RPC
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.register_organization_for_signup(
+  p_name          TEXT,
+  p_slug          TEXT,
+  p_contact_email TEXT
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id UUID;
+BEGIN
+  -- 入力バリデーション
+  IF p_name IS NULL OR trim(p_name) = '' THEN
+    RAISE EXCEPTION 'invalid_name: 組織名は必須です';
+  END IF;
+
+  IF p_slug IS NULL OR trim(p_slug) = '' THEN
+    RAISE EXCEPTION 'invalid_slug: 識別子は必須です';
+  END IF;
+
+  IF p_slug !~ '^[a-z0-9][a-z0-9\-]{0,29}$' THEN
+    RAISE EXCEPTION 'invalid_slug_format: 識別子は半角英数字とハイフンのみ使用できます';
+  END IF;
+
+  -- スラグ重複チェック
+  IF EXISTS (SELECT 1 FROM public.organizations WHERE slug = p_slug) THEN
+    RAISE EXCEPTION 'slug_already_exists: この識別子は既に使用されています';
+  END IF;
+
+  -- 組織を作成
+  INSERT INTO public.organizations (
+    name,
+    slug,
+    plan,
+    contact_email,
+    is_active,
+    is_license_manager,
+    settings
+  )
+  VALUES (
+    trim(p_name),
+    p_slug,
+    'free',
+    COALESCE(nullif(trim(p_contact_email), ''), NULL),
+    true,
+    false,
+    '{}'::jsonb
+  )
+  RETURNING id INTO v_org_id;
+
+  RETURN json_build_object(
+    'id',   v_org_id,
+    'slug', p_slug,
+    'name', trim(p_name)
+  );
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. スラグ使用可能チェック RPC（入力中のリアルタイムチェック用）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.check_organization_slug_available(
+  p_slug TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT NOT EXISTS (
+    SELECT 1 FROM public.organizations WHERE slug = p_slug
+  );
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. 権限付与（anon・authenticated 両方から呼び出し可能）
+-- ---------------------------------------------------------------------------
+GRANT EXECUTE ON FUNCTION public.register_organization_for_signup(TEXT, TEXT, TEXT)
+  TO anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.check_organization_slug_available(TEXT)
+  TO anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 完了通知
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  RAISE NOTICE '✅ register_organization_for_signup RPC を作成しました';
+  RAISE NOTICE '   - anon/authenticated から呼び出し可能';
+  RAISE NOTICE '   - スラグ重複・形式バリデーション付き';
+  RAISE NOTICE '✅ check_organization_slug_available RPC を作成しました';
+END $$;

--- a/supabase/migrations/20260516040000_fix_handle_new_user_for_org_signup.sql
+++ b/supabase/migrations/20260516040000_fix_handle_new_user_for_org_signup.sql
@@ -1,0 +1,108 @@
+-- =============================================================================
+-- handle_new_user トリガーを組織自己登録フローに対応させる
+-- =============================================================================
+-- 背景:
+--   新規組織登録（/start）では signUp 時に user_metadata として
+--   { organization_id, invited_as: 'admin', admin_name } を渡す。
+--   従来のトリガーはこれを無視していたため:
+--     - users.organization_id が NULL になる
+--     - staff レコードが作成されない
+--     - users/staff の手動 INSERT はRLSに弾かれる
+--
+-- 変更内容:
+--   1. user_metadata.organization_id を読み取り users.organization_id に設定
+--   2. invited_as='admin' かつ organization_id が設定されている場合、
+--      staff レコードを自動作成（SECURITY DEFINER でRLSをバイパス）
+--
+-- 既存フローへの影響:
+--   - 既存スタッフ招待フロー: user_metadata に organization_id を渡さないため変化なし
+--     （invitationsApi.ts が signUp 後に手動で users/staff を upsert する既存実装を維持）
+--   - 顧客登録: invited_as が null のため変化なし
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role   app_role := 'customer';
+  v_org_id UUID;
+  v_name   TEXT;
+BEGIN
+  -- user_metadata から組織自己登録用の情報を読む
+  v_org_id := (NEW.raw_user_meta_data->>'organization_id')::UUID;
+  v_name   := NULLIF(trim(COALESCE(NEW.raw_user_meta_data->>'admin_name', '')), '');
+
+  -- invited_as によるロール判定
+  IF (NEW.raw_user_meta_data->>'invited_as') IS NOT NULL THEN
+    CASE (NEW.raw_user_meta_data->>'invited_as')
+      WHEN 'staff'         THEN v_role := 'staff';
+      WHEN 'admin'         THEN v_role := 'admin';
+      WHEN 'license_admin' THEN v_role := 'license_admin';
+      ELSE                      v_role := 'customer';
+    END CASE;
+  END IF;
+
+  -- users テーブルに挿入（organization_id を含む）
+  -- ON CONFLICT: organization_id は新しい値があれば上書き（招待フローの上書き upsert を妨げない）
+  INSERT INTO public.users (id, email, role, organization_id, created_at, updated_at)
+  VALUES (NEW.id, NEW.email, v_role, v_org_id, NOW(), NOW())
+  ON CONFLICT (id) DO UPDATE SET
+    role            = EXCLUDED.role,
+    organization_id = COALESCE(EXCLUDED.organization_id, users.organization_id),
+    updated_at      = NOW();
+
+  -- 組織自己登録フローのみ: staff レコードを自動作成
+  -- 条件: invited_as='admin' かつ user_metadata に organization_id が設定されている
+  IF v_role = 'admin' AND v_org_id IS NOT NULL THEN
+    INSERT INTO public.staff (
+      name,
+      email,
+      user_id,
+      organization_id,
+      role,
+      status,
+      stores,
+      ng_days,
+      want_to_learn,
+      available_scenarios,
+      availability,
+      experience,
+      special_scenarios
+    ) VALUES (
+      COALESCE(v_name, split_part(NEW.email, '@', 1)),
+      NEW.email,
+      NEW.id,
+      v_org_id,
+      ARRAY['管理者']::TEXT[],
+      'active',
+      '{}'::TEXT[],
+      '{}'::TEXT[],
+      '{}'::TEXT[],
+      '{}'::TEXT[],
+      '{}'::TEXT[],
+      0,
+      '{}'::TEXT[]
+    )
+    ON CONFLICT (user_id) DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- トリガー内のエラーで auth.users 作成がロールバックされないよう、
+  -- エラーをログに残して続行する
+  RAISE WARNING 'handle_new_user: エラーが発生しました (user_id=%, error=%)', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+-- 完了通知
+DO $$
+BEGIN
+  RAISE NOTICE '✅ handle_new_user トリガーを更新しました';
+  RAISE NOTICE '   - user_metadata.organization_id を users テーブルに設定';
+  RAISE NOTICE '   - invited_as=admin かつ organization_id 設定時に staff レコードを自動作成';
+  RAISE NOTICE '   - 既存の招待フロー・顧客登録フローへの影響なし';
+END $$;

--- a/supabase/migrations/20260516050000_add_claim_organization_as_admin_rpc.sql
+++ b/supabase/migrations/20260516050000_add_claim_organization_as_admin_rpc.sql
@@ -1,0 +1,99 @@
+-- =============================================================================
+-- 既存ユーザーが新規組織の管理者になるための RPC
+-- =============================================================================
+-- 用途:
+--   /start 登録ページでログイン済みユーザーが組織を作成する際に使用。
+--   handle_new_user トリガーは signUp 時にしか動かないため、
+--   既存ユーザー向けに別 RPC で role 昇格と staff レコード作成を行う。
+--
+-- セキュリティ:
+--   - authenticated ロールのみ実行可能（anon 不可）
+--   - auth.uid() で本人確認
+--   - 既に organization_id が設定済みの場合はエラー（重複登録防止）
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.claim_organization_as_admin(
+  p_org_id    UUID,
+  p_admin_name TEXT DEFAULT NULL
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id   UUID := auth.uid();
+  v_email     TEXT;
+  v_org_slug  TEXT;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'unauthenticated: ログインが必要です';
+  END IF;
+
+  -- 組織の存在確認
+  SELECT slug INTO v_org_slug
+  FROM public.organizations
+  WHERE id = p_org_id AND is_active = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'org_not_found: 指定された組織が見つかりません';
+  END IF;
+
+  -- 既に別の組織に所属していないか確認
+  IF EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = v_user_id
+      AND organization_id IS NOT NULL
+      AND organization_id != p_org_id
+  ) THEN
+    RAISE EXCEPTION 'already_in_org: このアカウントは既に別の組織に所属しています';
+  END IF;
+
+  -- メールアドレスを取得
+  SELECT email INTO v_email FROM public.users WHERE id = v_user_id;
+
+  -- users レコードを admin に昇格・組織紐付け
+  UPDATE public.users
+  SET
+    role            = 'admin',
+    organization_id = p_org_id,
+    updated_at      = NOW()
+  WHERE id = v_user_id;
+
+  -- staff レコードを作成（未作成の場合のみ）
+  INSERT INTO public.staff (
+    name, email, user_id, organization_id,
+    role, status, stores, ng_days,
+    want_to_learn, available_scenarios, availability,
+    experience, special_scenarios
+  ) VALUES (
+    COALESCE(NULLIF(trim(p_admin_name), ''), split_part(v_email, '@', 1)),
+    v_email,
+    v_user_id,
+    p_org_id,
+    ARRAY['管理者']::TEXT[],
+    'active',
+    '{}', '{}', '{}', '{}', '{}', 0, '{}'
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    organization_id = EXCLUDED.organization_id,
+    role            = EXCLUDED.role,
+    updated_at      = NOW();
+
+  RETURN json_build_object(
+    'org_id',   p_org_id,
+    'org_slug', v_org_slug
+  );
+END;
+$$;
+
+-- authenticated のみ実行可能（anon は不可）
+GRANT EXECUTE ON FUNCTION public.claim_organization_as_admin(UUID, TEXT) TO authenticated;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ claim_organization_as_admin RPC を作成しました';
+  RAISE NOTICE '   - 既存ログイン済みユーザーを新規組織の admin に昇格';
+  RAISE NOTICE '   - staff レコードも自動作成';
+  RAISE NOTICE '   - 重複組織所属チェック付き';
+END $$;

--- a/supabase/migrations/20260516060000_add_booking_site_status.sql
+++ b/supabase/migrations/20260516060000_add_booking_site_status.sql
@@ -1,0 +1,134 @@
+-- =============================================================================
+-- 予約サイト公開申請・承認フロー
+-- =============================================================================
+-- 管理機能は誰でも即利用可能（plan='free'）。
+-- 予約サイト公開（plan='pro'）は MMQ 運営の承認が必要。
+-- organizations テーブルに booking_site_status カラムを追加し
+-- 申請 → 承認 の状態管理を行う。
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. booking_site_status カラムを追加
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.organizations
+  ADD COLUMN IF NOT EXISTS booking_site_status TEXT
+    NOT NULL DEFAULT 'none'
+    CHECK (booking_site_status IN ('none', 'pending', 'approved'));
+
+-- ---------------------------------------------------------------------------
+-- 2. 既存の pro/basic プランは承認済みとして扱う
+-- ---------------------------------------------------------------------------
+UPDATE public.organizations
+  SET booking_site_status = 'approved'
+  WHERE plan IN ('pro', 'basic')
+    AND booking_site_status = 'none';
+
+-- ---------------------------------------------------------------------------
+-- 3. 予約サイト公開を申請する RPC（組織管理者が呼び出す）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.apply_for_booking_site()
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id UUID;
+  v_status TEXT;
+BEGIN
+  -- 呼び出し元の組織を取得
+  SELECT organization_id INTO v_org_id
+  FROM public.users
+  WHERE id = auth.uid();
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'org_not_found: 組織に所属していません';
+  END IF;
+
+  -- 現在のステータスを確認
+  SELECT booking_site_status INTO v_status
+  FROM public.organizations
+  WHERE id = v_org_id;
+
+  IF v_status = 'approved' THEN
+    RAISE EXCEPTION 'already_approved: 既に承認済みです';
+  END IF;
+
+  IF v_status = 'pending' THEN
+    RAISE EXCEPTION 'already_pending: 既に申請中です';
+  END IF;
+
+  -- 申請中に更新
+  UPDATE public.organizations
+    SET booking_site_status = 'pending',
+        updated_at = NOW()
+  WHERE id = v_org_id;
+
+  RETURN json_build_object('status', 'pending', 'org_id', v_org_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.apply_for_booking_site() TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. 申請を承認する RPC（ライセンス管理者のみ呼び出せる）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.approve_booking_site(p_org_id UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- ライセンス管理者チェック
+  IF NOT public.is_license_admin() THEN
+    RAISE EXCEPTION 'forbidden: ライセンス管理者のみ実行できます';
+  END IF;
+
+  UPDATE public.organizations
+    SET booking_site_status = 'approved',
+        plan = 'pro',
+        updated_at = NOW()
+  WHERE id = p_org_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'org_not_found: 組織が見つかりません';
+  END IF;
+
+  RETURN json_build_object('status', 'approved', 'org_id', p_org_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.approve_booking_site(UUID) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. 申請中の組織一覧を返す RPC（ライセンス管理者のみ）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_pending_booking_site_applications()
+RETURNS TABLE (
+  id UUID, name TEXT, slug TEXT, contact_email TEXT,
+  created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id, name, slug, contact_email, created_at, updated_at
+  FROM public.organizations
+  WHERE booking_site_status = 'pending'
+    AND is_active = true
+  ORDER BY updated_at DESC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_pending_booking_site_applications() TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 完了通知
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  RAISE NOTICE '✅ booking_site_status カラムを追加しました';
+  RAISE NOTICE '✅ apply_for_booking_site RPC を作成しました（組織管理者用）';
+  RAISE NOTICE '✅ approve_booking_site RPC を作成しました（ライセンス管理者用）';
+  RAISE NOTICE '✅ get_pending_booking_site_applications RPC を作成しました';
+END $$;

--- a/supabase/migrations/20260517000000_add_email_logs_table.sql
+++ b/supabase/migrations/20260517000000_add_email_logs_table.sql
@@ -1,0 +1,133 @@
+-- =============================================================================
+-- email_logs テーブル
+-- Resendの保持期間（約30日）に依存せず、アプリ側でメール送信履歴を長期保存する
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. email_logs テーブル作成
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.email_logs (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id   UUID        REFERENCES public.organizations(id) ON DELETE SET NULL,
+  reservation_id    UUID        REFERENCES public.reservations(id)  ON DELETE SET NULL,
+  schedule_event_id UUID        REFERENCES public.schedule_events(id) ON DELETE SET NULL,
+  customer_id       UUID        REFERENCES public.users(id)          ON DELETE SET NULL,
+  email_type        TEXT        NOT NULL,
+  to_email          TEXT        NOT NULL,
+  to_name           TEXT,
+  subject           TEXT        NOT NULL,
+  body_text         TEXT,
+  body_html         TEXT,
+  provider          TEXT        NOT NULL DEFAULT 'resend',
+  provider_message_id TEXT,
+  status            TEXT        NOT NULL DEFAULT 'queued'
+                                CHECK (status IN (
+                                  'queued','sent','delivered','opened','clicked',
+                                  'bounced','complained','failed','delivery_delayed'
+                                )),
+  error_message     TEXT,
+  sent_at           TIMESTAMPTZ,
+  delivered_at      TIMESTAMPTZ,
+  opened_at         TIMESTAMPTZ,
+  bounced_at        TIMESTAMPTZ,
+  complained_at     TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT email_logs_email_type_check CHECK (email_type IN (
+    'reservation_confirmed',
+    'reservation_cancelled',
+    'reservation_changed',
+    'reservation_request',
+    'reminder',
+    'gm_notification',
+    'staff_invitation',
+    'waitlist_confirmed',
+    'guest_pin',
+    'performance_cancellation',
+    'license_report',
+    'contact_inquiry',
+    'other'
+  ))
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. インデックス
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_email_logs_org
+  ON public.email_logs (organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_email_logs_provider_message_id
+  ON public.email_logs (provider_message_id)
+  WHERE provider_message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_email_logs_reservation
+  ON public.email_logs (reservation_id)
+  WHERE reservation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_email_logs_status
+  ON public.email_logs (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_email_logs_created_at
+  ON public.email_logs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_email_logs_sent_at
+  ON public.email_logs (sent_at DESC)
+  WHERE sent_at IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. updated_at 自動更新トリガー（set_updated_at_manual を再利用）
+-- ---------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS trg_email_logs_updated_at ON public.email_logs;
+CREATE TRIGGER trg_email_logs_updated_at
+  BEFORE UPDATE ON public.email_logs
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_manual();
+
+-- ---------------------------------------------------------------------------
+-- 4. RLS 設定
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.email_logs ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: license_admin は全組織を閲覧可、admin は自組織のみ閲覧可
+DROP POLICY IF EXISTS "email_logs_select" ON public.email_logs;
+CREATE POLICY "email_logs_select" ON public.email_logs
+  FOR SELECT
+  USING (
+    -- service_role は RLS をバイパスするため実質不要だが明示
+    auth.role() = 'service_role'
+    OR public.is_license_admin()
+    OR (
+      -- 組織管理者は自組織のログのみ閲覧可
+      (SELECT role FROM public.users WHERE id = auth.uid() LIMIT 1) = 'admin'
+      AND organization_id = public.get_user_organization_id()
+    )
+  );
+
+-- INSERT/UPDATE: service_role のみ（service_role は RLS をバイパスするため
+--   INSERT/UPDATE ポリシーを明示しない = authenticated ユーザーは書き込み不可）
+
+-- ---------------------------------------------------------------------------
+-- 5. コメント
+-- ---------------------------------------------------------------------------
+COMMENT ON TABLE public.email_logs IS
+  'メール送信ログ。Resendの保持期間（約30日）に依存せず長期保存する。';
+COMMENT ON COLUMN public.email_logs.email_type IS
+  '送信種別: reservation_confirmed/cancelled/changed/request, reminder, gm_notification, staff_invitation, waitlist_confirmed, guest_pin, performance_cancellation, license_report, contact_inquiry, other';
+COMMENT ON COLUMN public.email_logs.status IS
+  'queued=送信待, sent=送信完了, delivered=配信済, opened=開封, clicked=クリック, bounced=バウンス, complained=苦情, failed=送信失敗, delivery_delayed=遅延';
+COMMENT ON COLUMN public.email_logs.provider_message_id IS
+  'Resend メッセージID (email_id)。Webhook でステータス更新に使用。';
+COMMENT ON COLUMN public.email_logs.body_html IS
+  'HTMLメール本文。PIIを含む可能性があるため閲覧制限に注意。';
+COMMENT ON COLUMN public.email_logs.body_text IS
+  'テキストメール本文。PIIを含む可能性があるため閲覧制限に注意。';
+
+-- ---------------------------------------------------------------------------
+-- 完了通知
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  RAISE NOTICE '✅ email_logs テーブルを作成しました';
+  RAISE NOTICE '   - organization_id / provider_message_id / reservation_id / status / created_at インデックス追加済み';
+  RAISE NOTICE '   - RLS: license_admin=全閲覧, admin=自組織のみ, service_role=書き込み';
+END $$;


### PR DESCRIPTION
## Summary

- **React Query 導入**: `@tanstack/react-query` + IndexedDB永続化で画面切替後も即表示
- **スケジュール**: `staleTime: Infinity` + Realtimeで安定・高速表示。ページ移動後もデータ維持
- **スタッフ・シナリオ・組織情報**: React Queryでキャッシュ化、再取得なし
- **サイドバー**: カテゴリ展開アニメーション修正・「基本データ」グループ追加
- **貸切管理**: 候補日行を直接クリック可能に・店舗/GMバッジの表示改善
- **メールログ**: Resend依存を排除する長期保存テーブル実装
- **その他**: `/register` → `/start` リダイレクト対応

## 主な技術変更

| ファイル | 変更内容 |
|---|---|
| `AppRoot.tsx` | QueryClient設定・IndexedDB永続化 |
| `useScheduleEventsQuery.ts` | スケジュールデータのReact Query化 |
| `useOrganization.ts` | 組織情報のReact Query化 |
| `StaffManagement/hooks/useStaffQuery.ts` | スタッフのReact Query化 |
| `ScenarioManagement/hooks/useScenarioQuery.ts` | シナリオのReact Query化 |

## Test plan

- [ ] スケジュールページ → 他ページ → スケジュールページに戻る（即表示されること）
- [ ] スタッフ管理・シナリオ管理でページ再訪時のローディングがないこと
- [ ] 貸切管理の候補日選択・店舗/GM表示が正常に動くこと
- [ ] サイドバーのカテゴリ展開アニメーションが正常に動くこと
- [ ] `/register` にアクセスすると `/start` にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)