### PR TITLE
feat(api): scenarioApi の write 系と残り read 系をバックエンド API に移行（マルチテナント境界強化）

### DIFF
--- a/api/scenarios.ts
+++ b/api/scenarios.ts
@@ -19,7 +19,7 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
@@ -51,35 +51,93 @@ const SELECT_FIELDS = [
   'private_booking_time_slots', 'private_booking_blocked_slots',
 ].join(', ')
 
-// ─── ハンドラ ─────────────────────────────────────────────────────────────────
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-  setCors(req, res)
-  if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+// 旧 scenarios テーブル（getAllLegacy 用）
+const LEGACY_SCENARIO_FIELDS = [
+  'id', 'title', 'slug', 'description', 'author', 'author_email', 'report_display_name',
+  'duration', 'weekend_duration', 'player_count_min', 'player_count_max',
+  'male_count', 'female_count', 'other_count',
+  'difficulty', 'rating', 'status', 'scenario_type',
+  'participation_fee', 'participation_costs', 'gm_costs',
+  'license_amount', 'gm_test_license_amount',
+  'franchise_license_amount', 'franchise_gm_test_license_amount',
+  'external_license_amount', 'external_gm_test_license_amount',
+  'license_rewards', 'production_cost', 'genre', 'has_pre_reading', 'key_visual_url',
+  'notes', 'required_props', 'production_costs', 'kit_count', 'gm_count',
+  'available_stores', 'scenario_master_id', 'organization_id', 'is_shared',
+  'extra_preparation_time', 'available_gms', 'play_count', 'release_date',
+  'is_recommended', 'created_at', 'updated_at',
+].join(', ')
 
-  // 環境変数チェック
+// 公開用（一般ユーザ向け）。マスタービュー上で必要な最小カラムのみ。
+const PUBLIC_FIELDS = [
+  'id', 'title', 'key_visual_url', 'author', 'duration',
+  'player_count_min', 'player_count_max', 'genre', 'release_date',
+  'status', 'participation_fee', 'scenario_type', 'organization_id',
+].join(', ')
+
+// 統計集計用に getScenarioStats が必要とする最小カラム
+const STATS_SCENARIO_FIELDS = [
+  'player_count_max', 'license_amount', 'gm_test_license_amount',
+  'license_rewards', 'participation_fee', 'gm_test_participation_fee',
+  'participation_costs', 'gm_costs', 'duration',
+].join(', ')
+
+const STATS_SCHEDULE_EVENT_COUNT_FIELDS = 'id'
+
+const STATS_SCHEDULE_EVENT_DETAIL_FIELDS =
+  'id, date, category, current_participants, total_revenue, gm_cost, license_cost, ' +
+  'start_time, store_id, is_cancelled, stores:store_id(venue_cost_per_performance)'
+
+const STATS_ALL_SCHEDULE_EVENT_FIELDS =
+  'scenario_master_id, is_cancelled, total_revenue, date, category'
+
+const STATS_RESERVATION_FIELDS =
+  'schedule_event_id, participant_count, reservation_source, payment_method'
+
+const STATS_FUTURE_RESERVATION_FIELDS = 'id'
+
+// クライアント側の reservationSource 定数と一致させる必要があるが、
+// /api/* は ESM 単独で動くため、定数を直接列挙する（src/lib/constants の DEMO/STAFF と同じ値）。
+// 値がずれた場合の影響範囲は集計値のみ（権限境界には影響しない）。
+const STAFF_RESERVATION_SOURCES = new Set<string>([
+  'manual_staff',
+  'staff',
+])
+const DEMO_RESERVATION_SOURCES = new Set<string>([
+  'manual_demo',
+  'demo',
+])
+
+// ─── 認証ヘルパー ─────────────────────────────────────────────────────────────
+type AuthResult = { orgId: string; userId: string; role: string }
+
+async function authenticate(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<AuthResult | null> {
   if (!db) {
     const missing = [
       !supabaseUrl && 'SUPABASE_URL',
       !serviceRoleKey && 'SUPABASE_SERVICE_ROLE_KEY',
     ].filter(Boolean).join(', ')
     console.error('[scenarios] 環境変数が未設定:', missing)
-    return res.status(500).json({ error: `環境変数が未設定です: ${missing}` })
+    res.status(500).json({ error: `環境変数が未設定です: ${missing}` })
+    return null
   }
 
-  // JWT 検証
   const authHeader = req.headers['authorization'] as string | undefined
   if (!authHeader?.startsWith('Bearer ')) {
-    return res.status(401).json({ error: 'Authorization ヘッダが必要です' })
+    res.status(401).json({ error: 'Authorization ヘッダが必要です' })
+    return null
   }
   const jwt = authHeader.slice(7)
 
   const { data: { user }, error: authError } = await db.auth.getUser(jwt)
   if (authError || !user) {
-    return res.status(401).json({ error: 'トークンが無効または期限切れです' })
+    res.status(401).json({ error: 'トークンが無効または期限切れです' })
+    return null
   }
 
-  // org_id・role を DB から取得（JWT クレームを信用しない）
   const { data: profile, error: profileError } = await db
     .from('users')
     .select('organization_id, role')
@@ -87,28 +145,70 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     .single()
 
   if (profileError || !profile?.organization_id) {
-    return res.status(403).json({ error: 'ユーザー情報が取得できません' })
+    res.status(403).json({ error: 'ユーザー情報が取得できません' })
+    return null
   }
 
-  const { organization_id: orgId, role } = profile
-  if (!['admin', 'staff', 'license_admin'].includes(role)) {
-    return res.status(403).json({ error: 'スタッフ以上の権限が必要です' })
+  if (!['admin', 'staff', 'license_admin'].includes(profile.role as string)) {
+    res.status(403).json({ error: 'スタッフ以上の権限が必要です' })
+    return null
   }
+
+  return {
+    userId: user.id,
+    orgId: profile.organization_id as string,
+    role: profile.role as string,
+  }
+}
+
+// ─── ハンドラ ─────────────────────────────────────────────────────────────────
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const method = req.method
+  if (method !== 'GET' && method !== 'POST' && method !== 'PATCH' && method !== 'DELETE') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const auth = await authenticate(req, res)
+  if (!auth) return // authenticate がレスポンスを返している
+
+  const { orgId } = auth
+
+  try {
+    if (method === 'GET') return await routeGet(req, res, orgId)
+    if (method === 'POST') return await routePost(req, res, orgId)
+    if (method === 'PATCH') return await routePatch(req, res, orgId)
+    if (method === 'DELETE') return await routeDelete(req, res, orgId)
+  } catch (err) {
+    console.error('[scenarios] unexpected error:', err)
+    return res.status(500).json({
+      error: 'サーバーエラーが発生しました',
+      detail: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+// ─── GET ルーティング ─────────────────────────────────────────────────────────
+async function routeGet(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
 
   const id = req.query.id as string | undefined
   const slug = req.query.slug as string | undefined
+  const type = req.query.type as string | undefined
 
-  // ?id=xxx → 単一シナリオ取得（master_id または org_scenario_id で検索）
-  if (id) {
-    return await handleGetById(res, orgId, id)
-  }
+  if (id) return await handleGetById(res, orgId, id)
+  if (slug) return await handleGetBySlug(res, orgId, slug)
 
-  // ?slug=xxx → slug で単一シナリオ取得
-  if (slug) {
-    return await handleGetBySlug(res, orgId, slug)
-  }
+  if (type === 'legacy') return await handleGetAllLegacy(res, orgId)
+  if (type === 'public') return await handleGetPublic(res, orgId)
+  if (type === 'paginated') return await handleGetPaginated(req, res, orgId)
+  if (type === 'performance-count') return await handleGetPerformanceCount(req, res, orgId)
+  if (type === 'stats') return await handleGetScenarioStats(req, res, orgId)
+  if (type === 'all-stats') return await handleGetAllScenarioStats(res, orgId)
 
-  // 一覧取得（org_id をサーバー側で強制フィルタ）
+  // デフォルト: 一覧取得（org_id をサーバー側で強制フィルタ）
   const { data, error } = await db
     .from('organization_scenarios_with_master')
     .select(SELECT_FIELDS)
@@ -207,4 +307,797 @@ async function handleGetBySlug(res: VercelResponse, orgId: string, slug: string)
   }
 
   return res.status(200).json(r2.data?.[0] ?? null)
+}
+
+// 旧 scenarios テーブルから取得（レガシー機能用）。組織でフィルタ。
+async function handleGetAllLegacy(res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const { data, error } = await db
+    .from('scenarios')
+    .select(LEGACY_SCENARIO_FIELDS)
+    .eq('organization_id', orgId)
+    .order('title', { ascending: true })
+  if (error) {
+    console.error('[scenarios:legacy] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// 公開用シナリオ（status='available' のみ、自組織のみ）
+async function handleGetPublic(res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const { data, error } = await db
+    .from('organization_scenarios_with_master')
+    .select(PUBLIC_FIELDS)
+    .eq('status', 'available')
+    .eq('organization_id', orgId)
+    .order('title', { ascending: true })
+  if (error) {
+    console.error('[scenarios:public] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// ページネーション
+async function handleGetPaginated(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const page = Math.max(0, Number.parseInt((req.query.page as string) ?? '0', 10) || 0)
+  const pageSize = Math.min(
+    1000,
+    Math.max(1, Number.parseInt((req.query.pageSize as string) ?? '20', 10) || 20),
+  )
+  const from = page * pageSize
+  const to = from + pageSize - 1
+
+  const { data, error, count } = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS, { count: 'exact' })
+    .eq('organization_id', orgId)
+    .order('title', { ascending: true })
+    .range(from, to)
+
+  if (error) {
+    console.error('[scenarios:paginated] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json({
+    data: data ?? [],
+    count: count ?? 0,
+    hasMore: count ? from + pageSize < count : false,
+  })
+}
+
+// 累計公演回数（scenario_master_id 指定、組織でフィルタ、非中止のみ）
+async function handleGetPerformanceCount(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const scenarioId = req.query.scenarioId as string | undefined
+  if (!scenarioId) {
+    return res.status(400).json({ error: 'scenarioId が必要です' })
+  }
+
+  const { count, error } = await db
+    .from('schedule_events')
+    .select(STATS_SCHEDULE_EVENT_COUNT_FIELDS, { count: 'exact', head: true })
+    .eq('scenario_master_id', scenarioId)
+    .eq('organization_id', orgId)
+    .not('status', 'eq', 'cancelled')
+
+  if (error) {
+    console.error('[scenarios:performance-count] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json({ count: count ?? 0 })
+}
+
+// シナリオ統計（公演回数・売上・コスト等）
+async function handleGetScenarioStats(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const scenarioId = req.query.scenarioId as string | undefined
+  if (!scenarioId) {
+    return res.status(400).json({ error: 'scenarioId が必要です' })
+  }
+  const today = new Date().toISOString().split('T')[0]
+
+  // ── シナリオの料金・GM報酬等のメタ情報を取得（自組織） ───────────────────
+  const { data: scenarioData } = await db
+    .from('organization_scenarios_with_master')
+    .select(STATS_SCENARIO_FIELDS)
+    .eq('id', scenarioId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+
+  const maxParticipants = (scenarioData?.player_count_max as number | undefined) ?? 99
+  const defaultLicenseAmount = (scenarioData?.license_amount as number | undefined) ?? 0
+  const defaultGmTestLicenseAmount = (scenarioData?.gm_test_license_amount as number | undefined) ?? 0
+  const licenseRewards = scenarioData?.license_rewards as Array<{ item: string; amount: number }> | undefined
+  const normalLicenseFromRewards = licenseRewards?.find((r) => r.item === 'normal')?.amount
+  const gmTestLicenseFromRewards = licenseRewards?.find((r) => r.item === 'gmtest')?.amount
+  const normalLicenseAmount = normalLicenseFromRewards ?? defaultLicenseAmount
+  const gmTestLicenseAmount = gmTestLicenseFromRewards ?? defaultGmTestLicenseAmount
+
+  const participationCosts = scenarioData?.participation_costs as Array<{ time_slot: string; amount: number }> | undefined
+  const normalParticipationFee =
+    participationCosts?.find((c) => c.time_slot === 'normal')?.amount ??
+    ((scenarioData?.participation_fee as number | undefined) ?? 0)
+  const gmTestParticipationFee =
+    participationCosts?.find((c) => c.time_slot === 'gmtest')?.amount ??
+    ((scenarioData?.gm_test_participation_fee as number | undefined) ?? 0)
+
+  const gmAssignments = scenarioData?.gm_costs as Array<{ category?: string; reward?: number }> | undefined
+  const hasCustomGmCosts = !!gmAssignments && gmAssignments.length > 0
+  let normalGmReward = 0
+  let gmTestGmReward = 0
+  if (hasCustomGmCosts && gmAssignments) {
+    normalGmReward = gmAssignments
+      .filter((a) => (a.category || 'normal') === 'normal')
+      .reduce((sum, a) => sum + (a.reward || 0), 0)
+    gmTestGmReward = gmAssignments
+      .filter((a) => a.category === 'gmtest')
+      .reduce((sum, a) => sum + (a.reward || 0), 0) || Math.max(0, normalGmReward - 2000)
+  }
+  // NOTE: 旧実装ではフロントの useSalarySettings を使ってカスタム GM コストが無い場合に
+  // 給与設定から動的計算していた。サーバ側からは fetchSalarySettings を呼べないため、
+  // ここでは normalGmReward=0 / gmTestGmReward=0 のまま進める。
+  // 影響: 旧実装で自動計算されていた GM コスト集計が 0 になる可能性がある。
+  // TODO: salary_settings を読み込んでサーバ側でも calculateGmWage 相当を実装する。
+
+  // ── 公演回数 ────────────────────────────────────────────────────────────
+  const { count: performanceCount, error: perfError } = await db
+    .from('schedule_events')
+    .select(STATS_SCHEDULE_EVENT_COUNT_FIELDS, { count: 'exact', head: true })
+    .eq('scenario_master_id', scenarioId)
+    .eq('organization_id', orgId)
+    .lte('date', today)
+    .neq('category', 'offsite')
+    .neq('is_cancelled', true)
+  if (perfError) throw perfError
+
+  const { count: cancelledCount, error: cancelError } = await db
+    .from('schedule_events')
+    .select(STATS_SCHEDULE_EVENT_COUNT_FIELDS, { count: 'exact', head: true })
+    .eq('scenario_master_id', scenarioId)
+    .eq('organization_id', orgId)
+    .lte('date', today)
+    .neq('category', 'offsite')
+    .eq('is_cancelled', true)
+  if (cancelError) throw cancelError
+
+  // ── 初公演日 ────────────────────────────────────────────────────────────
+  const { data: firstEvent, error: firstError } = await db
+    .from('schedule_events')
+    .select('date')
+    .eq('scenario_master_id', scenarioId)
+    .eq('organization_id', orgId)
+    .lte('date', today)
+    .neq('category', 'offsite')
+    .neq('is_cancelled', true)
+    .order('date', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+  const firstPerformanceDate = firstError ? null : (firstEvent?.date as string | null) ?? null
+
+  // ── 公演イベント詳細 ────────────────────────────────────────────────────
+  const { data: events, error: eventsError } = await db
+    .from('schedule_events_staff_view')
+    .select(STATS_SCHEDULE_EVENT_DETAIL_FIELDS)
+    .eq('scenario_master_id', scenarioId)
+    .eq('organization_id', orgId)
+    .lte('date', today)
+    .order('date', { ascending: false })
+  if (eventsError) throw eventsError
+
+  type EventRow = {
+    id: string
+    date: string
+    category: string | null
+    current_participants: number | null
+    total_revenue: number | null
+    gm_cost: number | null
+    license_cost: number | null
+    start_time: string | null
+    store_id: string | null
+    is_cancelled: boolean | null
+    stores?: { venue_cost_per_performance?: number | null } | null
+  }
+  const eventList = (events ?? []) as unknown as EventRow[]
+  const eventIds = eventList.map((e) => e.id)
+  const demoParticipantsMap: Record<string, number> = {}
+  const actualParticipantsMap: Record<string, number> = {}
+  const staffParticipantsMap: Record<string, number> = {}
+
+  if (eventIds.length > 0) {
+    const BATCH_SIZE = 100
+    type ResRow = {
+      schedule_event_id: string | null
+      participant_count: number | null
+      reservation_source: string | null
+      payment_method: string | null
+    }
+    const allReservations: ResRow[] = []
+
+    for (let i = 0; i < eventIds.length; i += BATCH_SIZE) {
+      const batchIds = eventIds.slice(i, i + BATCH_SIZE)
+      const { data, error: resError } = await db
+        .from('reservations')
+        .select(STATS_RESERVATION_FIELDS)
+        .eq('organization_id', orgId)
+        .in('schedule_event_id', batchIds)
+        .in('status', ['confirmed', 'gm_confirmed'])
+      if (!resError && data) {
+        allReservations.push(...(data as unknown as ResRow[]))
+      }
+    }
+
+    for (const r of allReservations) {
+      if (!r.schedule_event_id) continue
+      const count = r.participant_count ?? 0
+      const src = r.reservation_source ?? ''
+      if (DEMO_RESERVATION_SOURCES.has(src)) {
+        demoParticipantsMap[r.schedule_event_id] = (demoParticipantsMap[r.schedule_event_id] ?? 0) + count
+      } else if (STAFF_RESERVATION_SOURCES.has(src) || r.payment_method === 'staff') {
+        staffParticipantsMap[r.schedule_event_id] = (staffParticipantsMap[r.schedule_event_id] ?? 0) + count
+      } else {
+        actualParticipantsMap[r.schedule_event_id] = (actualParticipantsMap[r.schedule_event_id] ?? 0) + count
+      }
+    }
+  }
+
+  let totalRevenue = 0
+  let totalParticipants = 0
+  let totalStaffParticipants = 0
+  let totalGmCost = 0
+  let totalLicenseCost = 0
+  let totalVenueCost = 0
+  const venueCostSet = new Set<number>()
+  const performanceDates: Array<{
+    date: string
+    category: string
+    participants: number
+    demoParticipants: number
+    staffParticipants: number
+    revenue: number
+    startTime: string
+    storeId: string | null
+    isCancelled: boolean
+  }> = []
+
+  for (const event of eventList) {
+    const isCancelled = event.is_cancelled === true
+    const demoCount = demoParticipantsMap[event.id] ?? 0
+    const staffCount = staffParticipantsMap[event.id] ?? 0
+    const actualCount = actualParticipantsMap[event.id] ?? 0
+    const reservationParticipants = actualCount + demoCount
+    const rawParticipants = reservationParticipants > 0
+      ? reservationParticipants
+      : event.current_participants ?? 0
+    const participants = Math.min(rawParticipants, maxParticipants)
+
+    const isGmTest = event.category === 'gmtest'
+    const fee = isGmTest ? gmTestParticipationFee : normalParticipationFee
+    const eventRevenue = event.total_revenue ?? participants * fee
+    const eventGmCost = event.gm_cost ?? (isGmTest ? gmTestGmReward : normalGmReward)
+
+    if (!isCancelled) {
+      totalParticipants += participants
+      totalStaffParticipants += staffCount
+      totalRevenue += eventRevenue
+      totalGmCost += eventGmCost
+
+      let licenseCost = event.license_cost ?? 0
+      if (licenseCost === 0) {
+        licenseCost = isGmTest ? gmTestLicenseAmount : normalLicenseAmount
+      }
+      totalLicenseCost += licenseCost
+
+      const venueCost = event.stores?.venue_cost_per_performance ?? 0
+      totalVenueCost += venueCost
+      if (venueCost > 0) venueCostSet.add(venueCost)
+    }
+
+    performanceDates.push({
+      date: event.date,
+      category: event.category ?? 'open',
+      participants,
+      demoParticipants: demoCount,
+      staffParticipants: staffCount,
+      revenue: eventRevenue,
+      startTime: event.start_time ?? '',
+      storeId: event.store_id ?? null,
+      isCancelled,
+    })
+  }
+
+  const perfCount = performanceCount ?? 0
+  const venueCostPerPerformance =
+    venueCostSet.size === 1
+      ? [...venueCostSet][0]
+      : venueCostSet.size > 1
+        ? Math.round(totalVenueCost / (perfCount || 1))
+        : 0
+
+  // ── 将来分カウント ──────────────────────────────────────────────────────
+  const { count: futurePerformanceCount } = await db
+    .from('schedule_events')
+    .select(STATS_SCHEDULE_EVENT_COUNT_FIELDS, { count: 'exact', head: true })
+    .eq('scenario_master_id', scenarioId)
+    .eq('organization_id', orgId)
+    .gt('date', today)
+    .neq('category', 'offsite')
+    .neq('is_cancelled', true)
+
+  const { count: futureReservationCount } = await db
+    .from('reservations')
+    .select(STATS_FUTURE_RESERVATION_FIELDS, { count: 'exact', head: true })
+    .eq('scenario_master_id', scenarioId)
+    .eq('organization_id', orgId)
+    .is('schedule_event_id', null)
+    .in('status', ['confirmed', 'gm_confirmed', 'pending'])
+
+  return res.status(200).json({
+    performanceCount: perfCount,
+    cancelledCount: cancelledCount ?? 0,
+    totalRevenue,
+    totalParticipants,
+    totalStaffParticipants,
+    totalGmCost,
+    totalLicenseCost,
+    totalVenueCost,
+    venueCostPerPerformance,
+    firstPerformanceDate,
+    performanceDates,
+    futurePerformanceCount: futurePerformanceCount ?? 0,
+    futureReservationCount: futureReservationCount ?? 0,
+  })
+}
+
+// 全シナリオの統計（リスト表示用、scenario_master_id ごとに集計）
+async function handleGetAllScenarioStats(res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const today = new Date().toISOString().split('T')[0]
+
+  const pageSize = 1000
+  let page = 0
+  let hasMore = true
+  type EventStatsRow = {
+    scenario_master_id: string | null
+    is_cancelled: boolean | null
+    total_revenue: number | null
+    date: string
+    category: string | null
+  }
+  const allEvents: EventStatsRow[] = []
+
+  while (hasMore) {
+    const from = page * pageSize
+    const to = from + pageSize - 1
+    const { data, error } = await db
+      .from('schedule_events_staff_view')
+      .select(STATS_ALL_SCHEDULE_EVENT_FIELDS)
+      .eq('organization_id', orgId)
+      .lte('date', today)
+      .neq('category', 'offsite')
+      .range(from, to)
+      .order('date', { ascending: false })
+    if (error) {
+      console.error('[scenarios:all-stats] DB error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    const rows = (data ?? []) as unknown as EventStatsRow[]
+    allEvents.push(...rows)
+    hasMore = rows.length === pageSize
+    page++
+  }
+
+  const statsMap: Record<string, { performanceCount: number; cancelledCount: number; totalRevenue: number }> = {}
+  for (const event of allEvents) {
+    const sid = event.scenario_master_id
+    if (!sid) continue
+    if (!statsMap[sid]) {
+      statsMap[sid] = { performanceCount: 0, cancelledCount: 0, totalRevenue: 0 }
+    }
+    if (event.is_cancelled) {
+      statsMap[sid].cancelledCount++
+    } else {
+      statsMap[sid].performanceCount++
+      statsMap[sid].totalRevenue += event.total_revenue ?? 0
+    }
+  }
+
+  return res.status(200).json(statsMap)
+}
+
+// ─── POST: create ────────────────────────────────────────────────────────────
+async function routePost(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const scenario = (body.scenario ?? body) as Record<string, unknown>
+  if (!scenario || typeof scenario !== 'object') {
+    return res.status(400).json({ error: 'scenario が必要です' })
+  }
+  const title = scenario.title as string | undefined
+  if (!title) {
+    return res.status(400).json({ error: 'title が必要です' })
+  }
+
+  // STEP 1: scenario_masters に追加（submitted_by_organization_id は JWT 由来の orgId）
+  const masterPayload = {
+    title,
+    author: (scenario.author as string | null) ?? null,
+    author_email: (scenario.author_email as string | null) ?? null,
+    description: (scenario.description as string | null) ?? null,
+    synopsis: (scenario.synopsis as string | null) ?? null,
+    player_count_min: (scenario.player_count_min as number | null) ?? 4,
+    player_count_max: (scenario.player_count_max as number | null) ?? 6,
+    official_duration: (scenario.duration as number | null) ?? 180,
+    weekend_duration: (scenario.weekend_duration as number | null) ?? null,
+    genre: (scenario.genre as unknown[] | null) ?? [],
+    difficulty: scenario.difficulty !== undefined && scenario.difficulty !== null
+      ? String(scenario.difficulty)
+      : null,
+    key_visual_url: (scenario.key_visual_url as string | null) ?? null,
+    has_pre_reading: (scenario.has_pre_reading as boolean | null) ?? false,
+    release_date: (scenario.release_date as string | null) ?? null,
+    official_site_url: (scenario.official_site_url as string | null) ?? null,
+    master_status: 'draft',
+    submitted_by_organization_id: orgId,
+  }
+
+  const { data: masterData, error: masterError } = await db
+    .from('scenario_masters')
+    .insert(masterPayload)
+    .select('id')
+    .single()
+
+  if (masterError || !masterData) {
+    console.error('[scenarios:create] scenario_masters insert error:', masterError)
+    return res.status(500).json({
+      error: 'シナリオマスター作成に失敗しました',
+      detail: masterError?.message,
+    })
+  }
+
+  const scenarioMasterId = masterData.id as string
+
+  // STEP 2: organization_scenarios に追加
+  const orgStatus = scenario.status === 'available' ? 'available' : 'unavailable'
+  const orgScenarioPayload = {
+    organization_id: orgId, // ← JWT 由来。クライアント引数は無視
+    scenario_master_id: scenarioMasterId,
+    slug: (scenario.slug as string | null) ?? null,
+    duration: (scenario.duration as number | null) ?? null,
+    participation_fee: (scenario.participation_fee as number | null) ?? null,
+    gm_test_participation_fee: (scenario.gm_test_participation_fee as number | null) ?? null,
+    extra_preparation_time: (scenario.extra_preparation_time as number | null) ?? null,
+    org_status: orgStatus,
+    license_amount: (scenario.license_amount as number | null) ?? null,
+    gm_test_license_amount: (scenario.gm_test_license_amount as number | null) ?? null,
+    franchise_license_amount: (scenario.franchise_license_amount as number | null) ?? null,
+    franchise_gm_test_license_amount: (scenario.franchise_gm_test_license_amount as number | null) ?? null,
+    gm_count: (scenario.gm_count as number | null) ?? null,
+    gm_costs: (scenario.gm_costs as unknown[] | null) ?? [],
+    gm_assignments: (scenario.gm_assignments as unknown) ?? null,
+    available_gms: (scenario.available_gms as unknown[] | null) ?? [],
+    experienced_staff: (scenario.experienced_staff as unknown[] | null) ?? [],
+    available_stores: (scenario.available_stores as unknown[] | null) ?? [],
+    production_cost: (scenario.production_cost as number | null) ?? null,
+    production_costs: (scenario.production_costs as unknown[] | null) ?? [],
+    depreciation_per_performance: (scenario.depreciation_per_performance as number | null) ?? null,
+    play_count: (scenario.play_count as number | null) ?? 0,
+    notes: (scenario.notes as string | null) ?? null,
+  }
+
+  const { error: orgScenarioError } = await db
+    .from('organization_scenarios')
+    .insert(orgScenarioPayload)
+    .select('id')
+    .single()
+
+  if (orgScenarioError) {
+    console.error('[scenarios:create] organization_scenarios insert error:', orgScenarioError)
+    return res.status(500).json({
+      error: 'シナリオ作成に失敗しました（マスターは作成済み）',
+      detail: orgScenarioError.message,
+    })
+  }
+
+  // 作成したデータをビューから取得
+  const { data: createdScenario, error: fetchError } = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('id', scenarioMasterId)
+    .eq('organization_id', orgId)
+    .single()
+
+  if (fetchError || !createdScenario) {
+    console.error('[scenarios:create] fetch after insert error:', fetchError)
+    return res.status(500).json({
+      error: '作成後のシナリオ取得に失敗しました',
+      detail: fetchError?.message,
+    })
+  }
+
+  return res.status(201).json(createdScenario)
+}
+
+// ─── PATCH: update / updateAvailableGms / updateAvailableGmsWithSync ─────────
+async function routePatch(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const action = (req.query.action as string | undefined) ?? 'update'
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  if (action === 'update') return await handleUpdate(req, res, orgId, id)
+  if (action === 'updateAvailableGms') return await handleUpdateAvailableGms(req, res, orgId, id)
+  if (action === 'updateAvailableGmsWithSync') {
+    return await handleUpdateAvailableGmsWithSync(req, res, orgId, id)
+  }
+
+  return res.status(400).json({ error: `unknown action: ${action}` })
+}
+
+// 自組織が対象 scenario_master_id の organization_scenarios 行を保有しているか確認し、
+// その行 ID を返す。共有シナリオであっても、自組織がまだ取り込んでいなければ更新不可。
+async function ensureOwnedByOrg(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  database: any,
+  orgId: string,
+  scenarioMasterId: string,
+): Promise<{ orgScenarioId: string } | null> {
+  const { data } = await database
+    .from('organization_scenarios')
+    .select('id')
+    .eq('scenario_master_id', scenarioMasterId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (!data?.id) return null
+  return { orgScenarioId: data.id as string }
+}
+
+async function handleUpdate(req: VercelRequest, res: VercelResponse, orgId: string, id: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updates = (body.updates ?? body) as Record<string, unknown>
+  if (!updates || typeof updates !== 'object') {
+    return res.status(400).json({ error: 'updates が必要です' })
+  }
+
+  // マルチテナント境界: 自組織がこのシナリオを保有しているかチェック
+  const owned = await ensureOwnedByOrg(db, orgId, id)
+  if (!owned) {
+    return res.status(404).json({ error: 'シナリオが見つかりません' })
+  }
+
+  // organization_scenarios の更新ペイロード組み立て
+  const orgScenarioData: Record<string, unknown> = {}
+
+  if (updates.status) {
+    const validOrgStatuses = ['available', 'unavailable', 'coming_soon']
+    if (validOrgStatuses.includes(updates.status as string)) {
+      orgScenarioData.org_status = updates.status
+    }
+  }
+
+  const directOrgColumns = [
+    'slug', 'duration', 'participation_fee', 'gm_test_participation_fee',
+    'extra_preparation_time', 'license_amount', 'gm_test_license_amount',
+    'franchise_license_amount', 'franchise_gm_test_license_amount',
+    'available_gms', 'experienced_staff', 'available_stores',
+    'gm_costs', 'gm_count', 'gm_assignments',
+    'production_cost', 'production_costs', 'depreciation_per_performance',
+    'play_count', 'notes', 'participation_costs', 'flexible_pricing', 'use_flexible_pricing',
+    'booking_start_date', 'booking_end_date', 'private_booking_time_slots',
+  ] as const
+  for (const col of directOrgColumns) {
+    if (updates[col] !== undefined) {
+      orgScenarioData[col] = updates[col]
+    }
+  }
+
+  const overrideMapping: Record<string, string> = {
+    title: 'override_title',
+    author: 'override_author',
+    genre: 'override_genre',
+    difficulty: 'override_difficulty',
+    player_count_min: 'override_player_count_min',
+    player_count_max: 'override_player_count_max',
+  }
+  for (const [scenarioCol, orgCol] of Object.entries(overrideMapping)) {
+    if (updates[scenarioCol] !== undefined) {
+      orgScenarioData[orgCol] = updates[scenarioCol]
+    }
+  }
+
+  const customMapping: Record<string, string> = {
+    key_visual_url: 'custom_key_visual_url',
+    description: 'custom_description',
+    synopsis: 'custom_synopsis',
+    caution: 'custom_caution',
+  }
+  for (const [scenarioCol, orgCol] of Object.entries(customMapping)) {
+    if (updates[scenarioCol] !== undefined) {
+      orgScenarioData[orgCol] = updates[scenarioCol]
+    }
+  }
+
+  if (Object.keys(orgScenarioData).length > 0) {
+    orgScenarioData.updated_at = new Date().toISOString()
+    const { error: orgError } = await db
+      .from('organization_scenarios')
+      .update(orgScenarioData)
+      .eq('id', owned.orgScenarioId)
+      .eq('organization_id', orgId)
+    if (orgError) {
+      console.error('[scenarios:update] organization_scenarios error:', orgError)
+      return res.status(500).json({ error: '更新に失敗しました', detail: orgError.message })
+    }
+  }
+
+  // マスターを draft → pending に昇格（自組織が「公開中」にした場合のみ）
+  // TODO: 共有マスター（他組織が作成）の master_status を勝手に変えるのはリスクあり。
+  // 現状は旧挙動と同じく、自組織がこのマスターを保有していることを ensureOwnedByOrg で
+  // 確認済みなので、draft→pending 昇格自体は許可している。将来的には
+  // submitted_by_organization_id が自組織であることもチェックすることを検討する。
+  if (updates.status === 'available') {
+    const { data: masterData } = await db
+      .from('scenario_masters')
+      .select('id, master_status')
+      .eq('id', id)
+      .maybeSingle()
+
+    if (masterData && (masterData as { master_status?: string }).master_status === 'draft') {
+      await db
+        .from('scenario_masters')
+        .update({ master_status: 'pending', updated_at: new Date().toISOString() })
+        .eq('id', id)
+    }
+  }
+
+  const { data: updatedScenario, error: fetchError } = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .single()
+
+  if (fetchError || !updatedScenario) {
+    console.error('[scenarios:update] fetch error:', fetchError)
+    return res.status(500).json({
+      error: '更新後のシナリオ取得に失敗しました',
+      detail: fetchError?.message,
+    })
+  }
+
+  return res.status(200).json(updatedScenario)
+}
+
+async function handleUpdateAvailableGms(
+  req: VercelRequest,
+  res: VercelResponse,
+  orgId: string,
+  id: string,
+) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const availableGms = body.availableGms
+  if (!Array.isArray(availableGms)) {
+    return res.status(400).json({ error: 'availableGms (配列) が必要です' })
+  }
+
+  const owned = await ensureOwnedByOrg(db, orgId, id)
+  if (!owned) {
+    return res.status(404).json({ error: 'シナリオが見つかりません' })
+  }
+
+  const { error } = await db
+    .from('organization_scenarios')
+    .update({ available_gms: availableGms, updated_at: new Date().toISOString() })
+    .eq('id', owned.orgScenarioId)
+    .eq('organization_id', orgId)
+  if (error) {
+    console.error('[scenarios:updateAvailableGms] error:', error)
+    return res.status(500).json({ error: '更新に失敗しました', detail: error.message })
+  }
+
+  const { data: updatedScenario, error: fetchError } = await db
+    .from('organization_scenarios_with_master')
+    .select(SELECT_FIELDS)
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .single()
+  if (fetchError || !updatedScenario) {
+    console.error('[scenarios:updateAvailableGms] fetch error:', fetchError)
+    return res.status(500).json({
+      error: '更新後のシナリオ取得に失敗しました',
+      detail: fetchError?.message,
+    })
+  }
+  return res.status(200).json(updatedScenario)
+}
+
+// NOTE: staff.special_scenarios への同期は廃止済み。staff_scenario_assignments が唯一のソース。
+// 現時点では updateAvailableGms と同じ実装。互換性のため別アクションとして残す。
+async function handleUpdateAvailableGmsWithSync(
+  req: VercelRequest,
+  res: VercelResponse,
+  orgId: string,
+  id: string,
+) {
+  return await handleUpdateAvailableGms(req, res, orgId, id)
+}
+
+// ─── DELETE ──────────────────────────────────────────────────────────────────
+async function routeDelete(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  // マルチテナント境界: 自組織がこのシナリオを保有しているかチェック
+  const owned = await ensureOwnedByOrg(db, orgId, id)
+  if (!owned) {
+    return res.status(404).json({ error: 'シナリオが見つかりません' })
+  }
+
+  // 1. reservations の scenario_master_id を NULL に（自組織のみ）
+  const { error: reservationError } = await db
+    .from('reservations')
+    .update({ scenario_master_id: null })
+    .eq('scenario_master_id', id)
+    .eq('organization_id', orgId)
+  if (reservationError) {
+    console.error('[scenarios:delete] reservations update error:', reservationError)
+  }
+
+  // 2. schedule_events の scenario_master_id を NULL に（自組織のみ）
+  const { error: scheduleError } = await db
+    .from('schedule_events')
+    .update({ scenario_master_id: null })
+    .eq('scenario_master_id', id)
+    .eq('organization_id', orgId)
+  if (scheduleError) {
+    console.error('[scenarios:delete] schedule_events update error:', scheduleError)
+  }
+
+  // 3. staff_scenario_assignments を削除（自組織のみ）
+  const { error: assignmentError } = await db
+    .from('staff_scenario_assignments')
+    .delete()
+    .eq('scenario_master_id', id)
+    .eq('organization_id', orgId)
+  if (assignmentError) {
+    console.error('[scenarios:delete] staff_scenario_assignments delete error:', assignmentError)
+  }
+
+  // 4. performance_kits を削除
+  // NOTE: performance_kits は organization_id を持たない（または別構造）ため
+  // scenario_master_id のみで削除する。旧実装と同じ挙動。
+  // TODO: performance_kits が org_id を持つようになったら orgId でも絞り込む。
+  const { error: kitsError } = await db
+    .from('performance_kits')
+    .delete()
+    .eq('scenario_master_id', id)
+  if (kitsError) {
+    console.error('[scenarios:delete] performance_kits delete error:', kitsError)
+  }
+
+  // 5. organization_scenarios 本体を削除（scenario_masters は残す）
+  const { error } = await db
+    .from('organization_scenarios')
+    .delete()
+    .eq('id', owned.orgScenarioId)
+    .eq('organization_id', orgId)
+  if (error) {
+    console.error('[scenarios:delete] organization_scenarios delete error:', error)
+    return res.status(500).json({ error: '削除に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json({ success: true })
 }

--- a/src/lib/api/scenarioApi.ts
+++ b/src/lib/api/scenarioApi.ts
@@ -1,5 +1,12 @@
 /**
  * シナリオ関連API
+ *
+ * write 系 (create/update/delete/updateAvailableGms/updateAvailableGmsWithSync) と、
+ * 残り read 系 (getAllLegacy/getPublic/getPaginated/getPerformanceCount/
+ * getScenarioStats/getAllScenarioStats) はバックエンド API (/api/scenarios) 経由で実行する。
+ *
+ * org_id はフロントから渡さず、サーバー側で JWT から取得する（マルチテナント境界）。
+ * organizationId 引数は後方互換のため残してあるが、値はサーバー側で無視される。
  */
 import { supabase } from '../supabase'
 import { getCurrentOrganizationId } from '@/lib/organization'
@@ -7,16 +14,10 @@ import { apiClient } from '@/lib/apiClient'
 import type { Scenario } from '@/types'
 import type { PaginatedResponse } from './types'
 import { logger } from '@/utils/logger'
-import { fetchSalarySettings, calculateGmWage } from '@/hooks/useSalarySettings'
-import { RESERVATION_SOURCE, STAFF_RESERVATION_SOURCES, DEMO_RESERVATION_SOURCES } from '@/lib/constants'
-
-// NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
-const SCENARIO_SELECT_FIELDS =
-  // NOTE: scenarios テーブルに存在するカラムのみ（存在しないカラムを含めると PostgREST が 400 を返す）
-  'id, title, slug, description, author, author_email, report_display_name, duration, weekend_duration, player_count_min, player_count_max, male_count, female_count, other_count, difficulty, rating, status, scenario_type, participation_fee, participation_costs, gm_costs, license_amount, gm_test_license_amount, franchise_license_amount, franchise_gm_test_license_amount, external_license_amount, external_gm_test_license_amount, license_rewards, production_cost, genre, has_pre_reading, key_visual_url, notes, required_props, production_costs, kit_count, gm_count, available_stores, scenario_master_id, organization_id, is_shared, extra_preparation_time, available_gms, play_count, release_date, is_recommended, created_at, updated_at' as const
 
 // organization_scenarios_with_master ビュー用のSELECTフィールド
-const ORG_SCENARIOS_VIEW_SELECT_FIELDS = 
+// （skipOrgFilter=true の license_admin 用フォールバックでのみ利用）
+const ORG_SCENARIOS_VIEW_SELECT_FIELDS =
   'id, org_scenario_id, organization_id, scenario_master_id, slug, status, org_status, title, author, author_email, author_id, report_display_name, key_visual_url, description, synopsis, caution, player_count_min, player_count_max, male_count, female_count, other_count, duration, weekend_duration, genre, difficulty, has_pre_reading, release_date, official_site_url, required_props, participation_fee, gm_test_participation_fee, participation_costs, flexible_pricing, use_flexible_pricing, license_amount, gm_test_license_amount, franchise_license_amount, franchise_gm_test_license_amount, external_license_amount, external_gm_test_license_amount, fc_receive_license_amount, fc_receive_gm_test_license_amount, fc_author_license_amount, fc_author_gm_test_license_amount, gm_costs, gm_count, gm_assignments, available_gms, experienced_staff, available_stores, production_cost, production_costs, depreciation_per_performance, extra_preparation_time, play_count, notes, created_at, updated_at, master_status, pricing_patterns, is_shared, scenario_type, rating, kit_count, license_rewards, is_recommended, survey_url, survey_enabled, survey_deadline_days, characters, pre_reading_notice_message, booking_start_date, booking_end_date, individual_notice_template, character_assignment_method, private_booking_time_slots, private_booking_blocked_slots' as const
 
 export const scenarioApi = {
@@ -43,41 +44,16 @@ export const scenarioApi = {
     return apiClient.get<Scenario[]>('/api/scenarios')
   },
 
-  // 旧scenarios テーブルから全シナリオを取得（キット管理等レガシー機能用）
+  // 旧 scenarios テーブルから全シナリオを取得（キット管理等レガシー機能用）
   // NOTE: scenarios テーブル廃止後は削除予定
-  async getAllLegacy(organizationId?: string): Promise<Scenario[]> {
-    let query = supabase
-      .from('scenarios')
-      .select(SCENARIO_SELECT_FIELDS)
-    
-    const orgId = organizationId || await getCurrentOrganizationId()
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { data, error } = await query.order('title', { ascending: true })
-    
-    if (error) throw error
-    return (data || []) as Scenario[]
+  async getAllLegacy(_organizationId?: string): Promise<Scenario[]> {
+    return apiClient.get<Scenario[]>('/api/scenarios?type=legacy')
   },
 
   // 公開用シナリオを取得（status='available'のみ、必要なフィールドのみ）
-  // organizationId: 指定した場合そのIDを使用、未指定の場合はログインユーザーの組織で自動フィルタ
-  async getPublic(organizationId?: string): Promise<Partial<Scenario>[]> {
-    let query = supabase
-      .from('organization_scenarios_with_master')
-      .select('id, title, key_visual_url, author, duration, player_count_min, player_count_max, genre, release_date, status, participation_fee, scenario_type, organization_id')
-      .eq('status', 'available')
-    
-    const orgId = organizationId || await getCurrentOrganizationId()
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { data, error } = await query.order('title', { ascending: true })
-    
-    if (error) throw error
-    return data || []
+  // organizationId 引数は後方互換のため残すが、サーバー側で JWT から org_id を取得するため使われない。
+  async getPublic(_organizationId?: string): Promise<Partial<Scenario>[]> {
+    return apiClient.get<Partial<Scenario>[]>('/api/scenarios?type=public')
   },
 
   // IDでシナリオを取得（scenario_master_id で検索、見つからなければ org_scenario_id でも検索）
@@ -141,405 +117,72 @@ export const scenarioApi = {
   async getByIdOrSlug(idOrSlug: string, organizationId?: string): Promise<Scenario | null> {
     const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     const isUuid = uuidPattern.test(idOrSlug)
-    
+
     if (isUuid) {
       return this.getById(idOrSlug, organizationId)
     }
-    
+
     const bySlug = await this.getBySlug(idOrSlug, organizationId)
     if (bySlug) return bySlug
-    
+
     return this.getById(idOrSlug, organizationId)
   },
 
-  // ページネーション対応：シナリオを取得
-  async getPaginated(page: number = 0, pageSize: number = 20, organizationId?: string): Promise<PaginatedResponse<Scenario>> {
-    const from = page * pageSize
-    const to = from + pageSize - 1
-    
-    let query = supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS, { count: 'exact' })
-    
-    const orgId = organizationId || await getCurrentOrganizationId()
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { data, error, count } = await query
-      .order('title', { ascending: true })
-      .range(from, to)
-    
-    if (error) throw error
-    
-    return {
-      data: (data || []) as unknown as Scenario[],
-      count: count || 0,
-      hasMore: count ? (from + pageSize) < count : false
-    }
+  // ページネーション対応：シナリオを取得（バックエンド経由）
+  async getPaginated(
+    page: number = 0,
+    pageSize: number = 20,
+    _organizationId?: string,
+  ): Promise<PaginatedResponse<Scenario>> {
+    const params = new URLSearchParams({
+      type: 'paginated',
+      page: String(page),
+      pageSize: String(pageSize),
+    })
+    return apiClient.get<PaginatedResponse<Scenario>>(`/api/scenarios?${params}`)
   },
 
-  // シナリオを作成
-  // scenario_masters + organization_scenarios に保存
+  // シナリオを作成（バックエンド経由）。org_id は JWT から取得される。
   async create(scenario: Omit<Scenario, 'id' | 'created_at' | 'updated_at'>): Promise<Scenario> {
-    const organizationId = await getCurrentOrganizationId()
-    if (!organizationId) {
-      throw new Error('組織IDが取得できません')
-    }
-    
-    logger.log('📝 シナリオ作成開始')
-    
-    // ========================================
-    // STEP 1: scenario_masters に追加
-    // ========================================
-    const { data: masterData, error: masterError } = await supabase
-      .from('scenario_masters')
-      .insert({
-        title: scenario.title,
-        author: scenario.author || null,
-        author_email: scenario.author_email || null,
-        description: scenario.description || null,
-        synopsis: scenario.synopsis || null,
-        player_count_min: scenario.player_count_min || 4,
-        player_count_max: scenario.player_count_max || 6,
-        official_duration: scenario.duration || 180,
-        weekend_duration: scenario.weekend_duration || null,
-        genre: scenario.genre || [],
-        difficulty: scenario.difficulty ? String(scenario.difficulty) : null,
-        key_visual_url: scenario.key_visual_url || null,
-        has_pre_reading: scenario.has_pre_reading || false,
-        release_date: scenario.release_date || null,
-        official_site_url: scenario.official_site_url || null,
-        master_status: 'draft',
-        submitted_by_organization_id: organizationId,
-      })
-      .select()
-      .single()
-
-    if (masterError) {
-      logger.error('scenario_masters作成エラー:', masterError)
-      throw masterError
-    }
-    
-    const scenarioMasterId = masterData.id
-    logger.log('✅ scenario_masters作成成功:', scenarioMasterId)
-
-    // ========================================
-    // STEP 2: organization_scenarios に追加
-    // ========================================
-    const orgStatus = scenario.status === 'available' ? 'available' : 'unavailable'
-    
-    const { data: orgData, error: orgScenarioError } = await supabase
-      .from('organization_scenarios')
-      .insert({
-        organization_id: organizationId,
-        scenario_master_id: scenarioMasterId,
-        slug: scenario.slug || null,
-        duration: scenario.duration || null,
-        participation_fee: scenario.participation_fee || null,
-        gm_test_participation_fee: scenario.gm_test_participation_fee || null,
-        extra_preparation_time: scenario.extra_preparation_time ?? null,
-        org_status: orgStatus,
-        license_amount: scenario.license_amount || null,
-        gm_test_license_amount: scenario.gm_test_license_amount || null,
-        franchise_license_amount: scenario.franchise_license_amount || null,
-        franchise_gm_test_license_amount: scenario.franchise_gm_test_license_amount || null,
-        gm_count: scenario.gm_count || null,
-        gm_costs: scenario.gm_costs || [],
-        gm_assignments: scenario.gm_assignments || null,
-        available_gms: scenario.available_gms || [],
-        experienced_staff: scenario.experienced_staff || [],
-        available_stores: scenario.available_stores || [],
-        production_cost: scenario.production_cost || null,
-        production_costs: scenario.production_costs || [],
-        depreciation_per_performance: scenario.depreciation_per_performance || null,
-        play_count: scenario.play_count || 0,
-        notes: scenario.notes || null,
-      })
-      .select()
-      .single()
-
-    if (orgScenarioError) {
-      logger.error('organization_scenarios作成エラー:', orgScenarioError)
-      // マスターは作成済みなので、organization_scenariosの作成失敗はロールバックしない
-      throw orgScenarioError
-    }
-    
-    logger.log('✅ organization_scenarios作成成功:', orgData?.id)
-    
-    // organization_scenarios_with_master ビューから作成したデータを取得して返す
-    const { data: createdScenario, error: fetchError } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-      .eq('id', scenarioMasterId)
-      .eq('organization_id', organizationId)
-      .single()
-    
-    if (fetchError) {
-      logger.error('作成後のシナリオ取得エラー:', fetchError)
-      throw fetchError
-    }
-    
-    logger.log('✅ シナリオ作成完了')
-    return createdScenario as unknown as Scenario
+    return apiClient.post<Scenario>('/api/scenarios', { scenario })
   },
 
-  // シナリオを更新
-  // id: scenario_master_id として検索（organization_scenarios_with_master のid = scenario_master_id）
+  // シナリオを更新（バックエンド経由）。
+  // id: scenario_master_id として検索（organization_scenarios_with_master の id = scenario_master_id）
   async update(id: string, updates: Partial<Scenario>): Promise<Scenario> {
-    logger.log('📝 シナリオ更新:', id, Object.keys(updates))
-    
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) {
-      throw new Error('組織IDが取得できません')
-    }
-    
-    // 対象のorganization_scenariosを特定
-    const { data: orgScenario } = await supabase
-      .from('organization_scenarios')
-      .select('id, scenario_master_id')
-      .eq('scenario_master_id', id)
-      .eq('organization_id', orgId)
-      .maybeSingle()
-    
-    if (!orgScenario) {
-      throw new Error('シナリオが見つかりません')
-    }
-    
-    // organization_scenarios 用のデータを構築
-    const orgScenarioData: Record<string, unknown> = {}
-    
-    // statusはorg_statusにマッピング
-    if (updates.status) {
-      const validOrgStatuses = ['available', 'unavailable', 'coming_soon']
-      if (validOrgStatuses.includes(updates.status)) {
-        orgScenarioData.org_status = updates.status
-      }
-    }
-    
-    // 組織固有カラムをマッピング
-    const directOrgColumns = [
-      'slug', 'duration', 'participation_fee', 'gm_test_participation_fee',
-      'extra_preparation_time', 'license_amount', 'gm_test_license_amount',
-      'franchise_license_amount', 'franchise_gm_test_license_amount',
-      'available_gms', 'experienced_staff', 'available_stores',
-      'gm_costs', 'gm_count', 'gm_assignments',
-      'production_cost', 'production_costs', 'depreciation_per_performance',
-      'play_count', 'notes', 'participation_costs', 'flexible_pricing', 'use_flexible_pricing',
-      'booking_start_date', 'booking_end_date', 'private_booking_time_slots'
-    ]
-    
-    for (const col of directOrgColumns) {
-      if (updates[col as keyof Scenario] !== undefined) {
-        orgScenarioData[col] = updates[col as keyof Scenario]
-      }
-    }
-    
-    // override フィールド（マスター情報の組織固有上書き）
-    const overrideMapping: Record<string, string> = {
-      'title': 'override_title',
-      'author': 'override_author',
-      'genre': 'override_genre',
-      'difficulty': 'override_difficulty',
-      'player_count_min': 'override_player_count_min',
-      'player_count_max': 'override_player_count_max',
-    }
-    
-    for (const [scenarioCol, orgCol] of Object.entries(overrideMapping)) {
-      if (updates[scenarioCol as keyof Scenario] !== undefined) {
-        orgScenarioData[orgCol] = updates[scenarioCol as keyof Scenario]
-      }
-    }
-    
-    // custom フィールド
-    const customMapping: Record<string, string> = {
-      'key_visual_url': 'custom_key_visual_url',
-      'description': 'custom_description',
-      'synopsis': 'custom_synopsis',
-      'caution': 'custom_caution',
-    }
-    
-    for (const [scenarioCol, orgCol] of Object.entries(customMapping)) {
-      if (updates[scenarioCol as keyof Scenario] !== undefined) {
-        orgScenarioData[orgCol] = updates[scenarioCol as keyof Scenario]
-      }
-    }
-    
-    // organization_scenarios を更新
-    if (Object.keys(orgScenarioData).length > 0) {
-      orgScenarioData.updated_at = new Date().toISOString()
-      logger.log('📝 organization_scenarios更新:', Object.keys(orgScenarioData))
-      
-      const { error: orgError } = await supabase
-        .from('organization_scenarios')
-        .update(orgScenarioData)
-        .eq('id', orgScenario.id)
-      
-      if (orgError) {
-        logger.error('organization_scenarios更新エラー:', orgError)
-        throw orgError
-      }
-    }
-    
-    // 組織が「公開中」にした場合、マスターがdraftならpendingに昇格
-    if (updates.status === 'available') {
-      const { data: masterData } = await supabase
-        .from('scenario_masters')
-        .select('id, master_status')
-        .eq('id', id)
-        .maybeSingle()
-      
-      if (masterData && masterData.master_status === 'draft') {
-        logger.log('📝 マスターをdraft→pendingに昇格:', id)
-        await supabase
-          .from('scenario_masters')
-          .update({ master_status: 'pending', updated_at: new Date().toISOString() })
-          .eq('id', id)
-      }
-    }
-    
-    // 更新後のデータを取得して返す
-    const { data: updatedScenario, error: fetchError } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-      .eq('id', id)
-      .eq('organization_id', orgId)
-      .single()
-    
-    if (fetchError) {
-      logger.error('更新後のシナリオ取得エラー:', fetchError)
-      throw fetchError
-    }
-    
-    logger.log('✅ シナリオ更新完了')
-    return updatedScenario as unknown as Scenario
+    const params = new URLSearchParams({ action: 'update', id })
+    return apiClient.patch<Scenario>(`/api/scenarios?${params}`, { updates })
   },
 
   // シナリオを削除（organization_scenarios のみ削除、scenario_masters は残す）
   // id: scenario_master_id
   async delete(id: string): Promise<void> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) {
-      throw new Error('組織IDが取得できません')
-    }
-    
-    logger.log('📝 シナリオ削除:', id)
-    
-    // 関連データの参照をクリア（scenario_master_id を使用）
-    
-    // 1. reservationsのscenario_master_idをNULLに設定
-    // eslint-disable-next-line no-restricted-syntax -- シナリオ削除時の関連データクリアのため直接更新が必要
-    const { error: reservationError } = await supabase
-      .from('reservations')
-      .update({ scenario_master_id: null })
-      .eq('scenario_master_id', id)
-      .eq('organization_id', orgId)
-    
-    if (reservationError) {
-      logger.error('reservations更新エラー:', reservationError)
-    }
-    
-    // 2. schedule_eventsのscenario_master_idをNULLに設定
-    const { error: scheduleError } = await supabase
-      .from('schedule_events')
-      .update({ scenario_master_id: null })
-      .eq('scenario_master_id', id)
-      .eq('organization_id', orgId)
-    
-    if (scheduleError) {
-      logger.error('schedule_events更新エラー:', scheduleError)
-    }
-    
-    // 3. staff_scenario_assignmentsの削除
-    const { error: assignmentError } = await supabase
-      .from('staff_scenario_assignments')
-      .delete()
-      .eq('scenario_master_id', id)
-      .eq('organization_id', orgId)
-    
-    if (assignmentError) {
-      logger.error('staff_scenario_assignments削除エラー:', assignmentError)
-    }
-    
-    // 4. performance_kitsの削除（scenario_master_id を使用）
-    const { error: kitsError } = await supabase
-      .from('performance_kits')
-      .delete()
-      .eq('scenario_master_id', id)
-    
-    if (kitsError) {
-      logger.error('performance_kits削除エラー:', kitsError)
-    }
-    
-    // NOTE: staff.special_scenarios への同期は廃止
-    // staff_scenario_assignments が唯一のデータソース（既に削除済み）
-    
-    // 5. organization_scenarios を削除（scenario_masters は残す）
-    const { error } = await supabase
-      .from('organization_scenarios')
-      .delete()
-      .eq('scenario_master_id', id)
-      .eq('organization_id', orgId)
-    
-    if (error) {
-      logger.error('organization_scenarios削除エラー:', error)
-      throw error
-    }
-    
-    logger.log('✅ シナリオ削除完了（organization_scenariosのみ）')
+    const params = new URLSearchParams({ id })
+    await apiClient.delete<{ success: boolean }>(`/api/scenarios?${params}`)
   },
 
-  // シナリオの担当GMを更新
+  // シナリオの担当GMを更新（バックエンド経由）
   async updateAvailableGms(id: string, availableGms: string[]): Promise<Scenario> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) {
-      throw new Error('組織IDが取得できません')
-    }
-    
-    const { error } = await supabase
-      .from('organization_scenarios')
-      .update({ available_gms: availableGms, updated_at: new Date().toISOString() })
-      .eq('scenario_master_id', id)
-      .eq('organization_id', orgId)
-    
-    if (error) throw error
-    
-    // 更新後のデータを取得して返す
-    const { data, error: fetchError } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-      .eq('id', id)
-      .eq('organization_id', orgId)
-      .single()
-    
-    if (fetchError) throw fetchError
-    return data as unknown as Scenario
+    const params = new URLSearchParams({ action: 'updateAvailableGms', id })
+    return apiClient.patch<Scenario>(`/api/scenarios?${params}`, { availableGms })
   },
 
-  // シナリオの累計公演回数を取得
+  // シナリオの累計公演回数を取得（バックエンド経由）
   // scenarioId: scenario_master_id
   async getPerformanceCount(scenarioId: string): Promise<number> {
-    const orgId = await getCurrentOrganizationId()
-    
-    let query = supabase
-      .from('schedule_events')
-      .select('*', { count: 'exact', head: true })
-      .eq('scenario_master_id', scenarioId)
-      .not('status', 'eq', 'cancelled')
-    
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { count, error } = await query
-    
-    if (error) throw error
-    return count || 0
+    const params = new URLSearchParams({ type: 'performance-count', scenarioId })
+    const result = await apiClient.get<{ count: number }>(`/api/scenarios?${params}`)
+    return result.count ?? 0
   },
 
-  // シナリオの統計情報を取得（公演回数、中止回数、売上、利益など）
+  // シナリオの統計情報を取得（バックエンド経由）
   // 今日までの公演のみ計算（未来の公演は含めない）
-  // scenarioId は scenarios.id または scenario_master_id のどちらでも対応
+  // scenarioId は scenario_master_id
+  //
+  // NOTE: 旧実装はカスタム GM コスト未設定時にフロントの useSalarySettings を使って
+  // GM 報酬を動的計算していたが、サーバ実装では salary_settings をまだ参照していない。
+  // 影響: gm_costs を設定していないシナリオで GM コスト集計が 0 になる可能性がある。
+  // TODO: サーバ側でも calculateGmWage 相当を実装する。
   async getScenarioStats(scenarioId: string): Promise<{
     performanceCount: number
     cancelledCount: number
@@ -552,424 +195,27 @@ export const scenarioApi = {
     venueCostPerPerformance: number
     firstPerformanceDate: string | null
     performanceDates: Array<{ date: string; category: string; participants: number; demoParticipants: number; staffParticipants: number; revenue: number; startTime: string; storeId: string | null; isCancelled: boolean }>
-    futurePerformanceCount: number  // 将来の公演予定数
-    futureReservationCount: number  // 将来の貸切予約数（公演に紐付いていない）
+    futurePerformanceCount: number
+    futureReservationCount: number
   }> {
-    // 今日の日付（YYYY-MM-DD形式）
-    const today = new Date().toISOString().split('T')[0]
-    
-    // 組織フィルタ（マルチテナント対応）
-    const orgId = await getCurrentOrganizationId()
-    
-    logger.log('📊 getScenarioStats: scenario_master_id =', scenarioId)
-
-    // シナリオの最大参加者数・ライセンス料・参加費・GM報酬を取得（organization_scenarios_with_master から）
-    let scenarioQuery = supabase
-      .from('organization_scenarios_with_master')
-      .select('player_count_max, license_amount, gm_test_license_amount, license_rewards, participation_fee, gm_test_participation_fee, participation_costs, gm_costs, duration')
-      .eq('id', scenarioId)
-    
-    if (orgId) {
-      scenarioQuery = scenarioQuery.eq('organization_id', orgId)
-    }
-    
-    const { data: scenarioData } = await scenarioQuery.maybeSingle()
-    const maxParticipants = scenarioData?.player_count_max || 99
-    const defaultLicenseAmount = scenarioData?.license_amount || 0
-    const defaultGmTestLicenseAmount = scenarioData?.gm_test_license_amount || 0
-    const licenseRewards = scenarioData?.license_rewards as Array<{ item: string; amount: number }> | undefined
-    const normalLicenseFromRewards = licenseRewards?.find(r => r.item === 'normal')?.amount
-    const gmTestLicenseFromRewards = licenseRewards?.find(r => r.item === 'gmtest')?.amount
-    const normalLicenseAmount = normalLicenseFromRewards ?? defaultLicenseAmount
-    const gmTestLicenseAmount = gmTestLicenseFromRewards ?? defaultGmTestLicenseAmount
-    
-    // 参加費（売上計算用）
-    const participationCosts = scenarioData?.participation_costs as Array<{ time_slot: string; amount: number }> | undefined
-    const normalParticipationFee = participationCosts?.find(c => c.time_slot === 'normal')?.amount || scenarioData?.participation_fee || 0
-    const gmTestParticipationFee = participationCosts?.find(c => c.time_slot === 'gmtest')?.amount || scenarioData?.gm_test_participation_fee || 0
-    
-    // GM報酬（コスト計算用）
-    const gmAssignments = scenarioData?.gm_costs as Array<{ category?: string; reward?: number }> | undefined
-    const hasCustomGmCosts = gmAssignments && gmAssignments.length > 0
-    let normalGmReward = 0
-    let gmTestGmReward = 0
-    if (hasCustomGmCosts) {
-      normalGmReward = gmAssignments
-        .filter(a => (a.category || 'normal') === 'normal')
-        .reduce((sum, a) => sum + (a.reward || 0), 0)
-      gmTestGmReward = gmAssignments
-        .filter(a => a.category === 'gmtest')
-        .reduce((sum, a) => sum + (a.reward || 0), 0) || Math.max(0, normalGmReward - 2000)
-    } else {
-      const salarySettings = await fetchSalarySettings()
-      const duration = scenarioData?.duration || 0
-      normalGmReward = calculateGmWage(duration, false, salarySettings)
-      gmTestGmReward = calculateGmWage(duration, true, salarySettings)
-    }
-
-    // 公演回数（中止以外、今日まで、出張公演除外）- scenario_master_id で検索
-    let perfQuery = supabase
-      .from('schedule_events')
-      .select('*', { count: 'exact', head: true })
-      .eq('scenario_master_id', scenarioId)
-      .lte('date', today)
-      .neq('category', 'offsite')
-      .neq('is_cancelled', true)
-    
-    if (orgId) {
-      perfQuery = perfQuery.eq('organization_id', orgId)
-    }
-    
-    const { count: performanceCount, error: perfError } = await perfQuery
-    
-    if (perfError) throw perfError
-
-    // 中止回数（今日まで、出張公演除外）
-    let cancelQuery = supabase
-      .from('schedule_events')
-      .select('*', { count: 'exact', head: true })
-      .eq('scenario_master_id', scenarioId)
-      .lte('date', today)
-      .neq('category', 'offsite')
-      .eq('is_cancelled', true)
-    
-    if (orgId) {
-      cancelQuery = cancelQuery.eq('organization_id', orgId)
-    }
-    
-    const { count: cancelledCount, error: cancelError } = await cancelQuery
-    
-    if (cancelError) throw cancelError
-
-    // 初公演日を取得（今日までの公演から、中止以外、出張公演除外）
-    let firstQuery = supabase
-      .from('schedule_events')
-      .select('date, scenario_master_id')
-      .eq('scenario_master_id', scenarioId)
-      .lte('date', today)
-      .neq('category', 'offsite')
-      .neq('is_cancelled', true)
-      .order('date', { ascending: true })
-      .limit(1)
-    
-    if (orgId) {
-      firstQuery = firstQuery.eq('organization_id', orgId)
-    }
-    
-    // 新規シナリオなど公演0件のとき .single() は 406 になるため maybeSingle を使う
-    const { data: firstEvent, error: firstError } = await firstQuery.maybeSingle()
-    
-    const firstPerformanceDate = firstError ? null : firstEvent?.date || null
-
-    // 公演イベントを取得して売上・コストを集計（今日まで）
-    // ※ 中止公演もリスト表示のため取得（サマリー計算からは除外）
-    // ※ 出張公演（offsite）もリスト表示対象として含める
-    let eventsQuery = supabase
-      .from('schedule_events_staff_view')
-      .select('id, date, category, current_participants, total_revenue, gm_cost, license_cost, start_time, store_id, is_cancelled, stores:store_id(venue_cost_per_performance)')
-      .eq('scenario_master_id', scenarioId)
-      .lte('date', today)
-      .order('date', { ascending: false })
-    
-    if (orgId) {
-      eventsQuery = eventsQuery.eq('organization_id', orgId)
-    }
-    
-    const { data: events, error: eventsError } = await eventsQuery
-    
-    if (eventsError) throw eventsError
-
-    // 各イベントの予約情報を取得（実際の予約から参加者数を計算）
-    const eventIds = events?.map(e => e.id) || []
-    const demoParticipantsMap: Record<string, number> = {}
-    const actualParticipantsMap: Record<string, number> = {}
-    const staffParticipantsMap: Record<string, number> = {}
-    
-    if (eventIds.length > 0) {
-      // PostgREST URL長制限回避: IDをバッチに分割してクエリ
-      const BATCH_SIZE = 100
-      const allReservations: Array<{ schedule_event_id: string; participant_count: number; reservation_source: string | null; payment_method: string | null }> = []
-      
-      for (let i = 0; i < eventIds.length; i += BATCH_SIZE) {
-        const batchIds = eventIds.slice(i, i + BATCH_SIZE)
-        let resQuery = supabase
-          .from('reservations')
-          .select('schedule_event_id, participant_count, reservation_source, payment_method')
-          .in('schedule_event_id', batchIds)
-          .in('status', ['confirmed', 'gm_confirmed'])
-        
-        if (orgId) {
-          resQuery = resQuery.eq('organization_id', orgId)
-        }
-        
-        const { data, error: resError } = await resQuery
-        if (!resError && data) {
-          allReservations.push(...(data as typeof allReservations))
-        }
-      }
-      
-      allReservations.forEach(res => {
-        if (res.schedule_event_id) {
-          const count = res.participant_count || 0
-          
-          // デモ予約
-          if ((DEMO_RESERVATION_SOURCES as readonly string[]).includes(res.reservation_source ?? '')) {
-            demoParticipantsMap[res.schedule_event_id] =
-              (demoParticipantsMap[res.schedule_event_id] || 0) + count
-          }
-          // スタッフ参加
-          else if ((STAFF_RESERVATION_SOURCES as readonly string[]).includes(res.reservation_source ?? '') ||
-                   res.payment_method === 'staff') {
-            staffParticipantsMap[res.schedule_event_id] = 
-              (staffParticipantsMap[res.schedule_event_id] || 0) + count
-          }
-          // 通常予約（有料）
-          else {
-            actualParticipantsMap[res.schedule_event_id] = 
-              (actualParticipantsMap[res.schedule_event_id] || 0) + count
-          }
-        }
-      })
-    }
-
-    // 集計
-    let totalRevenue = 0
-    let totalParticipants = 0
-    let totalStaffParticipants = 0
-    let totalGmCost = 0
-    let totalLicenseCost = 0
-    let totalVenueCost = 0
-    const venueCostSet = new Set<number>()
-    const performanceDates: Array<{ date: string; category: string; participants: number; demoParticipants: number; staffParticipants: number; revenue: number; startTime: string; storeId: string | null; isCancelled: boolean }> = []
-
-    events?.forEach(event => {
-      const isCancelled = event.is_cancelled === true
-      const demoCount = demoParticipantsMap[event.id] || 0
-      const staffCount = staffParticipantsMap[event.id] || 0
-      const actualCount = actualParticipantsMap[event.id] || 0
-      
-      // 参加者数: 予約データがあればそれを使用、なければ current_participants を使用
-      // （予約データがない過去の公演では current_participants に直接入力されている）
-      // ※ スタッフ参加は有料参加者に含めない（actualCount + demoCount のみ）
-      const reservationParticipants = actualCount + demoCount
-      const rawParticipants = reservationParticipants > 0 
-        ? reservationParticipants 
-        : (event.current_participants || 0)
-      
-      // 最大参加者数を超えないように制限
-      const participants = Math.min(rawParticipants, maxParticipants)
-      
-      // 売上計算: event.total_revenue が未設定の場合は参加者数 × 参加費から計算
-      const isGmTest = event.category === 'gmtest'
-      const fee = isGmTest ? gmTestParticipationFee : normalParticipationFee
-      const eventRevenue = event.total_revenue || (participants * fee)
-      
-      // GM報酬: event.gm_cost が未設定の場合はシナリオ設定から計算
-      const eventGmCost = event.gm_cost || (isGmTest ? gmTestGmReward : normalGmReward)
-      
-      // サマリー計算は中止公演を除外
-      if (!isCancelled) {
-        totalParticipants += participants
-        totalStaffParticipants += staffCount
-        totalRevenue += eventRevenue
-        totalGmCost += eventGmCost
-        
-        // ライセンス料の計算: event.license_cost が0または未設定の場合はシナリオの設定値から計算
-        let licenseCost = event.license_cost || 0
-        if (licenseCost === 0) {
-          licenseCost = isGmTest ? gmTestLicenseAmount : normalLicenseAmount
-        }
-        totalLicenseCost += licenseCost
-
-        // 会場費: 店舗の venue_cost_per_performance から取得
-        const storeData = (event as any).stores
-        const venueCost = storeData?.venue_cost_per_performance || 0
-        totalVenueCost += venueCost
-        if (venueCost > 0) venueCostSet.add(venueCost)
-      }
-      
-      // リスト表示用には中止公演も含める
-      performanceDates.push({
-        date: event.date,
-        category: event.category || 'open',
-        participants,
-        demoParticipants: demoCount,
-        staffParticipants: staffCount,
-        revenue: eventRevenue,
-        startTime: event.start_time || '',
-        storeId: event.store_id || null,
-        isCancelled
-      })
-    })
-
-    // 1公演あたり会場費（全公演で同一値なら代表値を返す）
-    const venueCostPerPerformance = venueCostSet.size === 1
-      ? [...venueCostSet][0]
-      : venueCostSet.size > 1
-        ? Math.round(totalVenueCost / (performanceCount || 1))
-        : 0
-
-    // 将来の公演予定数（明日以降、出張公演除外、中止除外）
-    let futurePerfQuery = supabase
-      .from('schedule_events')
-      .select('*', { count: 'exact', head: true })
-      .eq('scenario_master_id', scenarioId)
-      .gt('date', today)
-      .neq('category', 'offsite')
-      .neq('is_cancelled', true)
-    
-    if (orgId) {
-      futurePerfQuery = futurePerfQuery.eq('organization_id', orgId)
-    }
-    
-    const { count: futurePerformanceCount } = await futurePerfQuery
-
-    // 将来の貸切予約数（公演に紐付いていない、確定済み）
-    let futureResQuery = supabase
-      .from('reservations')
-      .select('*', { count: 'exact', head: true })
-      .eq('scenario_master_id', scenarioId)
-      .is('schedule_event_id', null)
-      .in('status', ['confirmed', 'gm_confirmed', 'pending'])
-    
-    if (orgId) {
-      futureResQuery = futureResQuery.eq('organization_id', orgId)
-    }
-    
-    const { count: futureReservationCount } = await futureResQuery
-
-    // デバッグログ（本番では削除可）
-    logger.log('📊 シナリオ統計:', {
-      scenarioId,
-      maxParticipants,
-      performanceCount: performanceCount || 0,
-      totalParticipants,
-      futurePerformanceCount: futurePerformanceCount || 0,
-      futureReservationCount: futureReservationCount || 0,
-    })
-
-    return {
-      performanceCount: performanceCount || 0,
-      cancelledCount: cancelledCount || 0,
-      totalRevenue,
-      totalParticipants,
-      totalStaffParticipants,
-      totalGmCost,
-      totalLicenseCost,
-      totalVenueCost,
-      venueCostPerPerformance,
-      firstPerformanceDate,
-      performanceDates,
-      futurePerformanceCount: futurePerformanceCount || 0,
-      futureReservationCount: futureReservationCount || 0
-    }
+    const params = new URLSearchParams({ type: 'stats', scenarioId })
+    return apiClient.get(`/api/scenarios?${params}`)
   },
 
-  // 全シナリオの統計情報を一括取得（リスト表示用、ページネーションで全件取得）
+  // 全シナリオの統計情報を一括取得（バックエンド経由）
   async getAllScenarioStats(): Promise<Record<string, {
     performanceCount: number
     cancelledCount: number
     totalRevenue: number
   }>> {
-    const today = new Date().toISOString().split('T')[0]
-    
-    // 組織フィルタ（マルチテナント対応）
-    const orgId = await getCurrentOrganizationId()
-
-    // ページネーションで全件取得（Supabaseのmax_rows制限を回避）
-    const pageSize = 1000
-    let allEvents: any[] = []
-    let page = 0
-    let hasMore = true
-
-    while (hasMore) {
-      const from = page * pageSize
-      const to = from + pageSize - 1
-      
-      let query = supabase
-        .from('schedule_events_staff_view')
-        .select('scenario_master_id, is_cancelled, total_revenue, date, category')
-        .lte('date', today)
-        .neq('category', 'offsite')
-        .range(from, to)
-        .order('date', { ascending: false })
-      
-      if (orgId) {
-        query = query.eq('organization_id', orgId)
-      }
-      
-      const { data: events, error } = await query
-
-      if (error) throw error
-
-      if (events && events.length > 0) {
-        allEvents = allEvents.concat(events)
-        hasMore = events.length === pageSize
-        page++
-      } else {
-        hasMore = false
-      }
-    }
-
-    const events = allEvents
-
-    // scenario_master_id ごとに集計
-    const statsMap: Record<string, {
-      performanceCount: number
-      cancelledCount: number
-      totalRevenue: number
-    }> = {}
-
-    events?.forEach(event => {
-      if (!event.scenario_master_id) return
-
-      if (!statsMap[event.scenario_master_id]) {
-        statsMap[event.scenario_master_id] = {
-          performanceCount: 0,
-          cancelledCount: 0,
-          totalRevenue: 0
-        }
-      }
-
-      if (event.is_cancelled) {
-        statsMap[event.scenario_master_id].cancelledCount++
-      } else {
-        statsMap[event.scenario_master_id].performanceCount++
-        statsMap[event.scenario_master_id].totalRevenue += event.total_revenue || 0
-      }
-    })
-
-    return statsMap
+    return apiClient.get('/api/scenarios?type=all-stats')
   },
 
-  // シナリオの担当GMを更新
+  // シナリオの担当GMを更新（バックエンド経由）
   // NOTE: staff.special_scenarios への同期は廃止。staff_scenario_assignments が唯一のデータソース
   // id: scenario_master_id
   async updateAvailableGmsWithSync(id: string, availableGms: string[]): Promise<Scenario> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) {
-      throw new Error('組織IDが取得できません')
-    }
-    
-    // organization_scenarios の担当GMを更新
-    const { error: updateError } = await supabase
-      .from('organization_scenarios')
-      .update({ available_gms: availableGms, updated_at: new Date().toISOString() })
-      .eq('scenario_master_id', id)
-      .eq('organization_id', orgId)
-    
-    if (updateError) throw updateError
-
-    // 更新後のデータを取得して返す
-    const { data: updatedScenario, error: fetchError } = await supabase
-      .from('organization_scenarios_with_master')
-      .select(ORG_SCENARIOS_VIEW_SELECT_FIELDS)
-      .eq('id', id)
-      .eq('organization_id', orgId)
-      .single()
-    
-    if (fetchError) throw fetchError
-    return updatedScenario as unknown as Scenario
-  }
+    const params = new URLSearchParams({ action: 'updateAvailableGmsWithSync', id })
+    return apiClient.patch<Scenario>(`/api/scenarios?${params}`, { availableGms })
+  },
 }
-


### PR DESCRIPTION
## Summary

- `scenarioApi` の write 系 (`create` / `update` / `delete` / `updateAvailableGms` / `updateAvailableGmsWithSync`) と残り read 系 (`getAllLegacy` / `getPublic` / `getPaginated` / `getPerformanceCount` / `getScenarioStats` / `getAllScenarioStats`) を `/api/scenarios` バックエンド API 経由に切り替え
- `organization_id` はクライアントから受け取らず、すべて JWT からサーバ側で取得して強制適用（複数組織登録時のマルチテナント境界を強化）
- write 系では `ensureOwnedByOrg()` で対象シナリオが自組織所有かを明示検証してから書き込み

## 新規エンドポイント（既存 `api/scenarios.ts` を拡張）

| Method | クエリ | 機能 |
|---|---|---|
| GET | `?type=legacy` | 旧 `scenarios` テーブル全件（自組織のみ） |
| GET | `?type=public` | 公開用シナリオ一覧（`status=available` / 自組織のみ） |
| GET | `?type=paginated&page=N&pageSize=M` | ページネーション付き一覧（自組織のみ） |
| GET | `?type=performance-count&scenarioId=X` | 累計公演回数（自組織・非中止） |
| GET | `?type=stats&scenarioId=X` | シナリオ統計（公演数・売上・コスト等、自組織のみ） |
| GET | `?type=all-stats` | 全シナリオ統計マップ（自組織のみ、ページネーション内部処理） |
| POST | `/` | シナリオ作成（`scenario_masters` + `organization_scenarios`） |
| PATCH | `?action=update&id=X` | シナリオ更新（`status=available` でマスター昇格） |
| PATCH | `?action=updateAvailableGms&id=X` | 担当 GM 更新 |
| PATCH | `?action=updateAvailableGmsWithSync&id=X` | 担当 GM 更新（同期版、現状は通常版と同実装） |
| DELETE | `?id=X` | シナリオ削除（`organization_scenarios` のみ、`scenario_masters` は残す） |

CORS の `Access-Control-Allow-Methods` も `GET, POST, PATCH, DELETE, OPTIONS` に更新。

## セキュリティ強化点

- **`organization_id` を JWT 由来に固定**: クライアントから渡された値は無視。`create` の `organization_id` / `submitted_by_organization_id` も JWT 由来。
- **write 系の所有権チェック**: `ensureOwnedByOrg()` で `organization_scenarios` の自組織行 ID を取得し、見つからなければ `404`。`update` / `delete` / `updateAvailableGms` はその `id` 経由でのみ更新するため、他組織の `organization_scenarios` 行に影響しない。
- **`delete` の関連データ削除も `organization_id` でフィルタ**: `reservations` / `schedule_events` / `staff_scenario_assignments` の更新・削除も自組織のみ。`performance_kits` は組織カラム未対応のため `scenario_master_id` のみで削除（旧実装と同挙動、TODO コメント付き）。
- **`scenario_masters` の `draft → pending` 昇格**: 旧挙動と同じく自組織がそのマスターを保有していれば許可。さらに保守的にするための TODO コメントを残し、将来的な強化（`submitted_by_organization_id` チェック）に備える。

## 既知の差分

- 旧 `getScenarioStats` はカスタム GM コストが未設定の場合にフロントの `useSalarySettings` で `calculateGmWage` を呼んでいたが、サーバ実装ではまだ `salary_settings` を参照していない（GM コストが 0 になる可能性）。TODO コメントを残し、後続 PR で対応予定。

## Test plan

- [ ] スタッフでログイン → シナリオ管理画面が一覧表示される（`getPaginated`）
- [ ] シナリオを新規作成 → DB に `scenario_masters` と `organization_scenarios` が作成され、ビュー経由で取得できる
- [ ] 既存シナリオを編集 → `status=available` でマスターが `pending` に昇格する
- [ ] 既存シナリオを削除 → `organization_scenarios` のみ削除され、`scenario_masters` は残る
- [ ] シナリオ統計ダイアログを開く（`getScenarioStats` / `getPerformanceCount`）→ 公演数・売上が表示される
- [ ] シナリオ一覧の集計（`getAllScenarioStats`）が表示される
- [ ] 他組織のシナリオ ID を `update` / `delete` に渡しても `404` が返る（マルチテナント境界）

🤖 Generated with [Claude Code](https://claude.com/claude-code)