### PR TITLE
feat: 主要管理ページを React Query 化（ページ即時表示）

### DIFF
--- a/src/pages/CouponManagement/hooks/useCouponCampaigns.ts
+++ b/src/pages/CouponManagement/hooks/useCouponCampaigns.ts
@@ -1,0 +1,22 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { getCampaigns } from '@/lib/api/couponApi'
+import type { CouponCampaign } from '@/types'
+
+export const couponKeys = {
+  campaigns: ['coupon-campaigns'] as const,
+}
+
+export function useCouponCampaigns() {
+  const queryClient = useQueryClient()
+
+  const { data: campaigns = [], isLoading } = useQuery<CouponCampaign[]>({
+    queryKey: couponKeys.campaigns,
+    queryFn: getCampaigns,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const refetch = () =>
+    queryClient.invalidateQueries({ queryKey: couponKeys.campaigns })
+
+  return { campaigns, isLoading, refetch }
+}

--- a/src/pages/CouponManagement/index.tsx
+++ b/src/pages/CouponManagement/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { Header } from '@/components/layout/Header'
 import { AdminSidebar } from '@/components/layout/AdminSidebar'
 import { Button } from '@/components/ui/button'
@@ -6,18 +6,18 @@ import { Plus, RefreshCw, Ticket } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useNavigate } from 'react-router-dom'
 import { useOrganization } from '@/hooks/useOrganization'
-import { 
-  getCampaigns, 
-  createCampaign, 
-  updateCampaign, 
+import {
+  createCampaign,
+  updateCampaign,
   toggleCampaignActive,
-  type CampaignFormData 
+  type CampaignFormData
 } from '@/lib/api/couponApi'
 import type { CouponCampaign } from '@/types'
 import { CampaignList } from './components/CampaignList'
 import { CampaignDialog } from './components/CampaignDialog'
 import { GrantCouponDialog } from './components/GrantCouponDialog'
 import { CampaignStats } from './components/CampaignStats'
+import { useCouponCampaigns } from './hooks/useCouponCampaigns'
 import { toast } from 'sonner'
 
 export function CouponManagement() {
@@ -25,8 +25,7 @@ export function CouponManagement() {
   const navigate = useNavigate()
   const { organization } = useOrganization()
 
-  const [campaigns, setCampaigns] = useState<CouponCampaign[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const { campaigns, isLoading, refetch: loadCampaigns } = useCouponCampaigns()
   const [toggleLoading, setToggleLoading] = useState<string | null>(null)
 
   const [editDialogOpen, setEditDialogOpen] = useState(false)
@@ -37,23 +36,6 @@ export function CouponManagement() {
 
   const [statsDialogOpen, setStatsDialogOpen] = useState(false)
   const [statsCampaign, setStatsCampaign] = useState<CouponCampaign | null>(null)
-
-  const loadCampaigns = useCallback(async () => {
-    setIsLoading(true)
-    try {
-      const data = await getCampaigns()
-      setCampaigns(data)
-    } catch (error) {
-      console.error('キャンペーン取得エラー:', error)
-      toast.error('キャンペーンの取得に失敗しました')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    loadCampaigns()
-  }, [loadCampaigns])
 
   const handlePageChange = useCallback((pageId: string) => {
     const slug = organization?.slug || ''
@@ -101,9 +83,7 @@ export function CouponManagement() {
     try {
       const result = await toggleCampaignActive(campaign.id)
       if (result.success) {
-        setCampaigns(prev => prev.map(c => 
-          c.id === campaign.id ? { ...c, is_active: result.isActive! } : c
-        ))
+        loadCampaigns()
         toast.success(result.isActive ? 'キャンペーンを有効にしました' : 'キャンペーンを無効にしました')
       } else {
         toast.error(result.error || '状態の変更に失敗しました')

--- a/src/pages/CustomerManagement/hooks/useCustomerData.ts
+++ b/src/pages/CustomerManagement/hooks/useCustomerData.ts
@@ -1,164 +1,134 @@
-import { useState, useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '@/lib/supabase'
 import { getCurrentOrganizationId } from '@/lib/organization'
 import type { Customer } from '@/types'
 import { logger } from '@/utils/logger'
-import { showToast } from '@/utils/toast'
 
 export interface CustomerCouponStats {
-  total_coupons: number      // 取得したクーポン総数（uses_remaining の初期値の合計）
-  used_coupons: number       // 使用済みクーポン数
-  remaining_coupons: number  // 残りクーポン数
+  total_coupons: number
+  used_coupons: number
+  remaining_coupons: number
+}
+
+interface CustomerDataResult {
+  customers: Customer[]
+  couponStats: Record<string, CustomerCouponStats>
+}
+
+export const customerKeys = {
+  all: ['customers'] as const,
+}
+
+async function fetchCustomersWithStats(): Promise<CustomerDataResult> {
+  logger.log('顧客データ取得開始')
+  const orgId = await getCurrentOrganizationId()
+  const PAGE_SIZE = 1000
+
+  // 顧客一覧をページネーションで全件取得
+  let allCustomers: any[] = []
+  let from = 0
+  for (;;) {
+    let query = supabase
+      .from('customers')
+      .select('id, organization_id, user_id, name, nickname, email, email_verified, phone, address, line_id, notes, avatar_url, visit_count, total_spent, last_visit, preferences, notification_settings, created_at, updated_at')
+      .order('created_at', { ascending: false })
+      .range(from, from + PAGE_SIZE - 1)
+    if (orgId) query = query.eq('organization_id', orgId)
+    const { data: pageData, error } = await query
+    if (error) throw error
+    allCustomers = allCustomers.concat(pageData || [])
+    if ((pageData || []).length < PAGE_SIZE) break
+    from += PAGE_SIZE
+  }
+
+  const customerIds = allCustomers.map(c => c.id)
+  const reservationStats: Record<string, { total_paid: number; reservation_count: number; last_visit: string | null; visit_count: number }> = {}
+  const couponStats: Record<string, CustomerCouponStats> = {}
+
+  if (customerIds.length > 0) {
+    // 予約統計をページネーションで全件取得
+    let allReservations: any[] = []
+    let resFrom = 0
+    for (;;) {
+      let resQuery = supabase
+        .from('reservations')
+        .select('customer_id, total_price, status, requested_datetime')
+        .in('customer_id', customerIds)
+        .in('status', ['confirmed', 'gm_confirmed', 'completed'])
+        .range(resFrom, resFrom + PAGE_SIZE - 1)
+      if (orgId) resQuery = resQuery.eq('organization_id', orgId)
+      const { data: resPage } = await resQuery
+      allReservations = allReservations.concat(resPage || [])
+      if ((resPage || []).length < PAGE_SIZE) break
+      resFrom += PAGE_SIZE
+    }
+
+    allReservations.forEach(res => {
+      if (!res.customer_id) return
+      if (!reservationStats[res.customer_id]) {
+        reservationStats[res.customer_id] = { total_paid: 0, reservation_count: 0, last_visit: null, visit_count: 0 }
+      }
+      reservationStats[res.customer_id].total_paid += res.total_price || 0
+      reservationStats[res.customer_id].reservation_count += 1
+      if (res.requested_datetime) {
+        const prev = reservationStats[res.customer_id].last_visit
+        if (!prev || res.requested_datetime > prev) {
+          reservationStats[res.customer_id].last_visit = res.requested_datetime
+        }
+      }
+      if (res.status === 'completed') {
+        reservationStats[res.customer_id].visit_count += 1
+      }
+    })
+
+    // クーポン統計
+    const { data: coupons, error: couponError } = await supabase
+      .from('customer_coupons')
+      .select('id, customer_id, uses_remaining, status, coupon_campaigns (max_uses_per_customer)')
+      .in('customer_id', customerIds)
+    if (couponError) logger.error('クーポン取得エラー:', couponError)
+
+    coupons?.forEach((coupon: any) => {
+      if (!coupon.customer_id) return
+      if (!couponStats[coupon.customer_id]) {
+        couponStats[coupon.customer_id] = { total_coupons: 0, used_coupons: 0, remaining_coupons: 0 }
+      }
+      const maxUses = coupon.coupon_campaigns?.max_uses_per_customer || 0
+      const remaining = coupon.uses_remaining || 0
+      couponStats[coupon.customer_id].total_coupons += maxUses
+      couponStats[coupon.customer_id].used_coupons += maxUses - remaining
+      couponStats[coupon.customer_id].remaining_coupons += remaining
+    })
+  }
+
+  const customers = allCustomers.map(customer => ({
+    ...customer,
+    total_spent: reservationStats[customer.id]?.total_paid || customer.total_spent || 0,
+    reservation_count: reservationStats[customer.id]?.reservation_count || 0,
+    last_visit: reservationStats[customer.id]?.last_visit ?? customer.last_visit ?? null,
+    visit_count: reservationStats[customer.id]?.visit_count ?? customer.visit_count ?? 0,
+  }))
+
+  logger.log('顧客データ取得完了:', customers.length)
+  return { customers, couponStats }
 }
 
 export function useCustomerData() {
-  const [customers, setCustomers] = useState<Customer[]>([])
-  const [loading, setLoading] = useState(true)
-  const [couponStats, setCouponStats] = useState<Record<string, CustomerCouponStats>>({})
+  const queryClient = useQueryClient()
 
-  const fetchCustomers = async () => {
-    setLoading(true)
-    try {
-      logger.log('顧客データ取得開始')
+  const { data, isLoading } = useQuery<CustomerDataResult>({
+    queryKey: customerKeys.all,
+    queryFn: fetchCustomersWithStats,
+    staleTime: 3 * 60 * 1000, // 3分間キャッシュ
+  })
 
-      // 組織フィルタリング
-      const orgId = await getCurrentOrganizationId()
-
-      // Supabase のデフォルト上限（1000件）を超える場合にすべて取得するためページネーション
-      const PAGE_SIZE = 1000
-      let allCustomers: any[] = []
-      let from = 0
-      for (;;) {
-        let query = supabase
-          .from('customers')
-          .select('id, organization_id, user_id, name, nickname, email, email_verified, phone, address, line_id, notes, avatar_url, visit_count, total_spent, last_visit, preferences, notification_settings, created_at, updated_at')
-          .order('created_at', { ascending: false })
-          .range(from, from + PAGE_SIZE - 1)
-        if (orgId) {
-          query = query.eq('organization_id', orgId)
-        }
-        const { data: pageData, error } = await query
-        if (error) throw error
-        allCustomers = allCustomers.concat(pageData || [])
-        if ((pageData || []).length < PAGE_SIZE) break
-        from += PAGE_SIZE
-      }
-      const data = allCustomers
-
-      // 予約データから累計支払額と予約数を集計
-      const customerIds = data.map(c => c.id)
-      const reservationStats: Record<string, { total_paid: number; reservation_count: number; last_visit: string | null; visit_count: number }> = {}
-      const couponStatsMap: Record<string, CustomerCouponStats> = {}
-
-      if (customerIds.length > 0) {
-        let allReservations: any[] = []
-        let resFrom = 0
-        for (;;) {
-          let resQuery = supabase
-            .from('reservations')
-            .select('customer_id, total_price, status, requested_datetime')
-            .in('customer_id', customerIds)
-            .in('status', ['confirmed', 'gm_confirmed', 'completed'])
-            .range(resFrom, resFrom + PAGE_SIZE - 1)
-          if (orgId) {
-            resQuery = resQuery.eq('organization_id', orgId)
-          }
-          const { data: resPage } = await resQuery
-          allReservations = allReservations.concat(resPage || [])
-          if ((resPage || []).length < PAGE_SIZE) break
-          resFrom += PAGE_SIZE
-        }
-        const reservations = allReservations
-
-        if (reservations) {
-          reservations.forEach(res => {
-            if (res.customer_id) {
-              if (!reservationStats[res.customer_id]) {
-                reservationStats[res.customer_id] = { total_paid: 0, reservation_count: 0, last_visit: null, visit_count: 0 }
-              }
-              reservationStats[res.customer_id].total_paid += res.total_price || 0
-              reservationStats[res.customer_id].reservation_count += 1
-              if (res.requested_datetime) {
-                const prev = reservationStats[res.customer_id].last_visit
-                if (!prev || res.requested_datetime > prev) {
-                  reservationStats[res.customer_id].last_visit = res.requested_datetime
-                }
-              }
-              if (res.status === 'completed') {
-                reservationStats[res.customer_id].visit_count += 1
-              }
-            }
-          })
-        }
-
-        // クーポン情報を取得（組織フィルタなし - クーポンは複数組織で共有される可能性がある）
-        const { data: coupons, error: couponError } = await supabase
-          .from('customer_coupons')
-          .select(`
-            id,
-            customer_id,
-            uses_remaining,
-            status,
-            coupon_campaigns (max_uses_per_customer)
-          `)
-          .in('customer_id', customerIds)
-        
-        if (couponError) {
-          logger.error('クーポン取得エラー:', couponError)
-        }
-        logger.log('取得したクーポン数:', coupons?.length, coupons)
-        
-        if (coupons) {
-          coupons.forEach((coupon: any) => {
-            if (coupon.customer_id) {
-              if (!couponStatsMap[coupon.customer_id]) {
-                couponStatsMap[coupon.customer_id] = { total_coupons: 0, used_coupons: 0, remaining_coupons: 0 }
-              }
-              const maxUses = coupon.coupon_campaigns?.max_uses_per_customer || 0
-              const remaining = coupon.uses_remaining || 0
-              const used = maxUses - remaining
-              
-              couponStatsMap[coupon.customer_id].total_coupons += maxUses
-              couponStatsMap[coupon.customer_id].used_coupons += used
-              couponStatsMap[coupon.customer_id].remaining_coupons += remaining
-            }
-          })
-        }
-      }
-
-      // 顧客データに予約統計をマージ
-      const customersWithStats = (data || []).map(customer => ({
-        ...customer,
-        total_spent: reservationStats[customer.id]?.total_paid || customer.total_spent || 0,
-        reservation_count: reservationStats[customer.id]?.reservation_count || 0,
-        last_visit: reservationStats[customer.id]?.last_visit ?? customer.last_visit ?? null,
-        visit_count: reservationStats[customer.id]?.visit_count ?? customer.visit_count ?? 0,
-      }))
-
-      logger.log('顧客データ取得完了:', customersWithStats.length)
-      setCustomers(customersWithStats)
-      setCouponStats(couponStatsMap)
-    } catch (error) {
-      logger.error('顧客データ取得エラー:', error)
-      showToast.error('顧客データの取得に失敗しました')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    fetchCustomers()
-  }, [])
-
-  const refreshCustomers = () => {
-    fetchCustomers()
-  }
+  const refreshCustomers = () =>
+    queryClient.invalidateQueries({ queryKey: customerKeys.all })
 
   return {
-    customers,
-    loading,
-    couponStats,
+    customers: data?.customers ?? [],
+    loading: isLoading,
+    couponStats: data?.couponStats ?? {},
     refreshCustomers,
   }
 }
-

--- a/src/pages/ExternalReports/hooks/useExternalReports.ts
+++ b/src/pages/ExternalReports/hooks/useExternalReports.ts
@@ -1,39 +1,28 @@
 /**
  * 外部公演報告を取得するフック
  */
-import { logger } from '@/utils/logger'
-import { useState, useEffect, useCallback } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getMyExternalReports } from '@/lib/api/externalReportsApi'
 import type { ExternalPerformanceReport } from '@/types'
 
+export const externalReportKeys = {
+  all: ['external-reports'] as const,
+}
+
 export function useExternalReports() {
-  const [reports, setReports] = useState<ExternalPerformanceReport[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<Error | null>(null)
+  const queryClient = useQueryClient()
 
-  const fetchReports = useCallback(async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      const data = await getMyExternalReports()
-      setReports(data)
-    } catch (err) {
-      logger.error('Failed to fetch external reports:', err)
-      setError(err instanceof Error ? err : new Error('Unknown error'))
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
+  const { data: reports = [], isLoading, error } = useQuery<ExternalPerformanceReport[], Error>({
+    queryKey: externalReportKeys.all,
+    queryFn: getMyExternalReports,
+  })
 
-  useEffect(() => {
-    fetchReports()
-  }, [fetchReports])
+  const refetch = () => queryClient.invalidateQueries({ queryKey: externalReportKeys.all })
 
   return {
     reports,
     isLoading,
-    error,
-    refetch: fetchReports,
+    error: error ?? null,
+    refetch,
   }
 }
-

--- a/src/pages/GMAvailabilityCheck/hooks/useGMRequests.ts
+++ b/src/pages/GMAvailabilityCheck/hooks/useGMRequests.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '@/lib/supabase'
 import { sanitizeForPostgRestFilter } from '@/lib/utils'
 import * as storeApi from '@/lib/api'
@@ -40,261 +41,201 @@ interface UseGMRequestsProps {
   userId?: string
 }
 
-/**
- * GMリクエストデータ取得・管理フック
- */
-export function useGMRequests({ userId }: UseGMRequestsProps) {
-  const [requests, setRequests] = useState<GMRequest[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [stores, setStores] = useState<any[]>([])
-  const [staffName, setStaffName] = useState<string>('')
-  const [activeTab, setActiveTab] = useState<'pending' | 'all'>('pending')
-  const [currentDate, setCurrentDate] = useState(new Date())
-  const [selectedCandidates, setSelectedCandidates] = useState<Record<string, number[]>>({})
-  const [notes, setNotes] = useState<Record<string, string>>({})
+export const gmRequestKeys = {
+  byUser: (userId: string) => ['gm-requests', userId] as const,
+  stores: ['gm-request-stores'] as const,
+}
 
-  /**
-   * 店舗データ取得
-   */
-  const loadStores = async () => {
-    try {
-      const storesData = await storeApi.storeApi.getAll()
-      setStores(storesData)
-    } catch (error) {
-      logger.error('店舗データ取得エラー:', error)
-    }
+async function fetchGMRequestsForUser(userId: string): Promise<{ requests: GMRequest[]; staffName: string }> {
+  const { data: staffData, error: staffError } = await supabase
+    .from('staff')
+    .select('id, discord_id:discord_user_id, name')
+    .eq('user_id', userId)
+    .single()
+
+  if (staffError || !staffData) {
+    logger.error('スタッフ情報取得エラー:', staffError)
+    return { requests: [], staffName: '' }
   }
 
-  /**
-   * GMリクエスト取得
-   */
-  const loadGMRequests = async () => {
-    if (!userId) return
-    
-    try {
-      setIsLoading(true)
-      
-      // 現在のユーザーのstaff_idを取得
-      const { data: staffData, error: staffError } = await supabase
-        .from('staff')
-        .select('id, discord_id:discord_user_id, name')
-        .eq('user_id', userId)
-        .single()
-      
-      if (staffError) {
-        logger.error('スタッフ情報取得エラー:', staffError)
-        setRequests([])
-        setIsLoading(false)
-        return
-      }
-      
-      if (!staffData) {
-        logger.error('このユーザーにはスタッフ情報が紐付けられていません')
-        setRequests([])
-        setIsLoading(false)
-        return
-      }
-      
-      const staffId = staffData.id
-      setStaffName(staffData.name || '')
-      
-      // このGMに送られた確認リクエストを取得
-      const { data: responsesData, error: responsesError } = await supabase
-        .from('gm_availability_responses')
-        .select(`
+  const staffId = staffData.id
+
+  const { data: responsesData, error: responsesError } = await supabase
+    .from('gm_availability_responses')
+    .select(`
+      id,
+      reservation_id,
+      response_status,
+      available_candidates,
+      notes,
+      response_type,
+      selected_candidate_index,
+      gm_discord_id,
+      gm_name,
+      response_datetime,
+      reservations:reservation_id (
+        reservation_number,
+        title,
+        customer_name,
+        candidate_datetimes,
+        status,
+        store_id,
+        created_at,
+        stores:store_id (
           id,
-          reservation_id,
-          response_status,
-          available_candidates,
-          notes,
-          response_type,
-          selected_candidate_index,
-          gm_discord_id,
-          gm_name,
-          response_datetime,
-          reservations:reservation_id (
-            reservation_number,
-            title,
-            customer_name,
-            candidate_datetimes,
-            status,
-            store_id,
-            created_at,
-            stores:store_id (
-              id,
-              name,
-              short_name
-            )
-          )
-        `)
-        .or(`staff_id.eq.${sanitizeForPostgRestFilter(staffId) || staffId}${staffData.discord_id ? `,gm_discord_id.eq.${sanitizeForPostgRestFilter(staffData.discord_id) || staffData.discord_id}` : ''}`)
-        .order('response_datetime', { ascending: false })
-      
-      if (responsesError) {
-        logger.error('GMリクエスト取得エラー:', responsesError)
-        setRequests([])
-        return
+          name,
+          short_name
+        )
+      )
+    `)
+    .or(`staff_id.eq.${sanitizeForPostgRestFilter(staffId) || staffId}${staffData.discord_id ? `,gm_discord_id.eq.${sanitizeForPostgRestFilter(staffData.discord_id) || staffData.discord_id}` : ''}`)
+    .order('response_datetime', { ascending: false })
+
+  if (responsesError) {
+    logger.error('GMリクエスト取得エラー:', responsesError)
+    return { requests: [], staffName: staffData.name || '' }
+  }
+
+  const reservationIds = (responsesData || []).map((r: any) => r.reservation_id).filter(Boolean)
+  const otherGMResponses = new Set<string>()
+
+  if (reservationIds.length > 0) {
+    const { data: allResponsesData } = await supabase
+      .from('gm_availability_responses')
+      .select('reservation_id, response_status, staff_id')
+      .in('reservation_id', reservationIds)
+      .neq('staff_id', staffId)
+      .in('response_status', ['available', 'all_unavailable'])
+
+    allResponsesData?.forEach((r: any) => {
+      if (r.response_status && r.response_status !== 'pending') {
+        otherGMResponses.add(r.reservation_id)
       }
-      
-      logger.log('🔍 GM確認ページ - 取得したデータ:', {
-        staffId,
-        staffDiscordId: staffData.discord_id,
-        responsesCount: responsesData?.length || 0,
-        responsesData: responsesData
-      })
-      
-      // 同じreservation_idに対する他のGMの回答をチェック
-      const reservationIds = (responsesData || []).map((r: any) => r.reservation_id).filter(Boolean)
-      
-      const otherGMResponses: Set<string> = new Set()
-      
-      if (reservationIds.length > 0) {
-        const { data: allResponsesData } = await supabase
-          .from('gm_availability_responses')
-          .select('reservation_id, response_status, staff_id')
-          .in('reservation_id', reservationIds)
-          .neq('staff_id', staffId)
-          .in('response_status', ['available', 'all_unavailable'])
-        
-        if (allResponsesData) {
-          allResponsesData.forEach((r: any) => {
-            if (r.response_status && r.response_status !== 'pending') {
-              otherGMResponses.add(r.reservation_id)
-            }
-          })
+    })
+  }
+
+  const requests: GMRequest[] = (responsesData || []).map((response: any) => {
+    let candidateDatetimes = response.reservations?.candidate_datetimes || { candidates: [] }
+
+    if ((!candidateDatetimes.requestedStores || candidateDatetimes.requestedStores.length === 0) && response.reservations?.store_id) {
+      const storeInfo = response.reservations.stores
+      if (storeInfo) {
+        candidateDatetimes = {
+          ...candidateDatetimes,
+          requestedStores: [{ storeId: storeInfo.id, storeName: storeInfo.name, storeShortName: storeInfo.short_name }],
         }
       }
-      
-      // データを整形
-      const formattedRequests: GMRequest[] = (responsesData || []).map((response: any) => {
-        const hasOtherGMResponse = otherGMResponses.has(response.reservation_id)
-        
-        let candidateDatetimes = response.reservations?.candidate_datetimes || { candidates: [] }
-        
-        // requestedStoresが空で、store_idがある場合は補完
-        if ((!candidateDatetimes.requestedStores || candidateDatetimes.requestedStores.length === 0) && response.reservations?.store_id) {
-          const storeInfo = response.reservations.stores
-          if (storeInfo) {
-            candidateDatetimes = {
-              ...candidateDatetimes,
-              requestedStores: [{
-                storeId: storeInfo.id,
-                storeName: storeInfo.name,
-                storeShortName: storeInfo.short_name
-              }]
-            }
-          }
-        }
-        
-        return {
-          id: response.id,
-          reservation_id: response.reservation_id,
-          reservation_number: response.reservations?.reservation_number || '',
-          scenario_title: response.reservations?.title || '',
-          customer_name: response.reservations?.customer_name || '',
-          candidate_datetimes: candidateDatetimes,
-          response_status: response.response_status || 'pending',
-          available_candidates: response.available_candidates || [],
-          notes: response.notes || '',
-          reservation_status: response.reservations?.status || 'pending',
-          has_other_gm_response: hasOtherGMResponse,
-          created_at: response.reservations?.created_at || new Date().toISOString()
-        }
-      })
-      
-      setRequests(formattedRequests)
-      
-      // 既に回答済みのリクエストは選択状態を復元
+    }
+
+    return {
+      id: response.id,
+      reservation_id: response.reservation_id,
+      reservation_number: response.reservations?.reservation_number || '',
+      scenario_title: response.reservations?.title || '',
+      customer_name: response.reservations?.customer_name || '',
+      candidate_datetimes: candidateDatetimes,
+      response_status: response.response_status || 'pending',
+      available_candidates: response.available_candidates || [],
+      notes: response.notes || '',
+      reservation_status: response.reservations?.status || 'pending',
+      has_other_gm_response: otherGMResponses.has(response.reservation_id),
+      created_at: response.reservations?.created_at || new Date().toISOString(),
+    }
+  })
+
+  logger.log('🔍 GM確認ページ - 取得完了:', requests.length, '件')
+  return { requests, staffName: staffData.name || '' }
+}
+
+export function useGMRequests({ userId }: UseGMRequestsProps) {
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: userId ? gmRequestKeys.byUser(userId) : ['gm-requests-disabled'],
+    queryFn: () => fetchGMRequestsForUser(userId!),
+    enabled: !!userId,
+    staleTime: 2 * 60 * 1000, // 2分間キャッシュ
+  })
+
+  const { data: stores = [] } = useQuery({
+    queryKey: gmRequestKeys.stores,
+    queryFn: () => storeApi.storeApi.getAll(),
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const requests = data?.requests ?? []
+  const staffName = data?.staffName ?? ''
+
+  // 回答済みリクエストの初期選択状態を復元（データ初回取得時のみ）
+  const [selectedCandidates, setSelectedCandidates] = useState<Record<string, number[]>>({})
+  const [notes, setNotes] = useState<Record<string, string>>({})
+  const initializedRef = useRef(false)
+
+  useEffect(() => {
+    if (requests.length > 0 && !initializedRef.current) {
+      initializedRef.current = true
       const initialSelections: Record<string, number[]> = {}
       const initialNotes: Record<string, string> = {}
-      formattedRequests.forEach(req => {
-        if (req.available_candidates && req.available_candidates.length > 0) {
-          initialSelections[req.id] = req.available_candidates
-        }
-        if (req.notes) {
-          initialNotes[req.id] = req.notes
-        }
+      requests.forEach(req => {
+        if (req.available_candidates?.length > 0) initialSelections[req.id] = req.available_candidates
+        if (req.notes) initialNotes[req.id] = req.notes
       })
       setSelectedCandidates(initialSelections)
       setNotes(initialNotes)
-      
-    } catch (error) {
-      logger.error('データ読み込みエラー:', error)
-      setRequests([])
-    } finally {
-      setIsLoading(false)
+    }
+  }, [requests])
+
+  const [activeTab, setActiveTab] = useState<'pending' | 'all'>('pending')
+  const [currentDate, setCurrentDate] = useState(new Date())
+
+  const loadGMRequests = () => {
+    if (userId) {
+      initializedRef.current = false
+      queryClient.invalidateQueries({ queryKey: gmRequestKeys.byUser(userId) })
     }
   }
 
-  /**
-   * 候補日時の選択をトグル
-   */
+  const loadStores = () =>
+    queryClient.invalidateQueries({ queryKey: gmRequestKeys.stores })
+
   const toggleCandidate = (requestId: string, candidateOrder: number) => {
     const current = selectedCandidates[requestId] || []
     const newSelection = current.includes(candidateOrder)
       ? current.filter(c => c !== candidateOrder)
       : [...current, candidateOrder]
-    
-    setSelectedCandidates({
-      ...selectedCandidates,
-      [requestId]: newSelection
-    })
+    setSelectedCandidates({ ...selectedCandidates, [requestId]: newSelection })
   }
 
-  /**
-   * 月でフィルタリング
-   */
   const filterByMonth = (reqs: GMRequest[]) => {
     const year = currentDate.getFullYear()
     const month = currentDate.getMonth() + 1
-    
-    return reqs.filter(req => {
-      const candidates = req.candidate_datetimes?.candidates || []
-      return candidates.some(c => {
+    return reqs.filter(req =>
+      req.candidate_datetimes?.candidates?.some(c => {
         const [cYear, cMonth] = c.date.split('-').map(Number)
         return cYear === year && cMonth === month
       })
-    })
+    )
   }
 
-  /**
-   * フィルタリングされたリクエスト
-   */
-  const pendingRequests = requests.filter(r => 
-    r.response_status === 'pending' || 
-    r.response_status === null || 
+  const pendingRequests = requests.filter(r =>
+    r.response_status === 'pending' ||
+    r.response_status === null ||
     r.response_status === '' ||
     r.response_status === 'available'
   )
 
   const allRequests = filterByMonth(requests)
 
-  /**
-   * 月ナビゲーション
-   */
-  const handlePrevMonth = () => {
+  const handlePrevMonth = () =>
     setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1))
-  }
 
-  const handleNextMonth = () => {
+  const handleNextMonth = () =>
     setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1))
-  }
 
-  const formatMonthYear = (date: Date) => {
-    return `${date.getFullYear()}年${date.getMonth() + 1}月`
-  }
-
-  // 初期データ読み込み
-  useEffect(() => {
-    if (userId) {
-      loadGMRequests()
-      loadStores()
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userId])
+  const formatMonthYear = (date: Date) =>
+    `${date.getFullYear()}年${date.getMonth() + 1}月`
 
   return {
-    // 状態
     requests,
     isLoading,
     stores,
@@ -307,21 +248,14 @@ export function useGMRequests({ userId }: UseGMRequestsProps) {
     setSelectedCandidates,
     notes,
     setNotes,
-    
-    // 関数
     loadGMRequests,
     loadStores,
     toggleCandidate,
     filterByMonth,
-    
-    // フィルタリング結果
     pendingRequests,
     allRequests,
-    
-    // ナビゲーション (非推奨: MonthSwitcher使用を推奨)
     handlePrevMonth,
     handleNextMonth,
-    formatMonthYear
+    formatMonthYear,
   }
 }
-

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -202,14 +202,14 @@ export const BookingRequestCard = ({
                   </Button>
                 )}
               </div>
-              <div className="flex flex-wrap gap-x-3 gap-y-1.5">
+              <ul className="space-y-1">
                 {request.gm_responses.map((response, index) => {
                   const responded = hasGmResponded(response)
                   const available = isGmMarkedAvailable(response)
                   const candidates = response.available_candidates
                   return (
-                    <div key={index} className="flex flex-col gap-0.5">
-                      <span className={`text-xs flex items-center gap-0.5 ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
+                    <li key={index} className="flex flex-col gap-0.5">
+                      <span className={`text-xs flex items-center gap-1 ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
                         {!responded
                           ? <Clock className="w-3 h-3 shrink-0" />
                           : available
@@ -218,18 +218,18 @@ export const BookingRequestCard = ({
                         }
                         {response.gm_name || 'GM名不明'}
                         {responded && available && (candidates?.length ?? 0) > 0 && (
-                          <span className="text-purple-500 ml-0.5">({candidates!.map(i => i + 1).join(',')})</span>
+                          <span className="text-purple-500">({candidates!.map(i => i + 1).join(',')})</span>
                         )}
                       </span>
                       {responded && response.notes && (
-                        <span className="text-xs text-purple-600 pl-4 whitespace-pre-wrap flex items-start gap-0.5">
+                        <span className="text-xs text-purple-600 pl-4 whitespace-pre-wrap flex items-start gap-1">
                           <MessageCircle className="w-3 h-3 shrink-0 mt-0.5" />{response.notes}
                         </span>
                       )}
-                    </div>
+                    </li>
                   )
                 })}
-              </div>
+              </ul>
             </div>
           )}
 

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -4,14 +4,12 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
-  CheckCircle2, CircleDashed, XCircle, Clock, MessageCircle,
+  CheckCircle2, CircleDashed, XCircle, Clock,
   RefreshCw, Copy, Check, Mail, Phone
 } from 'lucide-react'
 import { StatusBadge } from './StatusBadge'
 import {
   formatDate,
-  formatGmReplyReceivedAt,
-  pickGmReplyIsoString,
   getElapsedTime,
   getElapsedDays,
   getCardClassName,
@@ -208,23 +206,17 @@ export const BookingRequestCard = ({
                   const available = isGmMarkedAvailable(response)
                   const candidates = response.available_candidates
                   return (
-                    <li key={index} className="flex flex-col gap-0.5">
-                      <span className={`text-xs flex items-center gap-1 ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
-                        {!responded
-                          ? <Clock className="w-3 h-3 shrink-0" />
-                          : available
-                            ? <CheckCircle2 className="w-3 h-3 shrink-0 text-green-600" />
-                            : <XCircle className="w-3 h-3 shrink-0 text-gray-400" />
-                        }
-                        {response.gm_name || 'GM名不明'}
-                        {responded && available && (candidates?.length ?? 0) > 0 && (
-                          <span className="text-purple-500">({candidates!.map(i => i + 1).join(',')})</span>
-                        )}
-                      </span>
-                      {responded && response.notes && (
-                        <span className="text-xs text-purple-600 pl-4 whitespace-pre-wrap flex items-start gap-1">
-                          <MessageCircle className="w-3 h-3 shrink-0 mt-0.5" />{response.notes}
-                        </span>
+                    <li key={index} className={`text-xs flex items-center gap-1 ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
+                      {!responded
+                        ? <Clock className="w-3 h-3 shrink-0" />
+                        : available
+                          ? <CheckCircle2 className="w-3 h-3 shrink-0 text-green-600" />
+                          : <XCircle className="w-3 h-3 shrink-0 text-gray-400" />
+                      }
+                      {response.gm_name || 'GM名不明'}
+                      {!responded && <span className="text-gray-400">未回答</span>}
+                      {responded && available && (candidates?.length ?? 0) > 0 && (
+                        <span className="text-purple-500">({candidates!.map(i => i + 1).join(',')})</span>
                       )}
                     </li>
                   )

--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
-  CheckCircle2, CircleDashed,
+  CheckCircle2, CircleDashed, XCircle, Clock, MessageCircle,
   RefreshCw, Copy, Check, Mail, Phone
 } from 'lucide-react'
 import { StatusBadge } from './StatusBadge'
@@ -209,15 +209,22 @@ export const BookingRequestCard = ({
                   const candidates = response.available_candidates
                   return (
                     <div key={index} className="flex flex-col gap-0.5">
-                      <span className={`text-xs ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
-                        {!responded ? '⏳' : available ? '✅' : '❌'}
-                        {' '}{response.gm_name || 'GM名不明'}
+                      <span className={`text-xs flex items-center gap-0.5 ${!responded ? 'text-gray-400' : available ? 'text-purple-800' : 'text-gray-400 line-through'}`}>
+                        {!responded
+                          ? <Clock className="w-3 h-3 shrink-0" />
+                          : available
+                            ? <CheckCircle2 className="w-3 h-3 shrink-0 text-green-600" />
+                            : <XCircle className="w-3 h-3 shrink-0 text-gray-400" />
+                        }
+                        {response.gm_name || 'GM名不明'}
                         {responded && available && (candidates?.length ?? 0) > 0 && (
                           <span className="text-purple-500 ml-0.5">({candidates!.map(i => i + 1).join(',')})</span>
                         )}
                       </span>
                       {responded && response.notes && (
-                        <span className="text-xs text-purple-600 pl-4 whitespace-pre-wrap">💬 {response.notes}</span>
+                        <span className="text-xs text-purple-600 pl-4 whitespace-pre-wrap flex items-start gap-0.5">
+                          <MessageCircle className="w-3 h-3 shrink-0 mt-0.5" />{response.notes}
+                        </span>
                       )}
                     </div>
                   )

--- a/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
@@ -1,9 +1,10 @@
-import { useState, useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '@/lib/supabase'
 import { getCurrentOrganizationId } from '@/lib/organization'
 import { logger, privateBookingTrace } from '@/utils/logger'
 import { RESERVATION_SOURCE } from '@/lib/constants'
-import { fetchScenarioTimingFromDb, getPrivateBookingDisplayEndTime } from '@/lib/privateBookingScenarioTime'
+import { getPrivateBookingDisplayEndTime } from '@/lib/privateBookingScenarioTime'
 import { useCustomHolidays } from '@/hooks/useCustomHolidays'
 import type { PrivateBookingRequest } from './usePrivateBookingData'
 import { sortGmResponsesByReplyTime } from '../utils/bookingFormatters'
@@ -27,325 +28,284 @@ const PRIVATE_BOOKING_LIST_STATUSES = [
   'no_show',
 ] as const
 
-/**
- * 貸切リクエストのデータ取得を管理するフック
- */
-// モジュールレベルキャッシュ（ページ遷移で消えない、ブラウザリロードで消える）
-const cache = {
-  data: null as PrivateBookingRequest[] | null,
-  userId: null as string | null | undefined,
-  fetchedAt: 0,
+export const privateBookingKeys = {
+  list: (userId: string, userRole: string) => ['private-bookings', userId, userRole] as const,
 }
-const CACHE_TTL_MS = 60_000 // 60秒間はキャッシュを使う
 
-export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps) {
-  const { isCustomHoliday } = useCustomHolidays()
+/** 生データ（endTime未計算）を取得する純粋関数 */
+async function fetchRawBookingRequests(
+  userId: string,
+  userRole: string
+): Promise<PrivateBookingRequest[]> {
+  if (userId == null || userRole == null) {
+    privateBookingTrace('ユーザー情報未確定のため取得をスキップ')
+    return []
+  }
 
-  const hasFreshCache = cache.data !== null
-    && cache.userId === userId
-    && Date.now() - cache.fetchedAt < CACHE_TTL_MS
+  const isOrgWideAccess = userRole === 'admin' || userRole === 'license_admin'
+  let allowedScenarioIds: string[] | null = null
 
-  const [requests, setRequests] = useState<PrivateBookingRequest[]>(
-    hasFreshCache ? cache.data! : []
-  )
-  const [loading, setLoading] = useState(!hasFreshCache)
+  if (!isOrgWideAccess) {
+    privateBookingTrace('スタッフユーザー - 担当シナリオのみ表示')
+    const { data: staffData } = await supabase
+      .from('staff')
+      .select('id')
+      .eq('user_id', userId)
+      .single()
 
-  // 月ごとにフィルタリング
-  const filterByMonth = useCallback((reqs: PrivateBookingRequest[], date: Date) => {
-    const year = date.getFullYear()
-    const month = date.getMonth()
-    return reqs.filter(req => {
-      if (!req.candidate_datetimes?.candidates || req.candidate_datetimes.candidates.length === 0) return false
-      const firstCandidate = req.candidate_datetimes.candidates[0]
-      const candidateDate = new Date(firstCandidate.date)
-      return candidateDate.getFullYear() === year && candidateDate.getMonth() === month
-    })
-  }, [])
+    if (staffData) {
+      const { data: assignments } = await supabase
+        .from('staff_scenario_assignments')
+        .select('scenario_master_id')
+        .eq('staff_id', staffData.id)
 
-  const loadRequests = useCallback(async (force = false) => {
-    try {
-      // Auth 復元前に userId / role が undefined のまま走ると、誤ってスタッフ扱いになり空になる
-      if (userId == null || userRole == null) {
-        privateBookingTrace('ユーザー情報未確定のため取得をスキップ')
-        return
-      }
+      allowedScenarioIds = assignments?.length
+        ? assignments.map(a => a.scenario_master_id)
+        : []
+    } else {
+      allowedScenarioIds = []
+    }
+  } else {
+    privateBookingTrace('管理者 / ライセンス管理者 - 組織内の全リクエスト表示')
+  }
 
-      // キャッシュが有効ならスキップ（強制再取得でない場合）
-      if (!force && cache.data !== null && cache.userId === userId && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
-        privateBookingTrace('キャッシュヒット - 取得をスキップ')
-        return
-      }
+  const orgId = await getCurrentOrganizationId()
+  if (!orgId) {
+    logger.warn('📋 貸切リクエスト: organization_id を取得できません')
+    return []
+  }
 
-      setLoading(true)
+  if (allowedScenarioIds !== null && allowedScenarioIds.length === 0) return []
 
-      // admin / license_admin は組織内の全リクエスト（RLS と organization_id で制限）
-      const isOrgWideAccess = userRole === 'admin' || userRole === 'license_admin'
-      
-      // スタッフの場合のみ、自分が担当しているシナリオのIDを取得
-      let allowedScenarioIds: string[] | null = null
-      
-      if (!isOrgWideAccess) {
-        privateBookingTrace('スタッフユーザー - 担当シナリオのみ表示')
-        
-        // ログインユーザーのstaffレコードを取得
-        const { data: staffData } = await supabase
-          .from('staff')
-          .select('id')
-          .eq('user_id', userId)
-          .single()
-        
-        if (staffData) {
-          const { data: assignments } = await supabase
-            .from('staff_scenario_assignments')
-            .select('scenario_master_id')
-            .eq('staff_id', staffData.id)
-          
-          if (assignments && assignments.length > 0) {
-            allowedScenarioIds = assignments.map(a => a.scenario_master_id)
-            privateBookingTrace(`${allowedScenarioIds.length}件の担当シナリオを検出`)
-          } else {
-            privateBookingTrace('担当シナリオなし - 空の結果を返します')
-            allowedScenarioIds = [] // 空配列で何も表示しない
-          }
-        } else {
-          privateBookingTrace('スタッフレコード未紐づけ - 空の結果を返します')
-          allowedScenarioIds = [] // 空配列で何も表示しない
-        }
-      } else {
-        privateBookingTrace('管理者 / ライセンス管理者 - 組織内の全リクエスト表示')
-      }
+  let query = supabase
+    .from('reservations')
+    .select(`
+      *,
+      scenario_masters:scenario_master_id(title, official_duration),
+      customers:customer_id(name, phone),
+      private_groups:private_group_id(invite_code, scenario_master_id)
+    `)
+    .eq('organization_id', orgId)
+    .eq('reservation_source', RESERVATION_SOURCE.WEB_PRIVATE)
+    .order('created_at', { ascending: false })
 
-      const orgId = await getCurrentOrganizationId()
-      if (!orgId) {
-        logger.warn('📋 貸切リクエスト: organization_id を取得できません')
-        setRequests([])
-        return
-      }
-      
-      // reservationsテーブルから貸切リクエストを取得（private_groupsのinvite_codeとscenario_master_idも含む）
-      let query = supabase
-        .from('reservations')
-        .select(`
-          *,
-          scenario_masters:scenario_master_id(title, official_duration),
-          customers:customer_id(name, phone),
-          private_groups:private_group_id(invite_code, scenario_master_id)
-        `)
-        .eq('organization_id', orgId)
-        .eq('reservation_source', RESERVATION_SOURCE.WEB_PRIVATE)
-        .order('created_at', { ascending: false })
+  if (allowedScenarioIds !== null) {
+    query = query.in('scenario_master_id', allowedScenarioIds)
+  }
+  query = query.in('status', [...PRIVATE_BOOKING_LIST_STATUSES])
 
-      // スタッフの場合、担当シナリオのみに絞り込み
-      if (allowedScenarioIds !== null) {
-        if (allowedScenarioIds.length === 0) {
-          setRequests([])
-          setLoading(false)
-          return
-        }
-        query = query.in('scenario_master_id', allowedScenarioIds)
-      }
+  const { data, error } = await query
+  if (error) {
+    logger.error('Supabaseエラー:', error)
+    throw error
+  }
 
-      // タブごとに API で絞らない（絞ると他タブの件数が 0 表示になる）。表示は親で activeTab フィルタ。
-      query = query.in('status', [...PRIVATE_BOOKING_LIST_STATUSES])
+  const reservationsList = data || []
+  privateBookingTrace(`取得: ${reservationsList.length} 件`)
 
-      const { data, error } = await query
+  // グループID一覧
+  const privateGroupIds = [
+    ...new Set(
+      reservationsList
+        .map((r: any) => r.private_group_id)
+        .filter((id): id is string => Boolean(id))
+    ),
+  ]
 
-      if (error) {
-        logger.error('Supabaseエラー:', error)
-        throw error
-      }
-
-      privateBookingTrace(`取得: ${data?.length ?? 0} 件（organization_id=${orgId}）`)
-
-      const reservationsList = data || []
-      const privateGroupIds = [
-        ...new Set(
-          reservationsList
-            .map((r: { private_group_id?: string | null }) => r.private_group_id)
-            .filter((id): id is string => Boolean(id))
-        ),
-      ]
-      const joinedMemberCountByGroupId = new Map<string, number>()
-      if (privateGroupIds.length > 0) {
-        const { data: memberRows, error: memberCountError } = await supabase
+  // バッチ取得（並列）
+  const [
+    memberRowsResult,
+    viewRowsResult,
+    allGmResponsesResult,
+    allCandidateDatesResult,
+  ] = await Promise.all([
+    privateGroupIds.length > 0
+      ? supabase
           .from('private_group_members')
           .select('group_id')
           .in('group_id', privateGroupIds)
           .eq('status', 'joined')
-
-        if (memberCountError) {
-          logger.warn('private_group_members 集計に失敗（参加人数は予約の participant_count のみ表示）:', memberCountError)
-        } else {
-          for (const row of memberRows || []) {
-            const gid = row.group_id as string
-            joinedMemberCountByGroupId.set(gid, (joinedMemberCountByGroupId.get(gid) || 0) + 1)
-          }
-        }
-      }
-
-      // ── バッチ取得 ① シナリオ情報（duration含む）──────────────────────────────
-      const masterIdsForGmCount = [
+      : Promise.resolve({ data: [], error: null }),
+    (() => {
+      const masterIds = [
         ...new Set(
           reservationsList
-            .map((r: { scenario_master_id?: string; private_groups?: { scenario_master_id?: string } }) =>
-              r.scenario_master_id || r.private_groups?.scenario_master_id
-            )
+            .map((r: any) => r.scenario_master_id || r.private_groups?.scenario_master_id)
             .filter(Boolean)
         ),
       ] as string[]
-      const gmCountByMasterId = new Map<string, number>()
-      const playerRangeByMasterId = new Map<string, { min: number; max: number }>()
-      const scenarioTimingByMasterId = new Map<string, { duration: number; weekend_duration: number | null; extra_preparation_time: number; private_booking_time_slots?: unknown }>()
-
-      if (masterIdsForGmCount.length > 0) {
-        const { data: viewRows } = await supabase
-          .from('organization_scenarios_with_master')
-          .select('scenario_master_id, gm_count, player_count_min, player_count_max, duration, weekend_duration, extra_preparation_time, private_booking_time_slots')
-          .eq('organization_id', orgId)
-          .in('scenario_master_id', masterIdsForGmCount)
-
-        for (const row of viewRows || []) {
-          if (!row.scenario_master_id) continue
-          gmCountByMasterId.set(row.scenario_master_id, resolveStaffProfileGmSlotCount({ gm_count: row.gm_count }))
-          const pMin = row.player_count_min
-          const pMax = row.player_count_max
-          if (typeof pMin === 'number' && typeof pMax === 'number' && pMin > 0 && pMax >= pMin) {
-            playerRangeByMasterId.set(row.scenario_master_id, { min: pMin, max: pMax })
-          }
-          if (typeof row.duration === 'number' && row.duration > 0) {
-            scenarioTimingByMasterId.set(row.scenario_master_id, {
-              duration: row.duration,
-              weekend_duration: typeof row.weekend_duration === 'number' && row.weekend_duration > 0 ? row.weekend_duration : null,
-              extra_preparation_time: typeof row.extra_preparation_time === 'number' ? row.extra_preparation_time : 0,
-              private_booking_time_slots: row.private_booking_time_slots ?? null,
-            })
-          }
-        }
-      }
-
-      // ── バッチ取得 ② GM回答（全予約まとめて1クエリ）──────────────────────────
-      const allReservationIds = reservationsList.map((r: { id: string }) => r.id)
-      const gmResponsesByReservationId = new Map<string, any[]>()
-      if (allReservationIds.length > 0) {
-        const { data: allGmResponses } = await supabase
+      return masterIds.length > 0
+        ? supabase
+            .from('organization_scenarios_with_master')
+            .select('scenario_master_id, gm_count, player_count_min, player_count_max, duration, weekend_duration, extra_preparation_time, private_booking_time_slots')
+            .eq('organization_id', orgId)
+            .in('scenario_master_id', masterIds)
+        : Promise.resolve({ data: [], error: null })
+    })(),
+    reservationsList.length > 0
+      ? supabase
           .from('gm_availability_responses')
           .select('reservation_id, staff_id, gm_name, response_status, available_candidates, selected_candidate_index, notes, response_datetime, responded_at, updated_at, created_at, staff:staff_id(name, avatar_color)')
-          .in('reservation_id', allReservationIds)
-        for (const gm of allGmResponses || []) {
-          const rid = gm.reservation_id as string
-          if (!gmResponsesByReservationId.has(rid)) gmResponsesByReservationId.set(rid, [])
-          gmResponsesByReservationId.get(rid)!.push(gm)
-        }
-      }
-
-      // ── バッチ取得 ③ 候補日（全グループまとめて1クエリ）──────────────────────
-      const candidateDatesByGroupId = new Map<string, any[]>()
-      if (privateGroupIds.length > 0) {
-        const { data: allCandidateDates } = await supabase
+          .in('reservation_id', reservationsList.map((r: any) => r.id))
+      : Promise.resolve({ data: [], error: null }),
+    privateGroupIds.length > 0
+      ? supabase
           .from('private_group_candidate_dates')
           .select('group_id, id, date, time_slot, start_time, end_time, status')
           .in('group_id', privateGroupIds)
           .order('date', { ascending: true })
-        for (const cd of allCandidateDates || []) {
-          if (cd.status === 'rejected') continue
-          const gid = cd.group_id as string
-          if (!candidateDatesByGroupId.has(gid)) candidateDatesByGroupId.set(gid, [])
-          candidateDatesByGroupId.get(gid)!.push(cd)
-        }
-      }
+      : Promise.resolve({ data: [], error: null }),
+  ])
 
-      // ── マップ参照のみで各予約を組み立て（追加クエリなし）─────────────────────
-      const formattedData: PrivateBookingRequest[] = reservationsList.map((req: any) => {
-          const gmResponses = gmResponsesByReservationId.get(req.id) || []
-          const transformedGMResponses = sortGmResponsesByReplyTime(
-            gmResponses.filter((gm: any) => shouldIncludeGmResponseRow(gm)).map((gm: any) => ({
-              ...gm,
-              gm_name: gm.gm_name || gm.staff?.name || '',
-            }))
-          )
-
-          let candidateDatetimes = req.candidate_datetimes || { candidates: [] }
-          const currentCandidates = candidateDatetimes.candidates || []
-          const originalCandidates = req.private_group_id
-            ? (candidateDatesByGroupId.get(req.private_group_id) || [])
-            : []
-
-          if (req.status === 'confirmed' && originalCandidates.length > currentCandidates.length) {
-            const confirmedCandidate = currentCandidates.find((c: any) => c.status === 'confirmed')
-            const restoredCandidates = originalCandidates.map((cd: any, idx: number) => {
-              const isConfirmed = confirmedCandidate &&
-                confirmedCandidate.date === cd.date &&
-                confirmedCandidate.timeSlot === cd.time_slot
-              return {
-                order: idx + 1,
-                date: cd.date,
-                timeSlot: cd.time_slot,
-                startTime: cd.start_time || confirmedCandidate?.startTime || '10:00',
-                endTime: cd.end_time || confirmedCandidate?.endTime || '13:00',
-                status: isConfirmed ? 'confirmed' : 'pending',
-              }
-            })
-            candidateDatetimes = { ...candidateDatetimes, candidates: restoredCandidates }
-          }
-
-          const scenarioMasterId = req.scenario_master_id || req.private_groups?.scenario_master_id
-          const cachedTiming = scenarioMasterId ? scenarioTimingByMasterId.get(scenarioMasterId) : undefined
-          let scenario_timing = cachedTiming ?? {
-            duration: typeof req.scenario_masters?.official_duration === 'number' && req.scenario_masters.official_duration > 0
-              ? req.scenario_masters.official_duration
-              : 180,
-            weekend_duration: null,
-            extra_preparation_time: 0,
-          }
-
-          const candidatesWithScenarioEnd = (candidateDatetimes.candidates || []).map((c: any) => ({
-            ...c,
-            endTime: getPrivateBookingDisplayEndTime(c.startTime, c.date, scenario_timing, isCustomHoliday),
-          }))
-          candidateDatetimes = { ...candidateDatetimes, candidates: candidatesWithScenarioEnd }
-
-          const pgId = req.private_group_id as string | undefined | null
-          const joinedN = pgId ? (joinedMemberCountByGroupId.get(pgId) ?? 0) : undefined
-
-          return {
-            id: req.id,
-            reservation_number: req.reservation_number || '',
-            scenario_master_id: scenarioMasterId,
-            required_gm_count: scenarioMasterId ? (gmCountByMasterId.get(scenarioMasterId) ?? 1) : 1,
-            scenario_timing,
-            scenario_title: req.scenario_masters?.title || req.title || 'シナリオ名不明',
-            customer_name: req.customers?.name || '顧客名不明',
-            customer_email: req.customer_email || '',
-            customer_phone: req.customers?.phone || req.customer_phone || '',
-            candidate_datetimes: candidateDatetimes,
-            participant_count: req.participant_count || 0,
-            joined_member_count: pgId !== undefined && pgId !== null ? joinedN : undefined,
-            scenario_player_count_range: scenarioMasterId ? playerRangeByMasterId.get(scenarioMasterId) ?? null : null,
-            notes: req.customer_notes || '',
-            status: req.status,
-            gm_responses: transformedGMResponses,
-            created_at: req.created_at,
-            invite_code: req.private_groups?.invite_code || '',
-          }
-        })
-
-      setRequests(formattedData)
-      // キャッシュを更新
-      cache.data = formattedData
-      cache.userId = userId
-      cache.fetchedAt = Date.now()
-    } catch (error) {
-      logger.error('貸切リクエスト取得エラー:', error)
-    } finally {
-      setLoading(false)
-    }
-  }, [userId, userRole, isCustomHoliday])
-
-  return {
-    requests,
-    loading,
-    loadRequests,
-    filterByMonth
+  // マップ構築
+  const joinedMemberCountByGroupId = new Map<string, number>()
+  for (const row of memberRowsResult.data || []) {
+    const gid = row.group_id as string
+    joinedMemberCountByGroupId.set(gid, (joinedMemberCountByGroupId.get(gid) || 0) + 1)
   }
+
+  const gmCountByMasterId = new Map<string, number>()
+  const playerRangeByMasterId = new Map<string, { min: number; max: number }>()
+  const scenarioTimingByMasterId = new Map<string, { duration: number; weekend_duration: number | null; extra_preparation_time: number; private_booking_time_slots?: unknown }>()
+  for (const row of viewRowsResult.data || []) {
+    if (!row.scenario_master_id) continue
+    gmCountByMasterId.set(row.scenario_master_id, resolveStaffProfileGmSlotCount({ gm_count: row.gm_count }))
+    if (typeof row.player_count_min === 'number' && typeof row.player_count_max === 'number' && row.player_count_min > 0 && row.player_count_max >= row.player_count_min) {
+      playerRangeByMasterId.set(row.scenario_master_id, { min: row.player_count_min, max: row.player_count_max })
+    }
+    if (typeof row.duration === 'number' && row.duration > 0) {
+      scenarioTimingByMasterId.set(row.scenario_master_id, {
+        duration: row.duration,
+        weekend_duration: typeof row.weekend_duration === 'number' && row.weekend_duration > 0 ? row.weekend_duration : null,
+        extra_preparation_time: typeof row.extra_preparation_time === 'number' ? row.extra_preparation_time : 0,
+        private_booking_time_slots: row.private_booking_time_slots ?? null,
+      })
+    }
+  }
+
+  const gmResponsesByReservationId = new Map<string, any[]>()
+  for (const gm of allGmResponsesResult.data || []) {
+    const rid = gm.reservation_id as string
+    if (!gmResponsesByReservationId.has(rid)) gmResponsesByReservationId.set(rid, [])
+    gmResponsesByReservationId.get(rid)!.push(gm)
+  }
+
+  const candidateDatesByGroupId = new Map<string, any[]>()
+  for (const cd of allCandidateDatesResult.data || []) {
+    if (cd.status === 'rejected') continue
+    const gid = cd.group_id as string
+    if (!candidateDatesByGroupId.has(gid)) candidateDatesByGroupId.set(gid, [])
+    candidateDatesByGroupId.get(gid)!.push(cd)
+  }
+
+  // 組み立て（endTime計算は呼び出し側で行う）
+  return reservationsList.map((req: any) => {
+    const gmResponses = gmResponsesByReservationId.get(req.id) || []
+    const transformedGMResponses = sortGmResponsesByReplyTime(
+      gmResponses.filter((gm: any) => shouldIncludeGmResponseRow(gm)).map((gm: any) => ({
+        ...gm,
+        gm_name: gm.gm_name || gm.staff?.name || '',
+      }))
+    )
+
+    let candidateDatetimes = req.candidate_datetimes || { candidates: [] }
+    const currentCandidates = candidateDatetimes.candidates || []
+    const originalCandidates = req.private_group_id
+      ? (candidateDatesByGroupId.get(req.private_group_id) || [])
+      : []
+
+    if (req.status === 'confirmed' && originalCandidates.length > currentCandidates.length) {
+      const confirmedCandidate = currentCandidates.find((c: any) => c.status === 'confirmed')
+      const restoredCandidates = originalCandidates.map((cd: any, idx: number) => {
+        const isConfirmed = confirmedCandidate &&
+          confirmedCandidate.date === cd.date &&
+          confirmedCandidate.timeSlot === cd.time_slot
+        return {
+          order: idx + 1,
+          date: cd.date,
+          timeSlot: cd.time_slot,
+          startTime: cd.start_time || confirmedCandidate?.startTime || '10:00',
+          endTime: cd.end_time || confirmedCandidate?.endTime || '13:00',
+          status: isConfirmed ? 'confirmed' : 'pending',
+        }
+      })
+      candidateDatetimes = { ...candidateDatetimes, candidates: restoredCandidates }
+    }
+
+    const scenarioMasterId = req.scenario_master_id || req.private_groups?.scenario_master_id
+    const scenario_timing = scenarioTimingByMasterId.get(scenarioMasterId) ?? {
+      duration: typeof req.scenario_masters?.official_duration === 'number' && req.scenario_masters.official_duration > 0
+        ? req.scenario_masters.official_duration
+        : 180,
+      weekend_duration: null,
+      extra_preparation_time: 0,
+    }
+
+    const pgId = req.private_group_id as string | undefined | null
+    const joinedN = pgId ? (joinedMemberCountByGroupId.get(pgId) ?? 0) : undefined
+
+    return {
+      id: req.id,
+      reservation_number: req.reservation_number || '',
+      scenario_master_id: scenarioMasterId,
+      required_gm_count: scenarioMasterId ? (gmCountByMasterId.get(scenarioMasterId) ?? 1) : 1,
+      scenario_timing,
+      scenario_title: req.scenario_masters?.title || req.title || 'シナリオ名不明',
+      customer_name: req.customers?.name || '顧客名不明',
+      customer_email: req.customer_email || '',
+      customer_phone: req.customers?.phone || req.customer_phone || '',
+      candidate_datetimes: candidateDatetimes,
+      participant_count: req.participant_count || 0,
+      joined_member_count: pgId !== undefined && pgId !== null ? joinedN : undefined,
+      scenario_player_count_range: scenarioMasterId ? playerRangeByMasterId.get(scenarioMasterId) ?? null : null,
+      notes: req.customer_notes || '',
+      status: req.status,
+      gm_responses: transformedGMResponses,
+      created_at: req.created_at,
+      invite_code: req.private_groups?.invite_code || '',
+    } as PrivateBookingRequest
+  })
 }
 
+export function useBookingRequests({ userId, userRole }: UseBookingRequestsProps) {
+  const { isCustomHoliday } = useCustomHolidays()
+  const queryClient = useQueryClient()
+
+  const enabled = userId != null && userRole != null
+  const { data: rawRequests = [], isLoading: loading } = useQuery<PrivateBookingRequest[]>({
+    queryKey: enabled ? privateBookingKeys.list(userId!, userRole!) : ['private-bookings-disabled'],
+    queryFn: () => fetchRawBookingRequests(userId!, userRole!),
+    enabled,
+    staleTime: 2 * 60 * 1000, // 2分
+  })
+
+  // endTime を isCustomHoliday で補正（サーバーデータと分離してキャッシュを壊さない）
+  const requests = useMemo<PrivateBookingRequest[]>(() => {
+    return rawRequests.map(req => {
+      const candidates = (req.candidate_datetimes?.candidates || []).map((c: any) => ({
+        ...c,
+        endTime: getPrivateBookingDisplayEndTime(c.startTime, c.date, req.scenario_timing ?? { duration: 180 }, isCustomHoliday),
+      }))
+      return { ...req, candidate_datetimes: { ...req.candidate_datetimes, candidates } }
+    })
+  }, [rawRequests, isCustomHoliday])
+
+  const loadRequests = useCallback((force = false) => {
+    if (!enabled) return
+    if (force) {
+      queryClient.invalidateQueries({ queryKey: privateBookingKeys.list(userId!, userRole!) })
+    }
+  }, [enabled, userId, userRole, queryClient])
+
+  const filterByMonth = useCallback((reqs: PrivateBookingRequest[], date: Date) => {
+    const year = date.getFullYear()
+    const month = date.getMonth()
+    return reqs.filter(req => {
+      if (!req.candidate_datetimes?.candidates?.length) return false
+      const d = new Date(req.candidate_datetimes.candidates[0].date)
+      return d.getFullYear() === year && d.getMonth() === month
+    })
+  }, [])
+
+  return { requests, loading, loadRequests, filterByMonth }
+}

--- a/src/pages/SalesManagement/hooks/useSalesData.ts
+++ b/src/pages/SalesManagement/hooks/useSalesData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { salesApi } from '@/lib/api'
 import { supabase } from '@/lib/supabase'
 import { SalesData } from '@/types'
@@ -58,255 +59,190 @@ const STORAGE_KEY_START_DATE = 'sales-custom-start-date'
 const STORAGE_KEY_END_DATE = 'sales-custom-end-date'
 const STORAGE_KEY_PERIOD = 'sales-selected-period'
 
+export const salesDataKeys = {
+  stores: ['sales-stores'] as const,
+  data: (startDate: string, endDate: string, storeIds: string, ownershipFilter: string) =>
+    ['sales-data', startDate, endDate, storeIds, ownershipFilter] as const,
+}
+
+/** 純粋なデータ取得関数（React Query の queryFn） */
+async function fetchSalesDataForPeriod(
+  startDateStr: string,
+  endDateStr: string,
+  storeIds: string[],
+  ownershipFilter: 'corporate' | 'franchise' | undefined,
+  allStores: Store[]
+): Promise<SalesData> {
+  const salarySettings = await fetchSalarySettings()
+
+  const startDate = new Date(startDateStr + 'T00:00:00+09:00')
+  const endDate = new Date(endDateStr + 'T23:59:59+09:00')
+  const daysDiff = getDaysDiff(startDate, endDate)
+
+  let chartStartDate: Date
+  let chartEndDate: Date
+
+  if (daysDiff <= 31) {
+    chartStartDate = new Date(startDate)
+    chartEndDate = new Date(endDate)
+  } else {
+    chartStartDate = new Date(startDate.getFullYear(), startDate.getMonth(), 1)
+    chartEndDate = new Date(startDate.getFullYear() + 1, startDate.getMonth(), 0)
+  }
+
+  const [eventsData, miscResult, staffResult] = await Promise.all([
+    salesApi.getSalesByPeriod(formatDateJST(chartStartDate), formatDateJST(chartEndDate)),
+    supabase
+      .from('miscellaneous_transactions')
+      .select('id, date, type, category, amount, scenario_id, store_id')
+      .gte('date', formatDateJST(chartStartDate))
+      .lte('date', formatDateJST(chartEndDate))
+      .eq('type', 'expense'),
+    supabase.from('staff').select('id, name, stores'),
+  ])
+
+  let events = eventsData
+  const miscTransactions = miscResult.data || []
+  const staffList = staffResult.data || []
+  const staffByName = new Map<string, string[]>()
+  staffList.forEach(s => staffByName.set(s.name, s.stores || []))
+
+  // 店舗フィルタリング
+  let filteredStores = allStores
+  if (ownershipFilter) {
+    filteredStores = ownershipFilter === 'corporate'
+      ? filteredStores.filter(s => s.ownership_type === 'corporate' || s.ownership_type === 'office')
+      : filteredStores.filter(s => s.ownership_type === ownershipFilter)
+  }
+  const filteredStoreIds = ownershipFilter ? filteredStores.map(s => s.id) : []
+
+  if (ownershipFilter && filteredStoreIds.length > 0) {
+    if (storeIds.length > 0) {
+      const validStoreIds = storeIds.filter(id => filteredStoreIds.includes(id))
+      events = events.filter(e => (validStoreIds.length > 0 ? validStoreIds : filteredStoreIds).includes(e.store_id))
+    } else {
+      events = events.filter(e => filteredStoreIds.includes(e.store_id))
+    }
+  } else if (storeIds.length > 0) {
+    events = events.filter(e => storeIds.includes(e.store_id))
+  }
+
+  if (ownershipFilter && filteredStoreIds.length > 0 && storeIds.length > 0) {
+    const validStoreIds = storeIds.filter(id => filteredStoreIds.includes(id))
+    if (validStoreIds.length > 0) filteredStores = filteredStores.filter(s => validStoreIds.includes(s.id))
+  } else if (storeIds.length > 0) {
+    filteredStores = filteredStores.filter(s => storeIds.includes(s.id))
+  }
+
+  return calculateSalesData(events, filteredStores, startDate, endDate, miscTransactions, salarySettings, staffByName)
+}
+
+interface ActiveSalesParams {
+  startDate: string
+  endDate: string
+  storeIds: string[]
+  ownershipFilter?: 'corporate' | 'franchise'
+}
+
+function periodToDateRange(period: string, customStart: string, customEnd: string): { startDate: string; endDate: string } | null {
+  if (period === 'custom') {
+    if (!customStart || !customEnd) return null
+    return { startDate: customStart, endDate: customEnd }
+  }
+  let result
+  switch (period) {
+    case 'thisMonth': result = getThisMonthRangeJST(); break
+    case 'lastMonth': result = getLastMonthRangeJST(); break
+    case 'thisWeek': result = getThisWeekRangeJST(); break
+    case 'lastWeek': result = getLastWeekRangeJST(); break
+    case 'last7days': result = getPastDaysRangeJST(7); break
+    case 'last30days': result = getPastDaysRangeJST(30); break
+    case 'thisYear': result = getThisYearRangeJST(); break
+    case 'lastYear': result = getLastYearRangeJST(); break
+    default: result = getThisMonthRangeJST()
+  }
+  return { startDate: result.startDateStr, endDate: result.endDateStr }
+}
+
 export function useSalesData() {
-  const [salesData, setSalesData] = useState<SalesData | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [stores, setStores] = useState<Store[]>([])
-  
   // localStorage から初期値を復元
-  const [selectedPeriod, setSelectedPeriod] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem(STORAGE_KEY_PERIOD) || 'thisMonth'
-    }
-    return 'thisMonth'
-  })
+  const [selectedPeriod, setSelectedPeriod] = useState(() =>
+    typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY_PERIOD) || 'thisMonth' : 'thisMonth'
+  )
+  const [customStartDate, setCustomStartDate] = useState(() =>
+    typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY_START_DATE) || '' : ''
+  )
+  const [customEndDate, setCustomEndDate] = useState(() =>
+    typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY_END_DATE) || '' : ''
+  )
   const [dateRange, setDateRange] = useState({ startDate: '', endDate: '' })
-  const [customStartDate, setCustomStartDate] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem(STORAGE_KEY_START_DATE) || ''
-    }
-    return ''
-  })
-  const [customEndDate, setCustomEndDate] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem(STORAGE_KEY_END_DATE) || ''
-    }
-    return ''
-  })
 
-  // localStorage に期間設定を保存
+  // アクティブなクエリパラメータ（これが変わると React Query が再フェッチ）
+  const [activeParams, setActiveParams] = useState<ActiveSalesParams | null>(null)
+
+  const queryClient = useQueryClient()
+
+  // localStorage 同期
   useEffect(() => {
-    if (typeof window !== 'undefined' && selectedPeriod) {
-      localStorage.setItem(STORAGE_KEY_PERIOD, selectedPeriod)
-    }
+    if (typeof window !== 'undefined' && selectedPeriod) localStorage.setItem(STORAGE_KEY_PERIOD, selectedPeriod)
   }, [selectedPeriod])
-
   useEffect(() => {
-    if (typeof window !== 'undefined' && customStartDate) {
-      localStorage.setItem(STORAGE_KEY_START_DATE, customStartDate)
-    }
+    if (typeof window !== 'undefined' && customStartDate) localStorage.setItem(STORAGE_KEY_START_DATE, customStartDate)
   }, [customStartDate])
-
   useEffect(() => {
-    if (typeof window !== 'undefined' && customEndDate) {
-      localStorage.setItem(STORAGE_KEY_END_DATE, customEndDate)
-    }
+    if (typeof window !== 'undefined' && customEndDate) localStorage.setItem(STORAGE_KEY_END_DATE, customEndDate)
   }, [customEndDate])
 
-  // 店舗一覧を取得
-  useEffect(() => {
-    const fetchStores = async () => {
-      try {
-        logger.log('🏪 店舗データ取得開始')
-        const storeData = await salesApi.getStores()
-        logger.log('🏪 店舗データ取得完了:', { storesCount: storeData.length })
-        setStores(storeData)
-      } catch (error) {
-        logger.error('❌ 店舗データの取得に失敗しました:', error)
-      }
-    }
-    fetchStores()
-  }, [])
+  // 店舗一覧（React Query）
+  const { data: stores = [] } = useQuery<Store[]>({
+    queryKey: salesDataKeys.stores,
+    queryFn: () => salesApi.getStores(),
+    staleTime: 30 * 60 * 1000,
+  })
 
-  // 売上データを取得（期間とストアを引数で受け取る）
+  // 売上データ（React Query）
+  const queryKey = activeParams
+    ? salesDataKeys.data(
+        activeParams.startDate,
+        activeParams.endDate,
+        activeParams.storeIds.slice().sort().join(','),
+        activeParams.ownershipFilter ?? 'all'
+      )
+    : null
+
+  const { data: salesData = null, isLoading: loading } = useQuery<SalesData | null>({
+    queryKey: queryKey ?? ['sales-data-disabled'],
+    queryFn: () => fetchSalesDataForPeriod(
+      activeParams!.startDate,
+      activeParams!.endDate,
+      activeParams!.storeIds,
+      activeParams!.ownershipFilter,
+      stores
+    ),
+    enabled: queryKey !== null && stores.length > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // loadSalesData: 期間・フィルターを受け取り activeParams を更新 → React Query が再フェッチ
   const loadSalesData = useCallback(async (period: string, storeIds: string[], ownershipFilter?: 'corporate' | 'franchise') => {
-    logger.log('📊 売上データ取得開始:', { period, storeIds, ownershipFilter, storesCount: stores.length })
-    setLoading(true)
+    logger.log('📊 売上データ取得開始:', { period, storeIds, ownershipFilter })
     setSelectedPeriod(period)
 
-    // 日付範囲を計算
-    let rangeResult
-    let range
-    
-    if (period === 'custom') {
-      // カスタム期間の場合は、customStartDateとcustomEndDateを使用
-      if (!customStartDate || !customEndDate) {
-        logger.warn('⚠️ カスタム期間が未設定です')
-        setLoading(false)
-        return
-      }
-      range = {
-        startDate: customStartDate,
-        endDate: customEndDate
-      }
-    } else {
-      // プリセット期間の場合
-      switch (period) {
-        case 'thisMonth':
-          rangeResult = getThisMonthRangeJST()
-          break
-        case 'lastMonth':
-          rangeResult = getLastMonthRangeJST()
-          break
-        case 'thisWeek':
-          rangeResult = getThisWeekRangeJST()
-          break
-        case 'lastWeek':
-          rangeResult = getLastWeekRangeJST()
-          break
-        case 'last7days':
-          rangeResult = getPastDaysRangeJST(7)
-          break
-        case 'last30days':
-          rangeResult = getPastDaysRangeJST(30)
-          break
-        case 'thisYear':
-          rangeResult = getThisYearRangeJST()
-          break
-        case 'lastYear':
-          rangeResult = getLastYearRangeJST()
-          break
-        default:
-          rangeResult = getThisMonthRangeJST()
-      }
-      
-      range = {
-        startDate: rangeResult.startDateStr,
-        endDate: rangeResult.endDateStr
-      }
-      
-      // プリセット期間の場合もcustomStartDateとcustomEndDateを更新
-      // これにより、SalesOverviewのcurrentMonthが正しく同期される
+    const range = periodToDateRange(period, customStartDate, customEndDate)
+    if (!range) {
+      logger.warn('⚠️ カスタム期間が未設定です')
+      return
+    }
+
+    // プリセット期間の場合は customStartDate/EndDate も更新
+    if (period !== 'custom') {
       setCustomStartDate(range.startDate)
       setCustomEndDate(range.endDate)
     }
 
     setDateRange(range)
-    logger.log('📊 計算された日付範囲:', { range })
-
-    if (!range.startDate || !range.endDate) {
-      logger.error('❌ 日付範囲が不正です:', { range })
-      setLoading(false)
-      return
-    }
-
-    try {
-      // 給与設定を取得
-      const salarySettings = await fetchSalarySettings()
-      
-      // 期間に応じてグラフ用のデータ取得期間を決定
-      logger.log('📊 日付変換:', { rangeStart: range.startDate, rangeEnd: range.endDate })
-      const startDate = new Date(range.startDate + 'T00:00:00+09:00')
-      const endDate = new Date(range.endDate + 'T23:59:59+09:00')
-      logger.log('📊 日付オブジェクト作成:', { startDate, endDate })
-      const daysDiff = getDaysDiff(startDate, endDate)
-      logger.log('📊 日数差:', { daysDiff })
-      
-      let chartStartDate: Date
-      let chartEndDate: Date
-      
-      if (daysDiff <= 31) {
-        // 31日以内の場合は日別グラフ（選択期間のデータ）
-        chartStartDate = new Date(startDate)
-        chartEndDate = new Date(endDate)
-      } else {
-        // 32日以上の場合は月別グラフ（1年分）
-        chartStartDate = new Date(startDate.getFullYear(), startDate.getMonth(), 1)
-        chartEndDate = new Date(startDate.getFullYear() + 1, startDate.getMonth(), 0)
-      }
-      
-      logger.log('📊 API呼び出し:', { 
-        start: formatDateJST(chartStartDate), 
-        end: formatDateJST(chartEndDate) 
-      })
-      
-      // イベントデータ、雑収支データ、スタッフデータを並列取得
-      const [eventsData, miscResult, staffResult] = await Promise.all([
-        salesApi.getSalesByPeriod(
-        formatDateJST(chartStartDate),
-        formatDateJST(chartEndDate)
-        ),
-        supabase
-          .from('miscellaneous_transactions')
-          .select('id, date, type, category, amount, scenario_id, store_id')
-          .gte('date', formatDateJST(chartStartDate))
-          .lte('date', formatDateJST(chartEndDate))
-          .eq('type', 'expense'),
-        supabase
-          .from('staff')
-          .select('id, name, stores')
-      ])
-      
-      let events = eventsData
-      const miscTransactions = miscResult.data || []
-      const staffList = staffResult.data || []
-      // スタッフ名→担当店舗のマップを作成
-      const staffByName = new Map<string, string[]>()
-      staffList.forEach(s => {
-        staffByName.set(s.name, s.stores || [])
-      })
-      logger.log('📊 データ取得完了:', { 
-        events: events.length, 
-        miscTransactions: miscTransactions.length,
-        staffCount: staffList.length
-      })
-      
-      // 店舗フィルタリング（ownership_type による絞り込み）
-      let filteredStores = stores
-      if (ownershipFilter) {
-        if (ownershipFilter === 'corporate') {
-          // 直営店の場合、オフィスも含める
-          filteredStores = filteredStores.filter(s => 
-            s.ownership_type === 'corporate' || s.ownership_type === 'office'
-          )
-        } else {
-          // フランチャイズの場合、フランチャイズのみ
-          filteredStores = filteredStores.filter(s => s.ownership_type === ownershipFilter)
-        }
-        logger.log('📊 店舗タイプでフィルター:', { ownershipFilter, filteredCount: filteredStores.length })
-      }
-      
-      // フィルタリング対象店舗のIDリストを取得
-      const filteredStoreIds = ownershipFilter ? filteredStores.map(s => s.id) : []
-
-      // イベントフィルタリング
-      // ownershipFilter が設定されている場合は常に店舗タイプで先に絞り込み、
-      // その中から storeIds でさらに絞り込む（storeIds が別タブの店舗IDを含む場合に誤表示しないため）
-      if (ownershipFilter && filteredStoreIds.length > 0) {
-        if (storeIds.length > 0) {
-          // ownershipFilter × storeIds の積集合
-          const validStoreIds = storeIds.filter(id => filteredStoreIds.includes(id))
-          events = events.filter(e => (validStoreIds.length > 0 ? validStoreIds : filteredStoreIds).includes(e.store_id))
-          logger.log('📊 店舗タイプ＋選択店舗でイベントに絞り込み:', { eventsCount: events.length, validStoreIds })
-        } else {
-          events = events.filter(e => filteredStoreIds.includes(e.store_id))
-          logger.log('📊 店舗タイプでイベントに絞り込み:', { eventsCount: events.length, filteredStoreIds })
-        }
-      } else if (storeIds.length > 0) {
-        events = events.filter(e => storeIds.includes(e.store_id))
-      }
-
-      // 店舗フィルタリング（固定費計算用）
-      if (ownershipFilter && filteredStoreIds.length > 0 && storeIds.length > 0) {
-        const validStoreIds = storeIds.filter(id => filteredStoreIds.includes(id))
-        if (validStoreIds.length > 0) {
-          filteredStores = filteredStores.filter(s => validStoreIds.includes(s.id))
-        }
-      } else if (storeIds.length > 0) {
-        filteredStores = filteredStores.filter(s => storeIds.includes(s.id))
-      }
-      
-      // 売上データを計算
-      logger.log('📊 イベントデータ取得完了:', { eventsCount: events.length, filteredStoresCount: filteredStores.length })
-      const data = calculateSalesData(events, filteredStores, startDate, endDate, miscTransactions || [], salarySettings, staffByName)
-      logger.log('📊 売上データ計算完了:', { totalRevenue: data.totalRevenue })
-      setSalesData(data)
-    } catch (error) {
-      logger.error('❌ 売上データの取得に失敗しました:', error)
-    } finally {
-      setLoading(false)
-    }
-  }, [stores, customStartDate, customEndDate])
+    setActiveParams({ startDate: range.startDate, endDate: range.endDate, storeIds, ownershipFilter })
+  }, [customStartDate, customEndDate])
 
   return {
     salesData,

--- a/src/pages/StaffManagement/hooks/useStoresAndScenarios.ts
+++ b/src/pages/StaffManagement/hooks/useStoresAndScenarios.ts
@@ -1,67 +1,40 @@
-import { useState, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { storeApi, scenarioApi } from '@/lib/api'
 import type { Store, Scenario } from '@/types'
-import { logger } from '@/utils/logger'
 
-/**
- * 店舗とシナリオデータを管理するフック
- */
+export const storeScenarioKeys = {
+  stores: ['staff-page-stores'] as const,
+  scenarios: ['staff-page-scenarios'] as const,
+}
+
 export function useStoresAndScenarios() {
-  const [stores, setStores] = useState<Store[]>([])
-  const [scenarios, setScenarios] = useState<Scenario[]>([])
+  const { data: stores = [] } = useQuery<Store[]>({
+    queryKey: storeScenarioKeys.stores,
+    queryFn: () => storeApi.getAll(),
+    staleTime: 30 * 60 * 1000,
+  })
 
-  /**
-   * 店舗データを読み込む
-   */
-  const loadStores = useCallback(async () => {
-    try {
-      const data = await storeApi.getAll()
-      setStores(data)
-    } catch (err: any) {
-      logger.error('Error loading stores:', err)
-    }
-  }, [])
+  const { data: scenarios = [] } = useQuery<Scenario[]>({
+    queryKey: storeScenarioKeys.scenarios,
+    queryFn: () => scenarioApi.getAll(),
+    staleTime: 30 * 60 * 1000,
+  })
 
-  /**
-   * シナリオデータを読み込む
-   */
-  const loadScenarios = useCallback(async () => {
-    try {
-      const data = await scenarioApi.getAll()
-      setScenarios(data)
-    } catch (err: any) {
-      logger.error('Error loading scenarios:', err)
-    }
-  }, [])
-
-  /**
-   * シナリオIDからシナリオオブジェクトを取得
-   * scenarioIdはscenarios.idまたはscenario_master_id（scenario_mastersテーブルのID）のどちらでも対応
-   */
   const getScenario = useCallback((scenarioId: string): Scenario | undefined => {
     return scenarios.find(s => s.id === scenarioId) ?? scenarios.find(s => s.scenario_master_id === scenarioId)
   }, [scenarios])
 
-  /**
-   * シナリオIDから名前を取得
-   * scenarioIdはscenarios.idまたはscenario_master_id（scenario_mastersテーブルのID）のどちらでも対応
-   */
   const getScenarioName = useCallback((scenarioId: string) => {
     return getScenario(scenarioId)?.title || '不明なシナリオ'
   }, [getScenario])
 
-  /**
-   * シナリオIDリストから名前リストを取得
-   */
   const getScenarioNames = useCallback((scenarioIds: string[]) => {
     return scenarioIds
       .map(id => getScenarioName(id))
       .filter(name => name !== '不明なシナリオ')
   }, [getScenarioName])
 
-  /**
-   * シナリオの選択肢リスト（Select用）
-   */
   const scenarioOptions = useMemo(() => {
     return scenarios.map(scenario => ({
       value: scenario.id,
@@ -69,15 +42,16 @@ export function useStoresAndScenarios() {
     }))
   }, [scenarios])
 
-  /**
-   * 店舗の選択肢リスト（Select用）
-   */
   const storeOptions = useMemo(() => {
     return stores.map(store => ({
       value: store.id,
       label: store.name
     }))
   }, [stores])
+
+  // index.tsx の useEffect から呼ばれていた関数（React Query 化により不要だが互換のため残す）
+  const loadStores = useCallback(() => {}, [])
+  const loadScenarios = useCallback(() => {}, [])
 
   return {
     stores,
@@ -88,7 +62,6 @@ export function useStoresAndScenarios() {
     getScenarioName,
     getScenarioNames,
     scenarioOptions,
-    storeOptions
+    storeOptions,
   }
 }
-

--- a/src/pages/StaffManagement/index.tsx
+++ b/src/pages/StaffManagement/index.tsx
@@ -50,7 +50,7 @@ export function StaffManagement() {
 
   // React Query でCRUD操作
   const queryClient = useQueryClient()
-  const { data: staff = [], isLoading: loading, error: queryError } = useStaffQuery()
+  const { data: staff = [], isLoading: staffLoading, error: queryError } = useStaffQuery()
   const staffMutation = useStaffMutation()
   const error = queryError ? (queryError as Error).message : ''
 
@@ -63,6 +63,9 @@ export function StaffManagement() {
     getScenario,
     getScenarioName
   } = useStoresAndScenarios()
+
+  // 店舗・シナリオが揃うまでローディング扱い（UUID/「不明なシナリオ」の一瞬表示を防ぐ）
+  const loading = staffLoading || stores.length === 0 || scenarios.length === 0
 
   // スタッフの認証状態を取得
   const staffUserIds = useMemo(() => staff.map(s => s.user_id ?? null), [staff])
@@ -165,12 +168,6 @@ export function StaffManagement() {
     }
   })
 
-  // 初期データ読み込み
-  useEffect(() => {
-    loadStores()
-    loadScenarios()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   // 検索・フィルタの状態を自動保存
   useEffect(() => {


### PR DESCRIPTION
## Summary

ページ遷移して戻ったときに「ローディングなしで即表示」されるよう、主要管理ページのデータ取得を React Query に移行。

| ページ | 変更内容 |
|---|---|
| 外部公演報告 | `useExternalReports` を `useQuery` 化 |
| 顧客管理 | `useCustomerData` を `useQuery` 化（staleTime 3分） |
| クーポン管理 | `useCouponCampaigns` フックを新規作成 |
| GM可否確認 | `useGMRequests` を `useQuery` 化（stores も別クエリ） |
| 貸切管理 | `useBookingRequests` の手動キャッシュを React Query に置換・並列 API 化 |
| 売上管理 | `useSalesData` の stores / 売上データを `useQuery` 化（同一期間はキャッシュ即表示） |

### 動作の変化
- **初回訪問**: 従来通りロードして取得
- **再訪問（キャッシュ期間内）**: ローディングなし、即時表示
- **staleTime**: 各ページ 2〜5分（店舗データのみ 30分）

## Test plan

- [ ] 各ページを開いてデータが正常に表示されること
- [ ] 他のページに移動して戻ったとき、ロードなしで即表示されること
- [ ] 顧客管理で更新（refreshCustomers）が正常に動くこと
- [ ] 貸切管理の承認・却下・GM回答が正常に動くこと
- [ ] 売上管理で期間を切り替えたとき、正しいデータが表示されること
- [ ] クーポン管理でキャンペーンの作成・有効/無効切替が動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)