### PR TITLE
feat(api): couponApi の read 系 3 メソッドをバックエンド API に移行

### DIFF
--- a/api/coupons.ts
+++ b/api/coupons.ts
@@ -1,0 +1,313 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, ApiError } from './_lib/auth.js'
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+const CUSTOMER_COUPON_FIELDS = `
+  id,
+  campaign_id,
+  customer_id,
+  organization_id,
+  uses_remaining,
+  expires_at,
+  status,
+  created_at,
+  updated_at,
+  coupon_campaigns (
+    id,
+    organization_id,
+    name,
+    description,
+    discount_type,
+    discount_amount,
+    max_uses_per_customer,
+    target_type,
+    target_ids,
+    trigger_type,
+    valid_from,
+    valid_until,
+    is_active
+  )
+`
+
+// JWT user.id から customer 行を1件取得（重複行があっても order + limit(1) で安全）
+async function findCustomerByUserId(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  database: any,
+  userId: string,
+  organizationId: string | null,
+  selectFields = 'id'
+): Promise<Record<string, unknown> | null> {
+  let query = database.from('customers').select(selectFields).eq('user_id', userId)
+  if (organizationId) {
+    query = query.eq('organization_id', organizationId)
+  }
+  const { data } = await query.order('created_at', { ascending: true }).limit(1)
+  return (data?.[0] as Record<string, unknown>) ?? null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+
+    const type = (req.query.type as string | undefined) ?? 'available'
+    const requestedOrgId = req.query.organization_id as string | undefined
+
+    if (type === 'available') {
+      return await handleAvailable(req, res, user.userId, requestedOrgId ?? user.orgId)
+    }
+    if (type === 'all') {
+      return await handleAll(req, res, user.userId, user.orgId)
+    }
+    if (type === 'usages') {
+      return await handleUsages(req, res, user.userId, user.orgId)
+    }
+
+    return res.status(400).json({ error: `unknown type: ${type}` })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[coupons] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// 利用可能クーポン: status='active' かつ uses_remaining > 0 かつ有効期限内
+async function handleAvailable(
+  _req: VercelRequest,
+  res: VercelResponse,
+  userId: string,
+  organizationId: string
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const customer = await findCustomerByUserId(database, userId, organizationId)
+  if (!customer) return res.status(200).json([])
+
+  const { data, error } = await database
+    .from('customer_coupons')
+    .select(CUSTOMER_COUPON_FIELDS)
+    .eq('customer_id', customer.id)
+    .eq('organization_id', organizationId)
+    .eq('status', 'active')
+    .gt('uses_remaining', 0)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('[coupons:available] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  // 有効期限フィルタはサーバ側でも行う（フロントの now と齟齬が出ないように）
+  const now = new Date()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const filtered = ((data as any[]) ?? []).filter((coupon: any) => {
+    if (coupon.expires_at && new Date(coupon.expires_at) < now) return false
+    const campaign = coupon.coupon_campaigns
+    if (campaign) {
+      if (!campaign.is_active) return false
+      if (campaign.valid_from && new Date(campaign.valid_from) > now) return false
+      if (campaign.valid_until && new Date(campaign.valid_until) < now) return false
+    }
+    return true
+  })
+
+  return res.status(200).json(filtered)
+}
+
+// マイページ用クーポン一覧（全ステータス・使用履歴付き・店舗名付き）
+async function handleAll(
+  _req: VercelRequest,
+  res: VercelResponse,
+  userId: string,
+  organizationId: string
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const customer = await findCustomerByUserId(database, userId, organizationId)
+  if (!customer) return res.status(200).json([])
+
+  const { data: couponRows, error: couponError } = await database
+    .from('customer_coupons')
+    .select(CUSTOMER_COUPON_FIELDS)
+    .eq('customer_id', customer.id)
+    .order('created_at', { ascending: false })
+
+  if (couponError) {
+    console.error('[coupons:all] coupons DB error:', couponError)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: couponError.message })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (couponRows as any[]) ?? []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const couponIds = rows.map((c: any) => c.id)
+  if (couponIds.length === 0) return res.status(200).json(rows)
+
+  // 使用履歴 + 紐づく予約
+  const { data: usageRows, error: usageError } = await database
+    .from('coupon_usages')
+    .select(`
+      id,
+      customer_coupon_id,
+      reservation_id,
+      used_at,
+      discount_amount,
+      reservations (
+        id,
+        title,
+        requested_datetime,
+        store_id
+      )
+    `)
+    .in('customer_coupon_id', couponIds)
+    .order('used_at', { ascending: false })
+
+  if (usageError) {
+    console.warn('[coupons:all] usages fetch failed:', usageError)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return res.status(200).json(rows.map((c: any) => ({ ...c, coupon_usages: [] })))
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const usages = (usageRows ?? []) as any[]
+  const storeIds = [
+    ...new Set(
+      usages
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .map((u: any) => {
+          const r = u.reservations
+          const one = Array.isArray(r) ? r[0] : r
+          return one?.store_id
+        })
+        .filter((id: unknown): id is string => typeof id === 'string'),
+    ),
+  ]
+
+  const storeMap: Record<string, { name: string; short_name: string | null }> = {}
+  if (storeIds.length > 0) {
+    const { data: storeRows, error: storeError } = await database
+      .from('stores')
+      .select('id, name, short_name')
+      .in('id', storeIds)
+    if (storeError) {
+      console.warn('[coupons:all] stores fetch failed:', storeError)
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(storeRows as any[])?.forEach((s: any) => {
+        storeMap[s.id] = { name: s.name, short_name: s.short_name }
+      })
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const byCoupon: Record<string, any[]> = {}
+  for (const u of usages) {
+    const resRaw = u.reservations
+    const r = Array.isArray(resRaw) ? resRaw[0] : resRaw
+    const sid = r?.store_id ?? null
+    const storeInfo = sid ? storeMap[sid] : undefined
+    const entry = {
+      id: u.id,
+      reservation_id: u.reservation_id,
+      used_at: u.used_at,
+      discount_amount: u.discount_amount,
+      reservations: r
+        ? {
+            id: r.id,
+            title: r.title,
+            requested_datetime: r.requested_datetime,
+            store_id: r.store_id,
+            stores: storeInfo ? { name: storeInfo.name, short_name: storeInfo.short_name } : null,
+          }
+        : null,
+    }
+    const cid = u.customer_coupon_id
+    if (!byCoupon[cid]) byCoupon[cid] = []
+    byCoupon[cid].push(entry)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = rows.map((c: any) => ({ ...c, coupon_usages: byCoupon[c.id] ?? [] }))
+  return res.status(200).json(result)
+}
+
+// クーポン使用履歴
+async function handleUsages(
+  _req: VercelRequest,
+  res: VercelResponse,
+  userId: string,
+  organizationId: string
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const customer = await findCustomerByUserId(database, userId, organizationId)
+  if (!customer) return res.status(200).json([])
+
+  const { data: coupons } = await database
+    .from('customer_coupons')
+    .select('id')
+    .eq('customer_id', customer.id)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const couponIds = ((coupons as any[]) ?? []).map((c: any) => c.id)
+  if (couponIds.length === 0) return res.status(200).json([])
+
+  const { data, error } = await database
+    .from('coupon_usages')
+    .select(`
+      id,
+      customer_coupon_id,
+      reservation_id,
+      discount_amount,
+      used_at,
+      customer_coupons (
+        id,
+        campaign_id,
+        coupon_campaigns (
+          name,
+          discount_type,
+          discount_amount
+        )
+      )
+    `)
+    .in('customer_coupon_id', couponIds)
+    .order('used_at', { ascending: false })
+
+  if (error) {
+    console.error('[coupons:usages] DB error:', error)
+    // JOIN 失敗のフォールバック（既存実装と同じ挙動）
+    const { data: usages, error: usageError } = await database
+      .from('coupon_usages')
+      .select('id, customer_coupon_id, reservation_id, discount_amount, used_at')
+      .in('customer_coupon_id', couponIds)
+      .order('used_at', { ascending: false })
+    if (usageError) {
+      console.error('[coupons:usages] fallback DB error:', usageError)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: usageError.message })
+    }
+    return res.status(200).json(usages ?? [])
+  }
+
+  return res.status(200).json(data ?? [])
+}

--- a/src/lib/api/couponApi.ts
+++ b/src/lib/api/couponApi.ts
@@ -6,11 +6,11 @@
  * - キャンペーン管理（管理者向け）
  */
 import { supabase } from '../supabase'
+import { apiClient } from '../apiClient'
 import { getCurrentOrganizationId } from '@/lib/organization'
 import { logger } from '@/utils/logger'
 import type {
   CustomerCoupon,
-  CustomerCouponUsageWithReservation,
   CouponUsage,
   CouponCampaign
 } from '@/types'
@@ -66,81 +66,19 @@ export interface CampaignFormData {
  * - 有効期限内（expires_at が NULL or 未来）
  * - キャンペーンもアクティブ
  *
- * @param organizationId 対象組織ID（予約先の組織でフィルタ）
+ * @param organizationId 対象組織ID（予約先の組織でフィルタ。省略時はサーバ側で JWT の orgId を使う）
  */
 export async function getAvailableCoupons(
   organizationId?: string
 ): Promise<CustomerCoupon[]> {
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return []
-
-  const orgForCustomer = organizationId ?? (await getCurrentOrganizationId())
-  const customer = await findCustomerByUserId(user.id, orgForCustomer)
-
-  if (!customer) return []
-
-  let query = supabase
-    .from('customer_coupons')
-    .select(`
-      id,
-      campaign_id,
-      customer_id,
-      organization_id,
-      uses_remaining,
-      expires_at,
-      status,
-      created_at,
-      updated_at,
-      coupon_campaigns (
-        id,
-        organization_id,
-        name,
-        description,
-        discount_type,
-        discount_amount,
-        max_uses_per_customer,
-        target_type,
-        target_ids,
-        trigger_type,
-        valid_from,
-        valid_until,
-        is_active
-      )
-    `)
-    .eq('customer_id', customer.id)
-    .eq('status', 'active')
-    .gt('uses_remaining', 0)
-
-  // 組織でフィルタ（予約先組織のクーポンのみ表示）
-  if (organizationId) {
-    query = query.eq('organization_id', organizationId)
-  }
-
-  const { data, error } = await query.order('created_at', { ascending: false })
-
-  if (error) {
-    logger.error('利用可能クーポン取得エラー:', error)
+  try {
+    const params = new URLSearchParams({ type: 'available' })
+    if (organizationId) params.set('organization_id', organizationId)
+    return await apiClient.get<CustomerCoupon[]>(`/api/coupons?${params}`)
+  } catch (err) {
+    logger.error('利用可能クーポン取得エラー:', err)
     return []
   }
-
-  // 有効期限チェック（クライアント側でもフィルタ）
-  const now = new Date()
-  const filtered = (data as unknown as CustomerCoupon[])?.filter(coupon => {
-    // クーポン自体の有効期限
-    if (coupon.expires_at && new Date(coupon.expires_at) < now) {
-      return false
-    }
-    // キャンペーンの有効期限
-    const campaign = coupon.coupon_campaigns
-    if (campaign) {
-      if (!campaign.is_active) return false
-      if (campaign.valid_from && new Date(campaign.valid_from) > now) return false
-      if (campaign.valid_until && new Date(campaign.valid_until) < now) return false
-    }
-    return true
-  }) || []
-
-  return filtered
 }
 
 /**
@@ -148,164 +86,12 @@ export async function getAvailableCoupons(
  * マイページ表示用
  */
 export async function getAllCoupons(): Promise<CustomerCoupon[]> {
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return []
-
-  const orgForCustomer = await getCurrentOrganizationId()
-  const customer = await findCustomerByUserId(user.id, orgForCustomer)
-
-  if (!customer) return []
-
-  // ネストを1段に抑える（customer_coupons → coupon_usages → … は PostgREST で失敗しやすい）
-  const { data, error } = await supabase
-    .from('customer_coupons')
-    .select(`
-      id,
-      campaign_id,
-      customer_id,
-      organization_id,
-      uses_remaining,
-      expires_at,
-      status,
-      created_at,
-      updated_at,
-      coupon_campaigns (
-        id,
-        organization_id,
-        name,
-        description,
-        discount_type,
-        discount_amount,
-        max_uses_per_customer,
-        target_type,
-        target_ids,
-        trigger_type,
-        valid_from,
-        valid_until,
-        is_active
-      )
-    `)
-    .eq('customer_id', customer.id)
-    .order('created_at', { ascending: false })
-
-  if (error) {
-    logger.error('クーポン一覧取得エラー:', error)
+  try {
+    return await apiClient.get<CustomerCoupon[]>('/api/coupons?type=all')
+  } catch (err) {
+    logger.error('クーポン一覧取得エラー:', err)
     return []
   }
-
-  const rows = (data as unknown as CustomerCoupon[]) || []
-  const couponIds = rows.map((c) => c.id)
-  if (couponIds.length === 0) {
-    return rows
-  }
-
-  const { data: usageRows, error: usageError } = await supabase
-    .from('coupon_usages')
-    .select(
-      `
-      id,
-      customer_coupon_id,
-      reservation_id,
-      used_at,
-      discount_amount,
-      reservations (
-        id,
-        title,
-        requested_datetime,
-        store_id
-      )
-    `
-    )
-    .in('customer_coupon_id', couponIds)
-    .order('used_at', { ascending: false })
-
-  if (usageError) {
-    logger.warn('クーポン使用履歴の取得に失敗しました（クーポン一覧のみ表示）:', usageError)
-    return rows.map((c) => ({ ...c, coupon_usages: [] }))
-  }
-
-  type UsageRow = {
-    id: string
-    customer_coupon_id: string
-    reservation_id: string
-    used_at: string
-    discount_amount: number
-    reservations:
-      | {
-          id: string
-          title: string | null
-          requested_datetime: string
-          store_id: string | null
-        }
-      | {
-          id: string
-          title: string | null
-          requested_datetime: string
-          store_id: string | null
-        }[]
-      | null
-  }
-
-  const usages = (usageRows || []) as UsageRow[]
-  const storeIds = [
-    ...new Set(
-      usages
-        .map((u) => {
-          const r = u.reservations
-          const one = Array.isArray(r) ? r[0] : r
-          return one?.store_id
-        })
-        .filter((id): id is string => !!id)
-    )
-  ]
-
-  const storeMap: Record<string, { name: string; short_name: string | null }> = {}
-  if (storeIds.length > 0) {
-    const { data: storeRows, error: storeError } = await supabase
-      .from('stores')
-      .select('id, name, short_name')
-      .in('id', storeIds)
-    if (storeError) {
-      logger.warn('店舗名の取得に失敗（公演表示から店舗名を省略）:', storeError)
-    } else {
-      storeRows?.forEach((s) => {
-        storeMap[s.id] = { name: s.name, short_name: s.short_name }
-      })
-    }
-  }
-
-  const byCoupon: Record<string, CustomerCouponUsageWithReservation[]> = {}
-  for (const u of usages) {
-    const resRaw = u.reservations
-    const res = Array.isArray(resRaw) ? resRaw[0] : resRaw
-    const sid = res?.store_id ?? null
-    const storeInfo = sid ? storeMap[sid] : undefined
-    const entry: CustomerCouponUsageWithReservation = {
-      id: u.id,
-      reservation_id: u.reservation_id,
-      used_at: u.used_at,
-      discount_amount: u.discount_amount,
-      reservations: res
-        ? {
-            id: res.id,
-            title: res.title,
-            requested_datetime: res.requested_datetime,
-            store_id: res.store_id,
-            stores: storeInfo
-              ? { name: storeInfo.name, short_name: storeInfo.short_name }
-              : null
-          }
-        : null
-    }
-    const cid = u.customer_coupon_id
-    if (!byCoupon[cid]) byCoupon[cid] = []
-    byCoupon[cid].push(entry)
-  }
-
-  return rows.map((c) => ({
-    ...c,
-    coupon_usages: byCoupon[c.id] ?? []
-  }))
 }
 
 /**
@@ -721,69 +507,12 @@ export async function getCurrentReservations(): Promise<Array<{
  * クーポン使用履歴を取得
  */
 export async function getCouponUsageHistory(): Promise<CouponUsage[]> {
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return []
-
-  const orgForCustomer = await getCurrentOrganizationId()
-  const customer = await findCustomerByUserId(user.id, orgForCustomer)
-
-  if (!customer) return []
-
-  // まず顧客のクーポンIDを取得
-  const { data: coupons } = await supabase
-    .from('customer_coupons')
-    .select('id')
-    .eq('customer_id', customer.id)
-
-  if (!coupons || coupons.length === 0) return []
-
-  const couponIds = coupons.map(c => c.id)
-
-  const { data, error } = await supabase
-    .from('coupon_usages')
-    .select(`
-      id,
-      customer_coupon_id,
-      reservation_id,
-      discount_amount,
-      used_at,
-      customer_coupons (
-        id,
-        campaign_id,
-        coupon_campaigns (
-          name,
-          discount_type,
-          discount_amount
-        )
-      )
-    `)
-    .in('customer_coupon_id', couponIds)
-    .order('used_at', { ascending: false })
-
-  if (error) {
-    logger.error('クーポン使用履歴取得エラー:', error)
-    // フォールバック: JOINなしで取得
-    const { data: usages, error: usageError } = await supabase
-      .from('coupon_usages')
-      .select(`
-        id,
-        customer_coupon_id,
-        reservation_id,
-        discount_amount,
-        used_at
-      `)
-      .in('customer_coupon_id', couponIds)
-      .order('used_at', { ascending: false })
-
-    if (usageError) {
-      logger.error('クーポン使用履歴取得フォールバックエラー:', usageError)
-      return []
-    }
-
-    return (usages as unknown as CouponUsage[]) || []
+  try {
+    return await apiClient.get<CouponUsage[]>('/api/coupons?type=usages')
+  } catch (err) {
+    logger.error('クーポン使用履歴取得エラー:', err)
+    return []
   }
-
-  return (data as unknown as CouponUsage[]) || []
 }
 
 // =========================================


### PR DESCRIPTION
## Summary
- セキュリティ最優先（他人のクーポン漏洩リスク）の couponApi 読み取り系メソッドを `/api/coupons` に集約。
- `customer_id` をフロントから受け取らず、サーバー側で JWT の `user_id` から `customers` 行を引いて使う。

## 変更内容

### 新規ファイル
- `api/coupons.ts`: 1 ファイル・`?type=` で分岐する単一エンドポイント
  - `?type=available[&organization_id=xxx]` → 利用可能クーポン（status=active かつ uses_remaining>0、有効期限内、キャンペーンも active）
  - `?type=all` → マイページ用全クーポン + 使用履歴 + 店舗名
  - `?type=usages` → クーポン使用履歴

### フロント変更
- `src/lib/api/couponApi.ts`:
  - `getAvailableCoupons(organizationId?)` → `apiClient.get('/api/coupons?type=available[&organization_id=xxx]')`
  - `getAllCoupons()` → `apiClient.get('/api/coupons?type=all')`
  - `getCouponUsageHistory()` → `apiClient.get('/api/coupons?type=usages')`
- 305 行 → 17 行（-288 行）

### 今回触らないもの（別 PR）
- write 系: `useCoupon` / `grantRegistrationCoupon` / `grantCouponToCustomer` / `restoreCouponUsage`
- 管理者向け read: `getCampaigns` / `getCouponUsagesForAdmin` / `getCampaignCoupons` / `getCampaignStats` / `searchCustomers`
- 複雑系: `getCurrentReservations`（複数テーブル合成）

## セキュリティ改善
- 旧: フロントが `customer_id` を渡せた → ユーザーが他人の `customer_id` を指定すれば他人のクーポン取得が理論上可能
- 新: サーバー側で JWT → user → customers 行を引くため、認証ユーザー自身のクーポンしか取得できない

## Test plan
- [ ] staging デプロイ後、マイページ（クーポン一覧）が正しく表示される
- [ ] 予約フローでクーポン選択画面に対象組織の利用可能クーポンが表示される
- [ ] クーポン使用履歴が表示される
- [ ] 認証されていない状態で `/api/coupons?type=available` を叩くと 401 が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)