### PR TITLE
fix(api): ESM 相対 import に .js 拡張子を付与（バックエンド API 500 解消）

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest } from '@vercel/node'
-import { db, getMissingEnvError } from './db'
+import { db, getMissingEnvError } from './db.js'
 
 export type ApiRole = 'admin' | 'staff' | 'customer' | 'license_admin'
 

--- a/api/assignments.ts
+++ b/api/assignments.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/customers.ts
+++ b/api/customers.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/event-history.ts
+++ b/api/event-history.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/kit-locations.ts
+++ b/api/kit-locations.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/manuals.ts
+++ b/api/manuals.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/memos.ts
+++ b/api/memos.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/org-settings.ts
+++ b/api/org-settings.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/reservations.ts
+++ b/api/reservations.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/shifts.ts
+++ b/api/shifts.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/staff.ts
+++ b/api/staff.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/api/stores.ts
+++ b/api/stores.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db, getMissingEnvError } from './_lib/db'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -100,6 +100,9 @@ export const AdminSidebar = memo(function AdminSidebar() {
       items: [
         { id: 'dashboard', label: 'ダッシュボード', icon: LayoutDashboard, path: `/${slug}/dashboard`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'schedule', label: 'スケジュール', icon: CalendarDays, path: `/${slug}/schedule`, roles: ['admin', 'staff', 'license_admin'] },
+        { id: 'stores',    label: '店舗',     icon: Store,    path: `/${slug}/stores`,    roles: ['admin', 'license_admin'] },
+        { id: 'staff',     label: 'スタッフ', icon: Users,    path: `/${slug}/staff`,     roles: ['admin', 'license_admin'] },
+        { id: 'scenarios', label: 'シナリオ', icon: BookOpen, path: `/${slug}/scenarios`, roles: ['admin', 'staff', 'license_admin'] },
       ],
     },
     {
@@ -110,16 +113,6 @@ export const AdminSidebar = memo(function AdminSidebar() {
         { id: 'shift-submission', label: 'シフト提出', icon: CalendarClock, path: `/${slug}/shift-submission`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'gm-availability', label: 'GM確認', icon: UserCheck, path: `/${slug}/gm-availability`, roles: ['admin', 'staff', 'license_admin'] },
         { id: 'staff-profile', label: '担当作品', icon: UserCircle, path: `/${slug}/staff-profile`, roles: ['admin', 'staff', 'license_admin'] },
-      ],
-    },
-    {
-      id: 'basic-data',
-      label: '基本データ',
-      icon: Store,
-      items: [
-        { id: 'stores',    label: '店舗',     icon: Store,    path: `/${slug}/stores`,    roles: ['admin', 'license_admin'] },
-        { id: 'staff',     label: 'スタッフ', icon: Users,    path: `/${slug}/staff`,     roles: ['admin', 'license_admin'] },
-        { id: 'scenarios', label: 'シナリオ', icon: BookOpen, path: `/${slug}/scenarios`, roles: ['admin', 'staff', 'license_admin'] },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- `package.json` が `"type": "module"` のため、Vercel Node Functions は ESM として実行され、相対 import に拡張子が必須
- 拡張子なしで `./_lib/db`, `./_lib/auth` を import していた結果、`ERR_MODULE_NOT_FOUND` → `FUNCTION_INVOCATION_FAILED` → HTTP 500 が発生していた（staff / stores / org-settings ページが開けない症状）
- 11 個の `api/*.ts` と `api/_lib/auth.ts` の相対 import に `.js` 拡張子を付与
- ついでに AdminSidebar の「基本データ」セクション統合も同梱

## Background
`2d15c974` で `api/scenarios.ts` を「単一ファイルにインライン化」して回避した問題と同じ根本原因。今回は拡張子付与で対応したため、scenarios.ts も将来 `_lib/` 経由に戻せる。

## Test plan
- [ ] staging デプロイ後、ブラウザで staff (`/{slug}/staff`) ページを開いて 200 が返ることを確認
- [ ] stores (`/{slug}/stores`) ページを開いて 200 が返ることを確認
- [ ] ダッシュボード (org-settings + stores 取得) を開いて 500 エラーが消えていることを確認
- [ ] その他のページ (reservations, customers, shifts 等) も同様に 500 が出ないことを確認
- [ ] AdminSidebar の項目並びが意図通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)