### PR TITLE
feat(api): scenarioApi.getAll() をバックエンド API 経由に切り替え

### DIFF
--- a/src/lib/api/scenarioApi.ts
+++ b/src/lib/api/scenarioApi.ts
@@ -29,24 +29,18 @@ export const scenarioApi = {
   // skipOrgFilter: license_admin が全組織を取得したい場合にのみ使用（将来拡張用）。
   //   現時点ではバックエンド未対応のため、true の場合は旧来の Supabase 直接クエリにフォールバック。
   async getAll(organizationId?: string, skipOrgFilter?: boolean): Promise<Scenario[]> {
-    // TODO: バックエンド API (/api/scenarios) 移行作業中。現在は Supabase 直接クエリを使用。
-    let query = supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-
-    if (!skipOrgFilter) {
-      const orgId = organizationId || await getCurrentOrganizationId()
-      logger.log('🏢 シナリオ取得: organization_id =', orgId)
-      if (orgId) {
-        query = query.eq('organization_id', orgId)
-      } else {
-        logger.log('⚠️ organization_idがnullのため、フィルタなしで取得')
-      }
+    // skipOrgFilter=true（ライセンス管理者の全組織取得）は Supabase 直接クエリを使う
+    if (skipOrgFilter) {
+      const { data, error } = await supabase
+        .from('organization_scenarios_with_master')
+        .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
+        .order('title', { ascending: true })
+      if (error) throw error
+      return (data || []) as unknown as Scenario[]
     }
 
-    const { data, error } = await query.order('title', { ascending: true })
-    if (error) throw error
-    return (data || []) as unknown as Scenario[]
+    // バックエンド API 経由: org_id をサーバー側で強制フィルタ（RLS に依存しない）
+    return apiClient.get<Scenario[]>('/api/scenarios')
   },
 
   // 旧scenarios テーブルから全シナリオを取得（キット管理等レガシー機能用）


### PR DESCRIPTION
## 概要

`/api/scenarios` エンドポイントの動作確認完了（ブラウザで 401 を正常返却を確認）。
`scenarioApi.getAll()` をバックエンド API 経由に切り替え。

## セキュリティ改善

- org_id はサーバー側で JWT → DB から取得（フロントの入力を信用しない）
- service_role で DB アクセスするため RLS ポリシーに依存しない
- 他組織のデータが漏洩するリスクを構造的に排除

## テスト確認事項

- [ ] シナリオ管理画面でシナリオ一覧が表示される
- [ ] Network タブで `/api/scenarios` が 200 OK になっている
- [ ] 他組織のシナリオが混入していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)