### PR TITLE
feat: バックエンド API レイヤー追加（シナリオ取得を service_role 経由に移行）

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,0 +1,76 @@
+import { db } from './db'
+
+export type ApiRole = 'admin' | 'staff' | 'customer' | 'license_admin'
+
+export type AuthUser = {
+  userId: string
+  orgId: string
+  role: ApiRole
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+/**
+ * リクエストの Authorization ヘッダから JWT を取り出し、
+ * Supabase で署名検証 → public.users テーブルから org_id と role を取得して返す。
+ *
+ * org_id はフロントから受け取るのではなく必ず DB から取得する。
+ * これにより、フロントが org_id を改ざんしても意味がない。
+ */
+export async function requireAuth(req: Request): Promise<AuthUser> {
+  const authHeader = req.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw new ApiError(401, 'Authorization ヘッダが必要です')
+  }
+
+  const jwt = authHeader.slice(7)
+
+  // Supabase 側で署名検証・有効期限チェックを行う
+  const { data: { user }, error: authError } = await db.auth.getUser(jwt)
+  if (authError || !user) {
+    throw new ApiError(401, 'トークンが無効または期限切れです')
+  }
+
+  // org_id と role は必ず DB から取得（JWT クレームは信用しない）
+  const { data: profile, error: profileError } = await db
+    .from('users')
+    .select('organization_id, role')
+    .eq('id', user.id)
+    .single()
+
+  if (profileError || !profile) {
+    throw new ApiError(403, 'ユーザープロフィールが見つかりません')
+  }
+
+  if (!profile.organization_id) {
+    throw new ApiError(403, 'このユーザーは組織に属していません')
+  }
+
+  return {
+    userId: user.id,
+    orgId: profile.organization_id as string,
+    role: profile.role as ApiRole,
+  }
+}
+
+/** スタッフ以上の権限が必要なエンドポイント用 */
+export function requireStaff(user: AuthUser): void {
+  if (!['admin', 'staff', 'license_admin'].includes(user.role)) {
+    throw new ApiError(403, 'スタッフ以上の権限が必要です')
+  }
+}
+
+/** ライセンス管理者のみ使えるエンドポイント用 */
+export function requireLicenseAdmin(user: AuthUser): void {
+  if (user.role !== 'license_admin') {
+    throw new ApiError(403, 'ライセンス管理者権限が必要です')
+  }
+}

--- a/api/_lib/db.ts
+++ b/api/_lib/db.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error(
+    'SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY 環境変数が必要です。' +
+    'Vercel の Environment Variables に設定してください。'
+  )
+}
+
+// service_role クライアント: RLS を完全にバイパスする
+// 絶対にフロントエンドのコードに含めないこと
+export const db = createClient(supabaseUrl, serviceRoleKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+})

--- a/api/scenarios.ts
+++ b/api/scenarios.ts
@@ -1,0 +1,93 @@
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { handle } from 'hono/vercel'
+import { z } from 'zod'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db } from './_lib/db'
+
+// Node.js ランタイムを明示（service_role key を安全に使うため Edge は使わない）
+export const config = { runtime: 'nodejs' }
+
+// 許可するオリジン（同一ドメイン本番 + ローカル開発）
+const allowedOrigins = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+const app = new Hono().basePath('/api')
+
+app.use(
+  '*',
+  cors({
+    origin: (origin) => (allowedOrigins.includes(origin) ? origin : allowedOrigins[0]),
+    allowHeaders: ['Authorization', 'Content-Type'],
+    allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    credentials: true,
+  }),
+)
+
+// ─── GET /api/scenarios ─────────────────────────────────────────────────────
+// スタッフ・管理者向け: 自組織のシナリオ一覧（全フィールド）を返す。
+// service_role で DB を叩くため RLS を完全にバイパスし、
+// 代わりにこの関数内で organization_id を強制フィルタする。
+const ScenariosQuerySchema = z.object({
+  status: z.enum(['available', 'unavailable', 'coming_soon']).optional(),
+})
+
+app.get('/scenarios', async (c) => {
+  try {
+    const user = await requireAuth(c.req.raw)
+    requireStaff(user)
+
+    const parsed = ScenariosQuerySchema.safeParse(c.req.query())
+    if (!parsed.success) {
+      return c.json({ error: 'パラメータが不正です', details: parsed.error.flatten() }, 400)
+    }
+
+    let query = db
+      .from('organization_scenarios_with_master')
+      .select(
+        'id, org_scenario_id, organization_id, scenario_master_id, slug, status, org_status, ' +
+        'title, author, author_email, author_id, report_display_name, key_visual_url, ' +
+        'description, synopsis, caution, player_count_min, player_count_max, ' +
+        'male_count, female_count, other_count, duration, weekend_duration, ' +
+        'genre, difficulty, has_pre_reading, release_date, official_site_url, required_props, ' +
+        'participation_fee, gm_test_participation_fee, participation_costs, ' +
+        'flexible_pricing, use_flexible_pricing, ' +
+        'license_amount, gm_test_license_amount, franchise_license_amount, franchise_gm_test_license_amount, ' +
+        'external_license_amount, external_gm_test_license_amount, ' +
+        'fc_receive_license_amount, fc_receive_gm_test_license_amount, ' +
+        'fc_author_license_amount, fc_author_gm_test_license_amount, ' +
+        'gm_costs, gm_count, gm_assignments, available_gms, experienced_staff, ' +
+        'available_stores, production_cost, production_costs, depreciation_per_performance, ' +
+        'extra_preparation_time, play_count, notes, created_at, updated_at, ' +
+        'master_status, pricing_patterns, is_shared, scenario_type, rating, kit_count, ' +
+        'license_rewards, is_recommended, survey_url, survey_enabled, survey_deadline_days, ' +
+        'characters, pre_reading_notice_message, booking_start_date, booking_end_date, ' +
+        'individual_notice_template, character_assignment_method, ' +
+        'private_booking_time_slots, private_booking_blocked_slots',
+      )
+      // org_id は auth.ts で DB から取得したもの。フロントからの入力を一切信用しない
+      .eq('organization_id', user.orgId)
+      .order('title', { ascending: true })
+
+    if (parsed.data.status) {
+      query = query.eq('org_status', parsed.data.status)
+    }
+
+    const { data, error } = await query
+    if (error) {
+      console.error('[GET /api/scenarios] DB error:', error)
+      return c.json({ error: 'データ取得に失敗しました' }, 500)
+    }
+
+    return c.json(data ?? [])
+  } catch (e) {
+    if (e instanceof ApiError) return c.json({ error: e.message }, e.status)
+    console.error('[GET /api/scenarios] Unexpected error:', e)
+    return c.json({ error: 'サーバーエラーが発生しました' }, 500)
+  }
+})
+
+export default handle(app)

--- a/env.example
+++ b/env.example
@@ -1,3 +1,23 @@
+# ============================================================
+# バックエンド API (/api/*) 用の環境変数
+# Vercel の Environment Variables に設定する（フロントには絶対含めない）
+# ============================================================
+
+# Supabase URL（フロントの VITE_SUPABASE_URL と同じ値）
+SUPABASE_URL=https://your-project.supabase.co
+
+# service_role キー: RLS を完全にバイパスするためサーバー側だけに置く
+# Supabase Dashboard → Project Settings → API → service_role
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
+
+# 本番の CORS 許可オリジン（例: https://mmq.jp）
+# 未設定の場合は localhost のみ許可される
+ALLOWED_ORIGIN=https://your-production-domain.com
+
+# ============================================================
+# フロントエンド用の環境変数
+# ============================================================
+
 # Supabase Configuration
 VITE_SUPABASE_URL=https://your-project.supabase.co
 # 推奨: Publishable key（sb_publishable_...）

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "dotenv": "^17.2.3",
         "exceljs": "^4.4.0",
         "file-saver": "^2.0.5",
+        "hono": "^4.12.19",
         "html2canvas": "^1.4.1",
         "idb-keyval": "^6.2.2",
         "lucide-react": "^0.400.0",
@@ -55,7 +56,8 @@
         "tailwind-merge": "^2.1.0",
         "tailwindcss-animate": "^1.0.7",
         "vite-plugin-pwa": "^1.1.0",
-        "workbox-window": "^7.3.0"
+        "workbox-window": "^7.3.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -4570,55 +4572,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -7353,6 +7306,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html2canvas": {
@@ -11574,6 +11536,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "dotenv": "^17.2.3",
     "exceljs": "^4.4.0",
     "file-saver": "^2.0.5",
+    "hono": "^4.12.19",
     "html2canvas": "^1.4.1",
     "idb-keyval": "^6.2.2",
     "lucide-react": "^0.400.0",
@@ -91,7 +92,8 @@
     "tailwind-merge": "^2.1.0",
     "tailwindcss-animate": "^1.0.7",
     "vite-plugin-pwa": "^1.1.0",
-    "workbox-window": "^7.3.0"
+    "workbox-window": "^7.3.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/src/lib/api/scenarioApi.ts
+++ b/src/lib/api/scenarioApi.ts
@@ -3,6 +3,7 @@
  */
 import { supabase } from '../supabase'
 import { getCurrentOrganizationId } from '@/lib/organization'
+import { apiClient } from '@/lib/apiClient'
 import type { Scenario } from '@/types'
 import type { PaginatedResponse } from './types'
 import { logger } from '@/utils/logger'
@@ -19,30 +20,31 @@ const ORG_SCENARIOS_VIEW_SELECT_FIELDS =
   'id, org_scenario_id, organization_id, scenario_master_id, slug, status, org_status, title, author, author_email, author_id, report_display_name, key_visual_url, description, synopsis, caution, player_count_min, player_count_max, male_count, female_count, other_count, duration, weekend_duration, genre, difficulty, has_pre_reading, release_date, official_site_url, required_props, participation_fee, gm_test_participation_fee, participation_costs, flexible_pricing, use_flexible_pricing, license_amount, gm_test_license_amount, franchise_license_amount, franchise_gm_test_license_amount, external_license_amount, external_gm_test_license_amount, fc_receive_license_amount, fc_receive_gm_test_license_amount, fc_author_license_amount, fc_author_gm_test_license_amount, gm_costs, gm_count, gm_assignments, available_gms, experienced_staff, available_stores, production_cost, production_costs, depreciation_per_performance, extra_preparation_time, play_count, notes, created_at, updated_at, master_status, pricing_patterns, is_shared, scenario_type, rating, kit_count, license_rewards, is_recommended, survey_url, survey_enabled, survey_deadline_days, characters, pre_reading_notice_message, booking_start_date, booking_end_date, individual_notice_template, character_assignment_method, private_booking_time_slots, private_booking_blocked_slots' as const
 
 export const scenarioApi = {
-  // 全シナリオを取得
-  // organizationId: 指定した場合そのIDを使用、未指定の場合はログインユーザーの組織で自動フィルタ
-  // skipOrgFilter: trueの場合、組織フィルタをスキップ（全組織のデータを取得）
+  // スタッフ・管理者向け: 自組織のシナリオ全件を取得する。
+  // バックエンド API (/api/scenarios) 経由で取得するため、
+  // org_id の強制フィルタはサーバー側で行われる（RLS に依存しない）。
+  //
+  // organizationId: 後方互換のため引数は残すが、サーバー側で JWT から org_id を
+  //   確実に取得するため、フロントから渡した値は使用されない。
+  // skipOrgFilter: license_admin が全組織を取得したい場合にのみ使用（将来拡張用）。
+  //   現時点ではバックエンド未対応のため、true の場合は旧来の Supabase 直接クエリにフォールバック。
   async getAll(organizationId?: string, skipOrgFilter?: boolean): Promise<Scenario[]> {
-    // organization_scenarios_with_master ビューを使用
-    let query = supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-    
-    // 組織フィルタリング
-    if (!skipOrgFilter) {
-      const orgId = organizationId || await getCurrentOrganizationId()
-      logger.log('🏢 シナリオ取得: organization_id =', orgId)
-      if (orgId) {
-        query = query.eq('organization_id', orgId)
-      } else {
-        logger.log('⚠️ organization_idがnullのため、フィルタなしで取得')
-      }
+    // skipOrgFilter=true（ライセンス管理者の全組織取得）は旧来の実装を使う
+    if (skipOrgFilter) {
+      logger.log('⚠️ skipOrgFilter=true: 旧来の Supabase 直接クエリを使用')
+      let query = supabase
+        .from('organization_scenarios_with_master')
+        .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
+      const { data, error } = await query.order('title', { ascending: true })
+      if (error) throw error
+      return (data || []) as unknown as Scenario[]
     }
-    
-    const { data, error } = await query.order('title', { ascending: true })
-    
-    if (error) throw error
-    return (data || []) as unknown as Scenario[]
+
+    // 通常のスタッフ・管理者: バックエンド API を経由して取得する
+    // サーバー側で JWT を検証し organization_id を確実にフィルタするため安全
+    logger.log('🏢 シナリオ取得: /api/scenarios を呼び出し')
+    const params = new URLSearchParams()
+    return apiClient.get<Scenario[]>(`/api/scenarios${params.size ? `?${params}` : ''}`)
   },
 
   // 旧scenarios テーブルから全シナリオを取得（キット管理等レガシー機能用）

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,51 @@
+/**
+ * バックエンド API (/api/*) を呼び出すためのクライアント。
+ *
+ * - Supabase セッションから JWT を取得して Authorization ヘッダに付与する
+ * - フロントは org_id をリクエストに含めない（サーバー側で JWT から確実に取得する）
+ * - エラー時は ApiClientError を throw する
+ */
+import { supabase } from './supabase'
+
+export class ApiClientError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ApiClientError'
+  }
+}
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const { data: { session }, error } = await supabase.auth.getSession()
+  if (error || !session) throw new ApiClientError(401, 'ログインが必要です')
+  return {
+    'Authorization': `Bearer ${session.access_token}`,
+    'Content-Type': 'application/json',
+  }
+}
+
+async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  const headers = await getAuthHeaders()
+  const res = await fetch(path, {
+    ...options,
+    headers: { ...headers, ...options?.headers },
+  })
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+    throw new ApiClientError(res.status, body?.error ?? `API エラー: ${res.status}`)
+  }
+
+  return res.json() as Promise<T>
+}
+
+export const apiClient = {
+  get: <T>(path: string) => apiFetch<T>(path),
+  post: <T>(path: string, body: unknown) =>
+    apiFetch<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: unknown) =>
+    apiFetch<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
+  delete: <T>(path: string) => apiFetch<T>(path, { method: 'DELETE' }),
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,6 +67,14 @@ export default defineConfig({
     strictPort: true, // 5173固定（別ポートに逃がさない）
     // CORS設定（ネットワーク経由アクセス対応）
     cors: true,
+    // /api/* を Vercel dev サーバー（port 3000）に転送する
+    // 開発時は `vercel dev` を port 3000 で起動すること
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
     hmr: {
       overlay: true,
       ...(devLan ? { clientPort: 5173 } : {}),


### PR DESCRIPTION
## 概要

RLS に依存しない安全なデータ取得のため、バックエンド API レイヤー（Vercel API Routes + Hono）を導入します。

## 変更内容

### 新規追加
- `api/_lib/db.ts` — Supabase service_role クライアント（RLS を完全にバイパス）
- `api/_lib/auth.ts` — JWT 検証 → org_id を DB から取得（フロント入力を信用しない）
- `api/scenarios.ts` — `GET /api/scenarios`（スタッフ向け・org_id 強制フィルタ）
- `src/lib/apiClient.ts` — フロント用 fetch ラッパー（Authorization ヘッダ自動付与）

### 変更
- `scenarioApi.getAll()` → `/api/scenarios` 経由に切り替え（RLS に依存しない安全な取得）
- `vite.config.ts` — 開発時の `/api` プロキシ設定（→ localhost:3000）
- `env.example` — バックエンド用環境変数を追記

## セキュリティの改善点

| 項目 | Before | After |
|---|---|---|
| org_id の保証 | RLS ポリシーに依存（壊れやすい） | サーバー側で JWT から確実に取得 |
| 機密データの保護 | RLS が壊れると全組織に漏洩 | service_role + org_id 強制フィルタ |
| 認証 | anon key + RLS | JWT 検証 → DB から role/org 取得 |

## Vercel 環境変数の設定（事前作業済み）

- `SUPABASE_URL` — Supabase プロジェクト URL
- `SUPABASE_SERVICE_ROLE_KEY` — service_role キー（ステージング・本番それぞれ）
- `ALLOWED_ORIGIN` — CORS 許可ドメイン

## テスト手順

1. staging デプロイ後、シナリオ管理画面を開く
2. シナリオ一覧が正常に表示されること
3. 別組織のスタッフアカウントでログインしても、自組織のシナリオのみ表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)