### PR TITLE
chore(dev): vite.config を vercel dev 互換に・.env*.local を gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ supabase/schema_snapshot.sql
 
 # AI team runtime state
 scripts/ai-team/.processed_issues
+.env*.local

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,8 +63,10 @@ export default defineConfig({
   server: {
     // 既定 127.0.0.1（起動安定）。スマホ等から繋ぐときは VITE_DEV_HOST=all npm run dev
     host: devHost,
-    port: 5173,
-    strictPort: true, // 5173固定（別ポートに逃がさない）
+    // `vercel dev` 経由で起動された場合は PORT env が渡されるのでそれに従う。
+    // 単独 `npm run dev` 時は 5173 固定（別ポートに逃がさない）。
+    port: process.env.PORT ? parseInt(process.env.PORT, 10) : 5173,
+    strictPort: !process.env.PORT,
     // CORS設定（ネットワーク経由アクセス対応）
     cors: true,
     // /api/* を Vercel dev サーバー（port 3000）に転送する


### PR DESCRIPTION
## Summary
- `vite.config.ts` の `server.port` を `PORT` env 対応に変更。`vercel dev` 経由起動時の port detection timeout を回避。単独 `npm run dev` 時は従来通り 5173 固定（strictPort も `PORT` 未設定時のみ true）。
- `.gitignore` に `.env*.local` 追加（`vercel env pull` が自動で追加した安全策）。

## Background
PR #147 の検証作業中、`npx vercel dev` を起動すると Vite が `strictPort: true` で 5173 固定するため、vercel dev が指定した別ポートを Vite が無視して `Detecting port XXXXX timed out` で 5 分タイムアウトする問題が発生。`PORT` env を渡されたときだけそれに従う形に変更し、両方の起動方法を共存可能にする。

## Test plan
- [ ] `npm run dev` 単独で 5173 に立ち上がる（従来挙動）
- [ ] `npx vercel dev --listen 5173` で Vite が同じプロセス内 5173 で起動して Ready になる
- [ ] CI typecheck / lint / build が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)