### PR TITLE
chore(lint): staging の既存リントエラー 8 件を修正

### DIFF
--- a/src/hooks/useScheduleEventsQuery.ts
+++ b/src/hooks/useScheduleEventsQuery.ts
@@ -229,7 +229,7 @@ export async function fetchScheduleEventsForMonth(
 
   const privateEvents: ScheduleEvent[] = []
   if (privateRequests) {
-    ;(privateRequests as unknown as PrivateRequestData[]).forEach(request => {
+    (privateRequests as unknown as PrivateRequestData[]).forEach(request => {
       if (!request.candidate_datetimes?.candidates) return
 
       let gmNames: string[] = []

--- a/src/lib/assignmentApi.ts
+++ b/src/lib/assignmentApi.ts
@@ -7,7 +7,6 @@ import {
 } from './gmScenarioMode'
 
 // 担当関係レコードの型（旧 Supabase select で推論されていた構造に合わせる）
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AssignmentRow = any
 
 // スタッフ⇔シナリオの担当関係を管理するAPI

--- a/src/pages/MyPage/hooks/useReservationsQuery.ts
+++ b/src/pages/MyPage/hooks/useReservationsQuery.ts
@@ -59,12 +59,12 @@ export function useReservationsQuery(userId: string | undefined, email: string |
       const reservations = reservationsResult.data || []
       const waitlist = waitlistResult.data || []
 
-      let scenarioImages: Record<string, string> = {}
-      let scenarioInfo: Record<string, { min: number; max: number }> = {}
-      let scenarioTitles: Record<string, string> = {}
-      let stores: Record<string, Store> = {}
-      let storeDeadlines: Record<string, number> = {}
-      let storePrivateDeadlines: Record<string, number> = {}
+      const scenarioImages: Record<string, string> = {}
+      const scenarioInfo: Record<string, { min: number; max: number }> = {}
+      const scenarioTitles: Record<string, string> = {}
+      const stores: Record<string, Store> = {}
+      const storeDeadlines: Record<string, number> = {}
+      const storePrivateDeadlines: Record<string, number> = {}
 
       if (reservations.length > 0) {
         const storeIds = new Set<string>()

--- a/src/pages/Settings/pages/PerformanceScheduleSettings.tsx
+++ b/src/pages/Settings/pages/PerformanceScheduleSettings.tsx
@@ -140,7 +140,7 @@ export function PerformanceScheduleSettings({ storeId }: PerformanceScheduleSett
     const defaultSlots = ['morning', 'afternoon', 'evening', 'late_night']
     const defaultTimes = ['10:00', '14:00', '18:00', '22:00']
     const currentTimes = formData.performance_times
-    let newTimes = count > currentTimes.length
+    const newTimes = count > currentTimes.length
       ? [...currentTimes, ...Array.from({ length: count - currentTimes.length }, (_, i) => ({
           slot: defaultSlots[currentTimes.length + i] || `slot${currentTimes.length + i + 1}`,
           start_time: defaultTimes[currentTimes.length + i] || '12:00'

--- a/src/pages/StoreManagement/index.tsx
+++ b/src/pages/StoreManagement/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -70,10 +70,10 @@ export function StoreManagement() {
     return () => window.removeEventListener('hashchange', handleHashChange)
   }, [])
 
-  function openEditModal(store: Store | null) {
+  const openEditModal = useCallback((store: Store | null) => {
     setEditingStore(store)
     setIsEditModalOpen(true)
-  }
+  }, [])
 
   async function handleSaveStore(updatedStore: Store) {
     try {
@@ -140,8 +140,7 @@ export function StoreManagement() {
 
   const tableColumns = useMemo(
     () => createStoreColumns({ onEdit: openEditModal }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [openEditModal]
   )
 
   const defaultColumnKeys = useMemo(() => tableColumns.map(c => c.key), [tableColumns])


### PR DESCRIPTION
## Summary

staging ブランチで CI が検出していた既存リントエラー **計 10 件** を機械的に修正しました。ロジック変更はありません。

## 修正内容（ファイル別）

- **src/hooks/useScheduleEventsQuery.ts:232** — `no-extra-semi`: `if` ブロック直後の不要なセミコロンを削除
- **src/lib/assignmentApi.ts:10** — `Unused eslint-disable directive`: `@typescript-eslint/no-explicit-any` はプロジェクト設定で `off` のため不要となっていた eslint-disable コメントを削除
- **src/pages/MyPage/hooks/useReservationsQuery.ts:62-67** — `prefer-const` × 6 件: `scenarioImages` / `scenarioInfo` / `scenarioTitles` / `stores` / `storeDeadlines` / `storePrivateDeadlines` を `let` → `const` に変更（いずれもプロパティ代入のみで再代入されていない）
- **src/pages/Settings/pages/PerformanceScheduleSettings.tsx:143** — `prefer-const`: `newTimes` を `let` → `const` に変更（追加コミット）
- **src/pages/StoreManagement/index.tsx:142-143** — `Unused eslint-disable directive`: 不要な eslint-disable コメントを削除し、`openEditModal` を `useCallback` 化して `useMemo` の依存配列に追加（追加コミット）

## Test plan

- [x] `npm run lint` でリントエラー **0 件** を確認（既存 warning は据え置き）
- [x] `npx tsc -p tsconfig.json --noEmit` で型エラーがないことを確認
- [ ] CI のリントジョブが通ること（PR 上で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>