### PR TITLE
fix(security): .select('*') を明示的なフィールド指定に置き換え (CI Security guardrails 通過)

### DIFF
--- a/src/lib/api/manualApi.ts
+++ b/src/lib/api/manualApi.ts
@@ -21,14 +21,16 @@ export const manualPageApi = {
   async getWithBlocks(pageId: string): Promise<ManualPageWithBlocks> {
     const { data: page, error: pageError } = await supabase
       .from('manual_pages')
-      .select('*')
+      .select(
+        'id, organization_id, title, slug, description, category, icon_name, display_order, is_active, created_at, updated_at, page_content',
+      )
       .eq('id', pageId)
       .single()
     if (pageError) throw pageError
 
     const { data: blocks, error: blocksError } = await supabase
       .from('manual_blocks')
-      .select('*')
+      .select('id, page_id, block_type, content, display_order, created_at, updated_at')
       .eq('page_id', pageId)
       .order('display_order', { ascending: true })
     if (blocksError) throw blocksError

--- a/src/pages/Settings/pages/EmailLogsSettings.tsx
+++ b/src/pages/Settings/pages/EmailLogsSettings.tsx
@@ -138,7 +138,9 @@ export function EmailLogsSettings() {
     try {
       let query = supabase
         .from('email_logs')
-        .select('*')
+        .select(
+          'id, organization_id, reservation_id, schedule_event_id, email_type, to_email, to_name, subject, body_text, body_html, provider, provider_message_id, status, error_message, sent_at, delivered_at, opened_at, bounced_at, complained_at, created_at',
+        )
         .order('created_at', { ascending: false })
         .limit(200)
 


### PR DESCRIPTION
## Summary
CI の Security guardrails チェックで forbidden pattern として検出されていた `.select('*')` 3 件を、対応する型定義のフィールド列挙に置き換え。これで staging ブランチの CI が完全グリーンに復帰する。

## 背景
`scripts/check-security-guardrails.mjs` は `.select('*')` を最小権限原則違反として検出してエラー終了する設計。リント修正 (PR #152) 後も staging の CI は本チェックで FAILURE のままだった。

## 変更内容
- `src/lib/api/manualApi.ts`:
  - `manual_pages` の SELECT を `ManualPage` 型のフィールド列に展開
  - `manual_blocks` の SELECT を `ManualBlock` 型のフィールド列に展開
- `src/pages/Settings/pages/EmailLogsSettings.tsx`:
  - `email_logs` の SELECT を `EmailLog` interface のフィールド列に展開

## 検証
- `node scripts/check-security-guardrails.mjs` → exit 0 (`[SECURITY_GUARDRAILS] OK` / `[RLS_CHECK] OK`)
- `npx tsc -p tsconfig.json --noEmit` → エラーなし

## スコープ外
- POLICY_IDEMPOTENCY 117 件 — warning のみで exit に影響しない。別 PR でまとめて対応。
- セキュリティ関数の上書き警告 — warning のみ。

## Test plan
- [ ] CI Security guardrails が SUCCESS になる
- [ ] manualApi の getWithBlocks が変わらず動作する
- [ ] EmailLogsSettings 画面でメールログが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)