### PR TITLE
fix(api): organizationScenarioApi のマルチテナント脆弱性を修正

### DIFF
--- a/api/org-scenarios.ts
+++ b/api/org-scenarios.ts
@@ -1,0 +1,77 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+const ORG_SCENARIO_WITH_MASTER_SELECT_FIELDS =
+  'id, organization_id, scenario_master_id, slug, org_status, pricing_patterns, gm_assignments, created_at, updated_at, title, author, author_id, key_visual_url, description, synopsis, caution, player_count_min, player_count_max, duration, genre, difficulty, participation_fee, extra_preparation_time, master_status'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  const id = req.query.id as string | undefined
+  const slug = req.query.slug as string | undefined
+  const status = req.query.status as string | undefined
+
+  try {
+    const user = await requireAuth(req)
+    requireStaff(user)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let query: any = (db as any)
+      .from('organization_scenarios_with_master')
+      .select(ORG_SCENARIO_WITH_MASTER_SELECT_FIELDS)
+      .eq('organization_id', user.orgId)
+
+    if (id) {
+      query = query.eq('id', id)
+    }
+    if (slug) {
+      query = query.eq('slug', slug)
+    }
+    if (status) {
+      query = query.eq('org_status', status)
+    }
+
+    query = query.order('title', { ascending: true })
+
+    if (id || slug) {
+      const { data, error } = await query.maybeSingle()
+      if (error) {
+        console.error('[org-scenarios] DB error:', error)
+        return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+      }
+      return res.status(200).json(data ?? null)
+    }
+
+    const { data, error } = await query
+    if (error) {
+      console.error('[org-scenarios] DB error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? [])
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[org-scenarios] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}

--- a/src/lib/api/scenarioMasterApi.ts
+++ b/src/lib/api/scenarioMasterApi.ts
@@ -4,6 +4,7 @@
  */
 import { supabase } from '../supabase'
 import { getCurrentOrganizationId } from '@/lib/organization'
+import { apiClient } from '@/lib/apiClient'
 import { logger } from '@/utils/logger'
 
 // NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
@@ -229,94 +230,57 @@ export const scenarioMasterApi = {
 export const organizationScenarioApi = {
   /**
    * 自組織のシナリオ一覧を取得（ビュー使用）
+   * 注: organizationId 引数は後方互換のため残しているが、サーバー側で JWT から強制されるため無視される
    */
-  async getAll(organizationId?: string): Promise<OrganizationScenarioWithMaster[]> {
-    const orgId = organizationId || await getCurrentOrganizationId()
-    
-    let query = supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIO_WITH_MASTER_SELECT_FIELDS)
-      .order('title', { ascending: true })
-    
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { data, error } = await query
-    
-    if (error) {
+  async getAll(_organizationId?: string): Promise<OrganizationScenarioWithMaster[]> {
+    try {
+      const data = await apiClient.get<OrganizationScenarioWithMaster[]>('/api/org-scenarios')
+      return data ?? []
+    } catch (error) {
       logger.error('Failed to get organization scenarios:', error)
       throw error
     }
-    return data || []
   },
 
   /**
    * 公開中のシナリオのみ取得（予約サイト用）
    */
-  async getAvailable(organizationId?: string): Promise<OrganizationScenarioWithMaster[]> {
-    const orgId = organizationId || await getCurrentOrganizationId()
-    
-    let query = supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIO_WITH_MASTER_SELECT_FIELDS)
-      .eq('org_status', 'available')
-      .order('title', { ascending: true })
-    
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { data, error } = await query
-    
-    if (error) {
+  async getAvailable(_organizationId?: string): Promise<OrganizationScenarioWithMaster[]> {
+    try {
+      const data = await apiClient.get<OrganizationScenarioWithMaster[]>('/api/org-scenarios?status=available')
+      return data ?? []
+    } catch (error) {
       logger.error('Failed to get available organization scenarios:', error)
       throw error
     }
-    return data || []
   },
 
   /**
-   * IDで組織シナリオを取得
+   * IDで組織シナリオを取得（自組織のみ。サーバー側で organization_id を強制）
    */
-  async getById(id: string): Promise<OrganizationScenarioWithMaster | null> {
-    const { data, error } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIO_WITH_MASTER_SELECT_FIELDS)
-      .eq('id', id)
-      .single()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null
+  async getById(id: string, _organizationId?: string): Promise<OrganizationScenarioWithMaster | null> {
+    try {
+      return await apiClient.get<OrganizationScenarioWithMaster | null>(
+        `/api/org-scenarios?id=${encodeURIComponent(id)}`
+      )
+    } catch (error) {
       logger.error('Failed to get organization scenario by id:', error)
       throw error
     }
-    return data
   },
 
   /**
-   * slugで組織シナリオを取得
+   * slugで組織シナリオを取得（自組織のみ。サーバー側で organization_id を強制）
    */
-  async getBySlug(slug: string, organizationId?: string): Promise<OrganizationScenarioWithMaster | null> {
-    const orgId = organizationId || await getCurrentOrganizationId()
-    
-    let query = supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIO_WITH_MASTER_SELECT_FIELDS)
-      .eq('slug', slug)
-    
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { data, error } = await query.single()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null
+  async getBySlug(slug: string, _organizationId?: string): Promise<OrganizationScenarioWithMaster | null> {
+    try {
+      return await apiClient.get<OrganizationScenarioWithMaster | null>(
+        `/api/org-scenarios?slug=${encodeURIComponent(slug)}`
+      )
+    } catch (error) {
       logger.error('Failed to get organization scenario by slug:', error)
       throw error
     }
-    return data
   },
 
   /**
@@ -349,16 +313,22 @@ export const organizationScenarioApi = {
   },
 
   /**
-   * 組織シナリオを更新
+   * 組織シナリオを更新（自組織のみ）
    */
   async update(id: string, data: Partial<OrganizationScenario>): Promise<OrganizationScenario> {
+    const orgId = await getCurrentOrganizationId()
+    if (!orgId) {
+      throw new Error('Organization ID is required')
+    }
+
     const { data: updated, error } = await supabase
       .from('organization_scenarios')
       .update(data)
       .eq('id', id)
+      .eq('organization_id', orgId)
       .select()
       .single()
-    
+
     if (error) {
       logger.error('Failed to update organization scenario:', error)
       throw error
@@ -367,14 +337,20 @@ export const organizationScenarioApi = {
   },
 
   /**
-   * 組織シナリオを削除
+   * 組織シナリオを削除（自組織のみ）
    */
   async delete(id: string): Promise<void> {
+    const orgId = await getCurrentOrganizationId()
+    if (!orgId) {
+      throw new Error('Organization ID is required')
+    }
+
     const { error } = await supabase
       .from('organization_scenarios')
       .delete()
       .eq('id', id)
-    
+      .eq('organization_id', orgId)
+
     if (error) {
       logger.error('Failed to delete organization scenario:', error)
       throw error


### PR DESCRIPTION
## Summary

組織シナリオの取得が ID/slug だけで全組織から検索可能になっていた問題を、バックエンド API 経由（サーバー側で JWT から `organization_id` を強制）に切り替えて修正。

### 脆弱性の内容

- `organizationScenarioApi.getById(id)`：`organization_id` フィルタなしで `organization_scenarios_with_master` を検索 → 他組織の ID を知っていれば直接読み取り可能だった
- `organizationScenarioApi.getBySlug(slug)`：`organizationId` 引数が undefined のとき、slug 単独で全組織から検索 → 他組織の slug を推測できれば読み取り可能だった
- `organizationScenarioApi.update(id, ...)` / `delete(id)`：`organization_id` チェックなしで書き込み可能だった

### 修正

- 新規: [api/org-scenarios.ts](api/org-scenarios.ts) — GET: `?id=` / `?slug=` / `?status=available` / no-params の各パラメータに対応。サーバー側で `requireAuth()` → `user.orgId` を必須フィルタとして付与
- 変更: [src/lib/api/scenarioMasterApi.ts](src/lib/api/scenarioMasterApi.ts) の `getAll` / `getAvailable` / `getById` / `getBySlug` を `apiClient.get()` 経由に
- 二重防護: `update` / `delete` にも `.eq('organization_id', orgId)` を追加（Supabase 直クエリのまま、サーバー側保護を残しつつクライアントレベルでも自組織以外を弾く）

### 精査の経緯

`scenario_masters` / `organization_scenarios` まわりを精査した結果、コードレベルで 3 件の高リスク箇所を発見。前回の作業（PR #146 / #147）で確立した「フロント Supabase 直クエリ → バックエンドAPI 経由」のパターンに従って統一。

### 残課題（別 PR）

精査では他にも対応すべき箇所が見つかっています：
- `scenarioMasterApi.getAll()` / `getApproved()` が draft も含めて全件返却（フロント側 supabase 直、RLS 任せ）
- `scenarioApi.getById()` のフォールバック検索に `organization_id` なし
- `ScenarioDetailGlobal` 内の複数箇所で組織フィルタ抜け
- `scenario_id` / `scenario_master_id` / `org_scenario_id` の使い分けの曖昧さ

## Test plan

- [ ] ステージングで自組織のシナリオ一覧・公開シナリオ一覧が表示されること
- [ ] 個別シナリオ詳細（ID / slug 経由の両方）が正しく取れること
- [ ] シナリオ更新・削除が自組織内で従来通り動くこと
- [ ] 他組織の ID/slug を直接叩いてもデータが返らないこと（404 or null）

🤖 Generated with [Claude Code](https://claude.com/claude-code)