### PR TITLE
feat(api): scenarioApi.getById/getBySlug をバックエンド API 経由に切り替え

### DIFF
--- a/api/scenarios.ts
+++ b/api/scenarios.ts
@@ -95,7 +95,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(403).json({ error: 'スタッフ以上の権限が必要です' })
   }
 
-  // シナリオ取得（org_id をサーバー側で強制フィルタ）
+  const id = req.query.id as string | undefined
+  const slug = req.query.slug as string | undefined
+
+  // ?id=xxx → 単一シナリオ取得（master_id または org_scenario_id で検索）
+  if (id) {
+    return await handleGetById(res, orgId, id)
+  }
+
+  // ?slug=xxx → slug で単一シナリオ取得
+  if (slug) {
+    return await handleGetBySlug(res, orgId, slug)
+  }
+
+  // 一覧取得（org_id をサーバー側で強制フィルタ）
   const { data, error } = await db
     .from('organization_scenarios_with_master')
     .select(SELECT_FIELDS)
@@ -108,4 +121,90 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   return res.status(200).json(data ?? [])
+}
+
+// 単一シナリオ取得: master_id または org_scenario_id で、まず自組織を、ダメなら共有シナリオを検索。
+// 他組織の非共有シナリオを返さないよう is_shared=true で明示フィルタする（RLS に依存しない）。
+async function handleGetById(res: VercelResponse, orgId: string, id: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  // 1. 自組織で id (= scenario_master_id) で検索
+  const r1 = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (r1.data) return res.status(200).json(r1.data)
+  if (r1.error && r1.error.code !== 'PGRST116') {
+    console.error('[scenarios:getById] step1 error:', r1.error)
+  }
+
+  // 2. 自組織で org_scenario_id でも検索
+  const r2 = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('org_scenario_id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (r2.data) return res.status(200).json(r2.data)
+  if (r2.error && r2.error.code !== 'PGRST116') {
+    console.error('[scenarios:getById] step2 error:', r2.error)
+  }
+
+  // 3. 共有シナリオ（他組織でも is_shared=true なら可）から id 検索
+  const r3 = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('id', id)
+    .eq('is_shared', true)
+    .limit(1)
+  if (r3.error) {
+    console.error('[scenarios:getById] step3 error:', r3.error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: r3.error.message })
+  }
+  if (r3.data?.[0]) return res.status(200).json(r3.data[0])
+
+  // 4. 共有シナリオから org_scenario_id でも検索
+  const r4 = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('org_scenario_id', id)
+    .eq('is_shared', true)
+    .limit(1)
+  if (r4.error) {
+    console.error('[scenarios:getById] step4 error:', r4.error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: r4.error.message })
+  }
+
+  return res.status(200).json(r4.data?.[0] ?? null)
+}
+
+// slug で単一シナリオ取得（自組織 → 共有シナリオの順）
+async function handleGetBySlug(res: VercelResponse, orgId: string, slug: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const r1 = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('slug', slug)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (r1.data) return res.status(200).json(r1.data)
+  if (r1.error && r1.error.code !== 'PGRST116') {
+    console.error('[scenarios:getBySlug] step1 error:', r1.error)
+  }
+
+  const r2 = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('slug', slug)
+    .eq('is_shared', true)
+    .limit(1)
+  if (r2.error) {
+    console.error('[scenarios:getBySlug] step2 error:', r2.error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: r2.error.message })
+  }
+
+  return res.status(200).json(r2.data?.[0] ?? null)
 }

--- a/src/lib/api/scenarioApi.ts
+++ b/src/lib/api/scenarioApi.ts
@@ -81,60 +81,17 @@ export const scenarioApi = {
   },
 
   // IDでシナリオを取得（scenario_master_id で検索、見つからなければ org_scenario_id でも検索）
-  // organizationId: 指定した場合そのIDを使用、未指定の場合はログインユーザーの組織で自動フィルタ
-  // 自組織で見つからない場合は組織を問わず検索（他組織の共有シナリオ対応）
-  async getById(id: string, organizationId?: string): Promise<Scenario | null> {
-    const orgId = organizationId || await getCurrentOrganizationId()
-    logger.log('[scenarioApi.getById] 検索開始:', { id, orgId })
-
-    if (orgId) {
-      const { data, error } = await supabase
-        .from('organization_scenarios_with_master')
-        .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-        .eq('id', id)
-        .eq('organization_id', orgId)
-        .maybeSingle()
-
-      if (!error && data) {
-        logger.log('[scenarioApi.getById] id (scenario_master_id) で発見')
-        return data as unknown as Scenario
-      }
-      logger.log('[scenarioApi.getById] id で未発見, org_scenario_id で再検索:', { error: error?.message })
-
-      // id (= scenario_master_id) で見つからない場合、org_scenario_id でも検索
-      const { data: byOrgId, error: orgErr } = await supabase
-        .from('organization_scenarios_with_master')
-        .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-        .eq('org_scenario_id', id)
-        .eq('organization_id', orgId)
-        .maybeSingle()
-
-      if (!orgErr && byOrgId) {
-        logger.log('[scenarioApi.getById] org_scenario_id で発見')
-        return byOrgId as unknown as Scenario
-      }
-      logger.log('[scenarioApi.getById] org_scenario_id でも未発見:', { error: orgErr?.message })
+  // organizationId 引数は後方互換のため残すが、サーバー側で JWT から org_id を取得するため使われない。
+  // 自組織で見つからない場合は is_shared=true の共有シナリオから検索（サーバー側でフィルタ）。
+  async getById(_id: string, _organizationId?: string): Promise<Scenario | null> {
+    try {
+      const params = new URLSearchParams({ id: _id })
+      const result = await apiClient.get<Scenario | null>(`/api/scenarios?${params}`)
+      return result
+    } catch (err) {
+      logger.error('[scenarioApi.getById] エラー:', err)
+      throw err
     }
-
-    const { data, error } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-      .eq('id', id)
-      .limit(1)
-
-    if (error) throw error
-    if (data?.[0]) return data[0] as unknown as Scenario
-
-    // org_scenario_id でもフォールバック検索
-    const { data: fallback, error: fbErr } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-      .eq('org_scenario_id', id)
-      .limit(1)
-
-    if (fbErr) throw fbErr
-    logger.log('[scenarioApi.getById] 全検索結果:', { found: !!fallback?.[0] })
-    return (fallback?.[0] as unknown as Scenario) || null
   },
 
   /**
@@ -166,32 +123,18 @@ export const scenarioApi = {
     return (data as unknown as Scenario) || null
   },
 
-  // slugでシナリオを取得
-  // 自組織で見つからない場合は組織を問わず検索（他組織の共有シナリオ対応）
-  async getBySlug(slug: string, organizationId?: string): Promise<Scenario | null> {
-    const orgId = organizationId || await getCurrentOrganizationId()
-
-    if (orgId) {
-      const { data, error } = await supabase
-        .from('organization_scenarios_with_master')
-        .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-        .eq('slug', slug)
-        .eq('organization_id', orgId)
-        .maybeSingle()
-
-      if (!error && data) {
-        return data as unknown as Scenario
-      }
+  // slugでシナリオを取得（バックエンド経由）。
+  // organizationId 引数は後方互換のため残すが、サーバー側で JWT から org_id を取得するため使われない。
+  // 自組織で見つからない場合は is_shared=true の共有シナリオから検索（サーバー側でフィルタ）。
+  async getBySlug(slug: string, _organizationId?: string): Promise<Scenario | null> {
+    try {
+      const params = new URLSearchParams({ slug })
+      const result = await apiClient.get<Scenario | null>(`/api/scenarios?${params}`)
+      return result
+    } catch (err) {
+      logger.error('[scenarioApi.getBySlug] エラー:', err)
+      throw err
     }
-
-    const { data, error } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-      .eq('slug', slug)
-      .limit(1)
-
-    if (error) throw error
-    return (data?.[0] as unknown as Scenario) || null
   },
 
   // IDまたはslugでシナリオを取得（slugを優先、見つからなければIDで検索）


### PR DESCRIPTION
## Summary
既存の `/api/scenarios` を拡張し、`?id=` / `?slug=` クエリで単一シナリオ取得をサポート。`scenarioApi.getById` / `getBySlug` をバックエンド経由に切り替え。

## 変更内容

### api/scenarios.ts（拡張）
- `?id=xxx` → `handleGetById`: master_id (`id`) → `org_scenario_id` → 共有シナリオの順で検索
- `?slug=xxx` → `handleGetBySlug`: 自組織 → 共有シナリオの順で検索
- クエリなし → 従来通り一覧取得

### src/lib/api/scenarioApi.ts
- `getById(id, ?orgId)` → `apiClient.get('/api/scenarios?id=...')`
- `getBySlug(slug, ?orgId)` → `apiClient.get('/api/scenarios?slug=...')`
- 旧 Supabase 直接実装（合計約 90 行）を削除

## セキュリティ改善
- 旧実装: 「自組織で見つからなければ全組織から検索」のフォールバックは RLS が他組織の非共有シナリオを遮断することに依存していた。
- 新実装: service_role 利用のため RLS をバイパスする。代わりに **サーバ側で `is_shared = true` を明示フィルタ**して、他組織の非共有シナリオが返らないことを保証。

## 影響範囲
`getByIdOrSlug` / `resolveOrganizationScenarioView` / `getPaginated` などは内部で `getById` / `getBySlug` を呼ぶため、自動的にバックエンド経由になる。

## Test plan
- [ ] シナリオ詳細画面が表示される（自組織のシナリオ）
- [ ] 共有シナリオ（他組織の `is_shared=true`）の詳細が表示される
- [ ] 存在しない ID/slug の場合は 200 + null が返る
- [ ] 認証なしで `/api/scenarios?id=xxx` を叩くと 401 が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)