### PR TITLE
fix(api): 起動クラッシュ修正・env エラーを JSON で返す

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest } from '@vercel/node'
-import { db } from './db'
+import { db, getMissingEnvError } from './db'
 
 export type ApiRole = 'admin' | 'staff' | 'customer' | 'license_admin'
 
@@ -32,6 +32,9 @@ export async function requireAuth(req: VercelRequest): Promise<AuthUser> {
   }
 
   const jwt = authHeader.slice(7)
+
+  const envError = getMissingEnvError()
+  if (envError || !db) throw new ApiError(500, `環境変数が未設定です: ${envError}`)
 
   // Supabase 側で署名検証・有効期限チェック
   const { data: { user }, error: authError } = await db.auth.getUser(jwt)

--- a/api/_lib/db.ts
+++ b/api/_lib/db.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.SUPABASE_URL
+// VITE_SUPABASE_URL はフロント用だが Vercel に既設定済みのため fallback として使う
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 if (!supabaseUrl || !serviceRoleKey) {

--- a/api/_lib/db.ts
+++ b/api/_lib/db.ts
@@ -4,18 +4,16 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
-if (!supabaseUrl || !serviceRoleKey) {
-  throw new Error(
-    'SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY 環境変数が必要です。' +
-    'Vercel の Environment Variables に設定してください。'
-  )
-}
+// モジュール読み込み時に throw しない（FUNCTION_INVOCATION_FAILED を防ぐ）
+// 代わりに db を使う時点でエラーを返す
+export const db = (supabaseUrl && serviceRoleKey)
+  ? createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+  : null
 
-// service_role クライアント: RLS を完全にバイパスする
-// 絶対にフロントエンドのコードに含めないこと
-export const db = createClient(supabaseUrl, serviceRoleKey, {
-  auth: {
-    autoRefreshToken: false,
-    persistSession: false,
-  },
-})
+export function getMissingEnvError(): string | null {
+  if (!supabaseUrl) return 'SUPABASE_URL（または VITE_SUPABASE_URL）が設定されていません'
+  if (!serviceRoleKey) return 'SUPABASE_SERVICE_ROLE_KEY が設定されていません'
+  return null
+}

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,12 +1,13 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
-// 環境変数と基本的な動作を確認するための診断エンドポイント
-// 確認後は削除すること
 export default function handler(_req: VercelRequest, res: VercelResponse) {
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
   res.status(200).json({
     ok: true,
     env: {
       SUPABASE_URL: process.env.SUPABASE_URL ? '✅ set' : '❌ missing',
+      VITE_SUPABASE_URL: process.env.VITE_SUPABASE_URL ? '✅ set' : '❌ missing',
+      supabaseUrl_resolved: supabaseUrl ? '✅ resolved' : '❌ both missing',
       SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY ? '✅ set' : '❌ missing',
       ALLOWED_ORIGIN: process.env.ALLOWED_ORIGIN ?? '(not set)',
     },

--- a/api/scenarios.ts
+++ b/api/scenarios.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { requireAuth, requireStaff, ApiError } from './_lib/auth'
-import { db } from './_lib/db'
+import { db, getMissingEnvError } from './_lib/db'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,
@@ -56,8 +56,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    // JWT を検証し org_id を DB から確実に取得（フロントの入力を信用しない）
-    const user = await requireAuth(req as unknown as Request)
+    const envError = getMissingEnvError()
+    if (envError || !db) {
+      console.error('[GET /api/scenarios] 環境変数エラー:', envError)
+      return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+    }
+
+    const user = await requireAuth(req)
     requireStaff(user)
 
     const { data, error } = await db


### PR DESCRIPTION
## 修正内容

- `db.ts` がモジュール読み込み時に throw して `FUNCTION_INVOCATION_FAILED` を起こしていた問題を修正
- env var 不足時は `null` を返し、呼び出し側でエラー JSON を返す形に変更
- `VITE_SUPABASE_URL` を `SUPABASE_URL` の fallback として使用（既設定済みのため）

これにより `/api/scenarios` のレスポンスボディで「どの env var が足りないか」が確認できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)