### PR TITLE
feat(api): authorApi/scenarioMasterApi/scenarioAliasApi をバックエンド API に移行（マルチテナント境界強化）

### DIFF
--- a/api/authors.ts
+++ b/api/authors.ts
@@ -1,0 +1,597 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
+
+/**
+ * Authors API
+ *
+ * authors テーブルは organization_id を持たない「全組織共有マスタ」。
+ * マルチテナント境界:
+ *   - READ: authenticated（staff 以上）に制限。顧客は参照しない想定。
+ *   - WRITE: staff 以上のみ。
+ *   - service_role で RLS をバイパスするため、サーバ側で role を必ず requireStaff で検証する。
+ *
+ * 既存 RPC 関数を service_role で呼ぶ:
+ *   - get_all_authors / get_author_by_name / upsert_author
+ * 直接 SQL 操作:
+ *   - notes フィールドへの直書き（setOrganizationName, markEmailSent, delete）
+ *
+ * フロント側の authorApi.ts のメソッドと 1:1 で対応する type 分岐:
+ *   GET    ?type=list            → 全作者
+ *   GET    ?type=by-name&name=   → 名前で取得
+ *   GET    ?type=current-email   → ログイン中ユーザーのメールアドレス
+ *   GET    ?type=scenarios-by-email&email=
+ *   GET    ?type=reports-by-email&email=&status?=&startDate?=&endDate?=
+ *   GET    ?type=summary-by-email&email=
+ *   GET    ?type=dashboard       → 自分のダッシュボード
+ *   POST   ?type=upsert          body: { name, email?, notes?, license_organization_name? }
+ *   PATCH  ?type=set-org-name    body: { authorName, organizationName, memo? }
+ *   PATCH  ?type=mark-email-sent body: { authorName, year, month }
+ *   PATCH  ?type=update          body: { id, ...updates }
+ *   DELETE ?id=xxx               → 削除
+ */
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+// notes フィールドへの license_organization_name エンコード（フロントと同じロジック）
+const ORG_NOTES_KEY = '__org__'
+const SENT_YM_KEY = '__sent_ym__'
+
+type AuthorNotes = { orgName: string | null; memo: string | null; sentYm: string | null }
+
+function parseAuthorNotes(rawNotes: string | null | undefined): AuthorNotes {
+  if (!rawNotes) return { orgName: null, memo: null, sentYm: null }
+  try {
+    const parsed = JSON.parse(rawNotes)
+    if (parsed && typeof parsed === 'object' && ORG_NOTES_KEY in parsed) {
+      return {
+        orgName: (parsed[ORG_NOTES_KEY] as string) || null,
+        memo: (parsed.memo as string) || null,
+        sentYm: (parsed[SENT_YM_KEY] as string) || null,
+      }
+    }
+  } catch {
+    /* 非JSON = 旧来のプレーンテキスト */
+  }
+  return { orgName: null, memo: rawNotes, sentYm: null }
+}
+
+function encodeAuthorNotes(
+  orgName: string | null,
+  memo: string | null,
+  sentYm?: string | null
+): string | null {
+  if (!orgName && !memo && !sentYm) return null
+  if (!orgName && !sentYm) return memo
+  return JSON.stringify({
+    [ORG_NOTES_KEY]: orgName || '',
+    memo: memo || '',
+    ...(sentYm ? { [SENT_YM_KEY]: sentYm } : {}),
+  })
+}
+
+function decodeAuthor(raw: Record<string, unknown>) {
+  const { orgName, memo, sentYm } = parseAuthorNotes(raw.notes as string | null)
+  return {
+    id: raw.id as string,
+    name: raw.name as string,
+    email: (raw.email as string | null) ?? null,
+    license_organization_name:
+      orgName ?? ((raw.license_organization_name as string | null) ?? null),
+    notes: memo,
+    last_email_sent_ym: sentYm,
+    created_at: raw.created_at as string,
+    updated_at: raw.updated_at as string,
+  }
+}
+
+const AUTHOR_PERFORMANCE_REPORT_SELECT_FIELDS =
+  'author_email, author_name, scenario_master_id, scenario_title, organization_id, organization_name, report_id, performance_date, performance_count, participant_count, venue_name, report_status, reported_at, license_amount, calculated_license_fee'
+const AUTHOR_SUMMARY_SELECT_FIELDS =
+  'author_email, total_scenarios, total_approved_reports, total_performance_count, total_license_fee, organizations_count'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+    // authors テーブルは全組織共有マスタだが、参照・書き込みともに
+    // スタッフ以上の権限が必要（顧客は使わない）
+    requireStaff(user)
+
+    const type = (req.query.type as string | undefined) ?? ''
+
+    if (req.method === 'GET') {
+      switch (type) {
+        case 'list':
+          return await handleList(res)
+        case 'by-name':
+          return await handleGetByName(req, res)
+        case 'current-email':
+          return await handleCurrentEmail(res, user.userId)
+        case 'scenarios-by-email':
+          return await handleScenariosByEmail(req, res)
+        case 'reports-by-email':
+          return await handleReportsByEmail(req, res)
+        case 'summary-by-email':
+          return await handleSummaryByEmail(req, res)
+        case 'dashboard':
+          return await handleDashboard(res, user.userId)
+        default:
+          return res.status(400).json({ error: `unknown type: ${type}` })
+      }
+    }
+
+    if (req.method === 'POST') {
+      if (type === 'upsert') return await handleUpsert(req, res)
+      return res.status(400).json({ error: `unknown type for POST: ${type}` })
+    }
+
+    if (req.method === 'PATCH') {
+      switch (type) {
+        case 'set-org-name':
+          return await handleSetOrganizationName(req, res)
+        case 'mark-email-sent':
+          return await handleMarkEmailSent(req, res)
+        case 'update':
+          return await handleUpdate(req, res)
+        default:
+          return res.status(400).json({ error: `unknown type for PATCH: ${type}` })
+      }
+    }
+
+    if (req.method === 'DELETE') {
+      return await handleDelete(req, res)
+    }
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[authors] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// ─── GET handlers ────────────────────────────────────────────────────────────
+
+async function handleList(res: VercelResponse) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database.rpc('get_all_authors')
+  if (error) {
+    console.warn('[authors:list] get_all_authors error:', error)
+    return res.status(200).json([])
+  }
+  if (Array.isArray(data)) {
+    return res.status(200).json((data as Record<string, unknown>[]).map(decodeAuthor))
+  }
+  return res.status(200).json([])
+}
+
+async function handleGetByName(req: VercelRequest, res: VercelResponse) {
+  const name = req.query.name as string | undefined
+  if (!name) return res.status(400).json({ error: 'name クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database.rpc('get_author_by_name', { p_name: name })
+  if (error) {
+    console.warn('[authors:by-name] get_author_by_name error:', error)
+    return res.status(200).json(null)
+  }
+  if (data && data.found) {
+    return res.status(200).json(decodeAuthor(data as Record<string, unknown>))
+  }
+  return res.status(200).json(null)
+}
+
+async function handleCurrentEmail(res: VercelResponse, userId: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database.auth.admin.getUserById(userId)
+  if (error || !data?.user) return res.status(200).json({ email: null })
+  return res.status(200).json({ email: data.user.email ?? null })
+}
+
+async function handleScenariosByEmail(req: VercelRequest, res: VercelResponse) {
+  const email = req.query.email as string | undefined
+  if (!email) return res.status(400).json({ error: 'email クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data: masters, error: mastersError } = await database
+    .from('scenario_masters')
+    .select('id, title, author, author_email')
+    .eq('author_email', email)
+    .order('title')
+
+  if (mastersError) {
+    if (mastersError.code === 'PGRST204' || mastersError.message?.includes('author_email')) {
+      return res.status(200).json([])
+    }
+    console.error('[authors:scenarios-by-email] DB error:', mastersError)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: mastersError.message })
+  }
+  if (!masters || masters.length === 0) return res.status(200).json([])
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const masterIds = (masters as any[]).map((m) => m.id)
+  const { data: orgScenarios } = await database
+    .from('organization_scenarios')
+    .select('scenario_master_id, play_count')
+    .in('scenario_master_id', masterIds)
+
+  const playCountMap = new Map<string, number>()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;((orgScenarios as any[]) ?? []).forEach((os) => {
+    const current = playCountMap.get(os.scenario_master_id) || 0
+    playCountMap.set(os.scenario_master_id, current + (os.play_count || 0))
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = (masters as any[]).map((m) => ({
+    id: m.id,
+    title: m.title,
+    author: m.author || '',
+    author_email: m.author_email,
+    play_count: playCountMap.get(m.id) || 0,
+  }))
+  return res.status(200).json(result)
+}
+
+async function handleReportsByEmail(req: VercelRequest, res: VercelResponse) {
+  const email = req.query.email as string | undefined
+  if (!email) return res.status(400).json({ error: 'email クエリパラメータが必要です' })
+
+  const status = req.query.status as string | undefined
+  const startDate = req.query.startDate as string | undefined
+  const endDate = req.query.endDate as string | undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  let query = database
+    .from('author_performance_reports')
+    .select(AUTHOR_PERFORMANCE_REPORT_SELECT_FIELDS)
+    .eq('author_email', email)
+    .order('reported_at', { ascending: false })
+
+  if (status) query = query.eq('report_status', status)
+  if (startDate) query = query.gte('performance_date', startDate)
+  if (endDate) query = query.lte('performance_date', endDate)
+
+  const { data, error } = await query
+  if (error) {
+    if (error.code === 'PGRST204' || error.code === '42P01') return res.status(200).json([])
+    console.error('[authors:reports-by-email] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+async function handleSummaryByEmail(req: VercelRequest, res: VercelResponse) {
+  const email = req.query.email as string | undefined
+  if (!email) return res.status(400).json({ error: 'email クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('author_summary')
+    .select(AUTHOR_SUMMARY_SELECT_FIELDS)
+    .eq('author_email', email)
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116' || error.code === '42P01') {
+      return res.status(200).json({
+        author_email: email,
+        total_scenarios: 0,
+        total_approved_reports: 0,
+        total_performance_count: 0,
+        total_license_fee: 0,
+        organizations_count: 0,
+      })
+    }
+    console.error('[authors:summary-by-email] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json({
+    author_email: data.author_email,
+    total_scenarios: data.total_scenarios || 0,
+    total_approved_reports: data.total_approved_reports || 0,
+    total_performance_count: data.total_performance_count || 0,
+    total_license_fee: data.total_license_fee || 0,
+    organizations_count: data.organizations_count || 0,
+  })
+}
+
+async function handleDashboard(res: VercelResponse, userId: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data: userData, error: userError } = await database.auth.admin.getUserById(userId)
+  if (userError || !userData?.user?.email) return res.status(200).json(null)
+  const email = userData.user.email as string
+
+  type AuthorSummary = {
+    author_email: string
+    total_scenarios: number
+    total_approved_reports: number
+    total_performance_count: number
+    total_license_fee: number
+    organizations_count: number
+  }
+
+  let summary: AuthorSummary = {
+    author_email: email,
+    total_scenarios: 0,
+    total_approved_reports: 0,
+    total_performance_count: 0,
+    total_license_fee: 0,
+    organizations_count: 0,
+  }
+  let reports: unknown[] = []
+  let scenarios: Array<{
+    id: string
+    title: string
+    author: string
+    author_email: string | null
+    play_count: number
+  }> = []
+
+  // シナリオ一覧
+  try {
+    const { data: masters } = await database
+      .from('scenario_masters')
+      .select('id, title, author, author_email')
+      .eq('author_email', email)
+      .order('title')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const masterList = (masters as any[]) ?? []
+    if (masterList.length > 0) {
+      const masterIds = masterList.map((m) => m.id)
+      const { data: orgScenarios } = await database
+        .from('organization_scenarios')
+        .select('scenario_master_id, play_count')
+        .in('scenario_master_id', masterIds)
+
+      const playCountMap = new Map<string, number>()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;((orgScenarios as any[]) ?? []).forEach((os) => {
+        const current = playCountMap.get(os.scenario_master_id) || 0
+        playCountMap.set(os.scenario_master_id, current + (os.play_count || 0))
+      })
+
+      scenarios = masterList.map((m) => ({
+        id: m.id,
+        title: m.title,
+        author: m.author || '',
+        author_email: m.author_email,
+        play_count: playCountMap.get(m.id) || 0,
+      }))
+      summary.total_scenarios = scenarios.length
+    }
+  } catch (e) {
+    console.warn('[authors:dashboard] シナリオ取得失敗:', e)
+  }
+
+  // 報告一覧
+  try {
+    const { data, error } = await database
+      .from('author_performance_reports')
+      .select(AUTHOR_PERFORMANCE_REPORT_SELECT_FIELDS)
+      .eq('author_email', email)
+      .order('reported_at', { ascending: false })
+    if (!error && data) reports = data
+  } catch (e) {
+    console.warn('[authors:dashboard] 報告取得失敗 (ビュー未作成の可能性):', e)
+  }
+
+  // サマリー
+  try {
+    const { data, error } = await database
+      .from('author_summary')
+      .select(AUTHOR_SUMMARY_SELECT_FIELDS)
+      .eq('author_email', email)
+      .single()
+    if (!error && data) {
+      summary = {
+        author_email: data.author_email,
+        total_scenarios: data.total_scenarios || 0,
+        total_approved_reports: data.total_approved_reports || 0,
+        total_performance_count: data.total_performance_count || 0,
+        total_license_fee: data.total_license_fee || 0,
+        organizations_count: data.organizations_count || 0,
+      }
+    }
+  } catch (e) {
+    console.warn('[authors:dashboard] サマリー取得失敗 (ビュー未作成の可能性):', e)
+  }
+
+  return res.status(200).json({ email, summary, reports, scenarios })
+}
+
+// ─── POST / PATCH / DELETE handlers ─────────────────────────────────────────
+
+async function handleUpsert(req: VercelRequest, res: VercelResponse) {
+  const body = (req.body ?? {}) as {
+    name?: string
+    email?: string | null
+    notes?: string | null
+    license_organization_name?: string | null
+  }
+  if (!body.name) return res.status(400).json({ error: 'name は必須です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database.rpc('upsert_author', {
+    p_name: body.name,
+    p_email: body.email ?? null,
+    p_notes: body.notes ?? null,
+    p_license_organization_name: body.license_organization_name ?? null,
+  })
+
+  if (error) {
+    console.error('[authors:upsert] DB error:', error)
+    return res.status(500).json({ error: 'upsert に失敗しました', detail: error.message })
+  }
+  if (!data?.success) {
+    return res
+      .status(500)
+      .json({ error: data?.error ?? 'upsert に失敗しました' })
+  }
+
+  // 最新を取得して返す
+  const { data: latest } = await database.rpc('get_author_by_name', { p_name: body.name })
+  if (latest && latest.found) {
+    return res.status(200).json(decodeAuthor(latest as Record<string, unknown>))
+  }
+  return res.status(200).json({ success: true, ...data })
+}
+
+async function handleUpdate(req: VercelRequest, res: VercelResponse) {
+  const body = (req.body ?? {}) as {
+    id?: string
+    name?: string
+    email?: string | null
+    notes?: string | null
+    license_organization_name?: string | null
+  }
+  if (!body.id) return res.status(400).json({ error: 'id は必須です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  // id から name を引く
+  const { data: row, error: lookupError } = await database
+    .from('authors')
+    .select('name')
+    .eq('id', body.id)
+    .single()
+  if (lookupError || !row) {
+    return res.status(404).json({ error: 'Author not found' })
+  }
+
+  const name = row.name as string
+  const { data, error } = await database.rpc('upsert_author', {
+    p_name: name,
+    p_email: body.email ?? null,
+    p_notes: body.notes ?? null,
+    p_license_organization_name: body.license_organization_name ?? null,
+  })
+
+  if (error) {
+    console.error('[authors:update] DB error:', error)
+    return res.status(500).json({ error: '更新に失敗しました', detail: error.message })
+  }
+  if (!data?.success) {
+    return res.status(500).json({ error: data?.error ?? '更新に失敗しました' })
+  }
+
+  const { data: latest } = await database.rpc('get_author_by_name', { p_name: name })
+  if (latest && latest.found) {
+    return res.status(200).json(decodeAuthor(latest as Record<string, unknown>))
+  }
+  return res.status(200).json({ success: true })
+}
+
+async function handleSetOrganizationName(req: VercelRequest, res: VercelResponse) {
+  const body = (req.body ?? {}) as {
+    authorName?: string
+    organizationName?: string
+    memo?: string | null
+  }
+  if (!body.authorName) return res.status(400).json({ error: 'authorName は必須です' })
+  if (body.organizationName === undefined) {
+    return res.status(400).json({ error: 'organizationName は必須です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // memo が undefined なら既存メモを保持
+  let currentMemo: string | null = body.memo === undefined ? null : (body.memo ?? null)
+  let currentSentYm: string | null = null
+  if (body.memo === undefined) {
+    const { data: current } = await database.rpc('get_author_by_name', { p_name: body.authorName })
+    if (current && current.found) {
+      const decoded = decodeAuthor(current as Record<string, unknown>)
+      currentMemo = decoded.notes
+      currentSentYm = decoded.last_email_sent_ym
+    }
+  }
+
+  const encodedNotes = encodeAuthorNotes(body.organizationName, currentMemo, currentSentYm)
+
+  const { error } = await database
+    .from('authors')
+    .update({ notes: encodedNotes })
+    .eq('name', body.authorName)
+  if (error) {
+    console.error('[authors:set-org-name] DB error:', error)
+    return res.status(500).json({ error: '更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
+}
+
+async function handleMarkEmailSent(req: VercelRequest, res: VercelResponse) {
+  const body = (req.body ?? {}) as { authorName?: string; year?: number; month?: number }
+  if (!body.authorName) return res.status(400).json({ error: 'authorName は必須です' })
+  if (typeof body.year !== 'number' || typeof body.month !== 'number') {
+    return res.status(400).json({ error: 'year と month は必須です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const sentYm = `${body.year}-${String(body.month).padStart(2, '0')}`
+
+  const { data: current } = await database.rpc('get_author_by_name', { p_name: body.authorName })
+  let orgName: string | null = null
+  let memo: string | null = null
+  if (current && current.found) {
+    const decoded = decodeAuthor(current as Record<string, unknown>)
+    orgName = decoded.license_organization_name
+    memo = decoded.notes
+  }
+
+  const encodedNotes = encodeAuthorNotes(orgName, memo, sentYm)
+  const { error } = await database
+    .from('authors')
+    .update({ notes: encodedNotes })
+    .eq('name', body.authorName)
+  if (error) {
+    console.error('[authors:mark-email-sent] DB error:', error)
+    return res.status(500).json({ error: '更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
+}
+
+async function handleDelete(req: VercelRequest, res: VercelResponse) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { error } = await database.from('authors').delete().eq('id', id)
+  if (error) {
+    console.error('[authors:delete] DB error:', error)
+    return res.status(500).json({ error: '削除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
+}

--- a/api/scenario-aliases.ts
+++ b/api/scenario-aliases.ts
@@ -1,0 +1,188 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError, type AuthUser } from './_lib/auth.js'
+
+/**
+ * Scenario Aliases API
+ *
+ * scenario_import_aliases は organization_id を持たない「全組織共有マスタ」。
+ * スケジュールインポート時のシナリオ名揺れ → 正式名称マッピング。
+ *
+ * マルチテナント境界:
+ *   - READ: 認証済みユーザー（顧客でも構わないが、現状の利用箇所は
+ *           スタッフ機能のみなので requireStaff で絞る）
+ *   - WRITE: admin のみ（is_org_admin 相当）
+ *
+ * type 分岐:
+ *   GET   ?type=map      → { alias: canonical_name } のマップを返す（フロントのキャッシュ前提）
+ *   GET   ?type=list     → [{ id, alias, canonical_name, created_at }] の配列
+ *   POST                 body: { alias, canonical_name } → 追加
+ *   PATCH ?id=           body: { alias?, canonical_name? } → 更新
+ *   DELETE ?id=          → 削除
+ */
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+function requireAdmin(user: AuthUser): void {
+  if (user.role !== 'admin') {
+    throw new ApiError(403, '管理者権限が必要です')
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+    const type = (req.query.type as string | undefined) ?? ''
+
+    if (req.method === 'GET') {
+      // 参照は staff 以上で許可（スケジュールインポート機能で使う）
+      requireStaff(user)
+      if (type === 'map' || type === '') return await handleMap(res)
+      if (type === 'list') return await handleList(res)
+      return res.status(400).json({ error: `unknown type for GET: ${type}` })
+    }
+
+    if (req.method === 'POST') {
+      requireAdmin(user)
+      return await handleCreate(req, res)
+    }
+
+    if (req.method === 'PATCH') {
+      requireAdmin(user)
+      return await handleUpdate(req, res)
+    }
+
+    if (req.method === 'DELETE') {
+      requireAdmin(user)
+      return await handleDelete(req, res)
+    }
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[scenario-aliases] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// ─── handlers ────────────────────────────────────────────────────────────────
+
+async function handleMap(res: VercelResponse) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_import_aliases')
+    .select('alias, canonical_name')
+
+  if (error) {
+    console.warn('[scenario-aliases:map] DB error:', error)
+    return res.status(200).json({})
+  }
+
+  const map: Record<string, string> = {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const row of (data as any[]) ?? []) {
+    map[row.alias] = row.canonical_name
+  }
+  return res.status(200).json(map)
+}
+
+async function handleList(res: VercelResponse) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_import_aliases')
+    .select('id, alias, canonical_name, created_at')
+    .order('alias', { ascending: true })
+
+  if (error) {
+    console.error('[scenario-aliases:list] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+async function handleCreate(req: VercelRequest, res: VercelResponse) {
+  const body = (req.body ?? {}) as { alias?: string; canonical_name?: string }
+  if (!body.alias || !body.canonical_name) {
+    return res.status(400).json({ error: 'alias と canonical_name は必須です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_import_aliases')
+    .insert({
+      alias: body.alias,
+      canonical_name: body.canonical_name,
+    })
+    .select('id, alias, canonical_name, created_at')
+    .single()
+
+  if (error) {
+    console.error('[scenario-aliases:create] DB error:', error)
+    return res.status(500).json({ error: '作成に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handleUpdate(req: VercelRequest, res: VercelResponse) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  const body = (req.body ?? {}) as { alias?: string; canonical_name?: string }
+  const updates: Record<string, unknown> = {}
+  if (body.alias !== undefined) updates.alias = body.alias
+  if (body.canonical_name !== undefined) updates.canonical_name = body.canonical_name
+  if (Object.keys(updates).length === 0) {
+    return res.status(400).json({ error: '更新対象のフィールドがありません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_import_aliases')
+    .update(updates)
+    .eq('id', id)
+    .select('id, alias, canonical_name, created_at')
+    .single()
+
+  if (error) {
+    console.error('[scenario-aliases:update] DB error:', error)
+    return res.status(500).json({ error: '更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handleDelete(req: VercelRequest, res: VercelResponse) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { error } = await database.from('scenario_import_aliases').delete().eq('id', id)
+  if (error) {
+    console.error('[scenario-aliases:delete] DB error:', error)
+    return res.status(500).json({ error: '削除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
+}

--- a/api/scenario-masters.ts
+++ b/api/scenario-masters.ts
@@ -1,0 +1,369 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError, type AuthUser } from './_lib/auth.js'
+
+/**
+ * Scenario Masters API
+ *
+ * scenario_masters は「全組織で共有される横断マスタ」だが、
+ * 各レコードは submitted_by_organization_id（提出元組織）を持つ。
+ *
+ * マルチテナント境界:
+ *   - READ:
+ *       - approved: 全認証ユーザーが参照可能
+ *       - draft/pending/rejected: 提出元組織のスタッフのみ、または license_admin
+ *   - CREATE: スタッフ以上。submitted_by_organization_id は JWT の orgId を強制（クライアントから受け取らない）
+ *   - UPDATE: 提出元組織のスタッフ、または license_admin（approve/reject 系）
+ *   - DELETE: 同じく提出元組織のスタッフ または license_admin
+ *
+ * service_role で RLS をバイパスするため、上記の権限チェックをサーバコードで明示的に行う。
+ *
+ * type 分岐:
+ *   GET    ?type=list                 → 全シナリオマスタ（権限フィルタ込み）
+ *   GET    ?type=approved             → approved のみ（誰でも参照可能）
+ *   GET    ?type=by-id&id=            → 単一取得
+ *   POST   (body)                     → 作成（draft）
+ *   PATCH  ?type=update&id=           body: 部分更新
+ *   PATCH  ?type=publish&id=          → draft → pending
+ *   PATCH  ?type=approve&id=          → pending → approved（license_admin のみ）
+ *   PATCH  ?type=reject&id=           body: { reason } → pending → rejected（license_admin のみ）
+ */
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+const SCENARIO_MASTER_SELECT_FIELDS =
+  'id, title, author, author_id, key_visual_url, description, player_count_min, player_count_max, official_duration, genre, difficulty, synopsis, caution, required_items, master_status, submitted_by_organization_id, approved_by, approved_at, rejection_reason, created_at, updated_at, created_by'
+
+// master 上で許可された更新可能フィールド（任意のカラムを無制限に更新させない）
+const ALLOWED_UPDATE_FIELDS = new Set([
+  'title',
+  'author',
+  'author_id',
+  'key_visual_url',
+  'description',
+  'player_count_min',
+  'player_count_max',
+  'official_duration',
+  'genre',
+  'difficulty',
+  'synopsis',
+  'caution',
+  'required_items',
+])
+
+function pickAllowedUpdates(body: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(body)) {
+    if (ALLOWED_UPDATE_FIELDS.has(key)) out[key] = body[key]
+  }
+  return out
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+    const type = (req.query.type as string | undefined) ?? ''
+
+    if (req.method === 'GET') {
+      switch (type) {
+        case 'list':
+          return await handleList(res, user)
+        case 'approved':
+          return await handleApproved(res)
+        case 'by-id':
+          return await handleGetById(req, res, user)
+        default:
+          return res.status(400).json({ error: `unknown type for GET: ${type}` })
+      }
+    }
+
+    if (req.method === 'POST') {
+      // create
+      requireStaff(user)
+      return await handleCreate(req, res, user)
+    }
+
+    if (req.method === 'PATCH') {
+      requireStaff(user)
+      switch (type) {
+        case 'update':
+          return await handleUpdate(req, res, user)
+        case 'publish':
+          return await handlePublish(req, res, user)
+        case 'approve':
+          return await handleApprove(req, res, user)
+        case 'reject':
+          return await handleReject(req, res, user)
+        default:
+          return res.status(400).json({ error: `unknown type for PATCH: ${type}` })
+      }
+    }
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[scenario-masters] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+async function fetchMasterById(id: string): Promise<Record<string, unknown> | null> {
+  if (!db) return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('scenario_masters')
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .eq('id', id)
+    .maybeSingle()
+  if (error) {
+    console.error('[scenario-masters] fetchMasterById error:', error)
+    return null
+  }
+  return (data as Record<string, unknown> | null) ?? null
+}
+
+function canReadMaster(master: Record<string, unknown>, user: AuthUser): boolean {
+  if (master.master_status === 'approved') return true
+  if (user.role === 'license_admin') return true
+  if (
+    ['admin', 'staff'].includes(user.role) &&
+    master.submitted_by_organization_id === user.orgId
+  ) {
+    return true
+  }
+  return false
+}
+
+function canWriteMaster(master: Record<string, unknown>, user: AuthUser): boolean {
+  if (user.role === 'license_admin') return true
+  if (
+    ['admin', 'staff'].includes(user.role) &&
+    master.submitted_by_organization_id === user.orgId
+  ) {
+    return true
+  }
+  return false
+}
+
+// ─── GET handlers ────────────────────────────────────────────────────────────
+
+async function handleList(res: VercelResponse, user: AuthUser) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 権限に応じた可視範囲:
+  //   - license_admin: 全件
+  //   - その他: approved を全件 + 自組織が提出元のレコード（draft/pending/rejected 含む）
+  let query = database
+    .from('scenario_masters')
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .order('title', { ascending: true })
+
+  if (user.role !== 'license_admin') {
+    query = query.or(
+      `master_status.eq.approved,submitted_by_organization_id.eq.${user.orgId}`
+    )
+  }
+
+  const { data, error } = await query
+  if (error) {
+    console.error('[scenario-masters:list] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+async function handleApproved(res: VercelResponse) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_masters')
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .eq('master_status', 'approved')
+    .order('title', { ascending: true })
+
+  if (error) {
+    console.error('[scenario-masters:approved] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+async function handleGetById(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  const master = await fetchMasterById(id)
+  if (!master) return res.status(200).json(null)
+
+  if (!canReadMaster(master, user)) {
+    // 自分が見るべきでないレコードは「見つからない」として null を返す
+    // （存在の有無を漏らさないため）
+    return res.status(200).json(null)
+  }
+
+  return res.status(200).json(master)
+}
+
+// ─── POST / PATCH handlers ──────────────────────────────────────────────────
+
+async function handleCreate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const insertPayload = pickAllowedUpdates(body)
+
+  // submitted_by_organization_id は JWT から強制
+  // master_status は draft で固定
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_masters')
+    .insert({
+      ...insertPayload,
+      master_status: 'draft',
+      submitted_by_organization_id: user.orgId,
+      created_by: user.userId,
+    })
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[scenario-masters:create] DB error:', error)
+    return res.status(500).json({ error: '作成に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handleUpdate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  const existing = await fetchMasterById(id)
+  if (!existing) return res.status(404).json({ error: 'シナリオマスタが見つかりません' })
+  if (!canWriteMaster(existing, user)) {
+    return res.status(403).json({ error: 'このシナリオマスタを更新する権限がありません' })
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updates = pickAllowedUpdates(body)
+  if (Object.keys(updates).length === 0) {
+    return res.status(400).json({ error: '更新対象のフィールドがありません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_masters')
+    .update(updates)
+    .eq('id', id)
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[scenario-masters:update] DB error:', error)
+    return res.status(500).json({ error: '更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handlePublish(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  const existing = await fetchMasterById(id)
+  if (!existing) return res.status(404).json({ error: 'シナリオマスタが見つかりません' })
+  if (!canWriteMaster(existing, user)) {
+    return res.status(403).json({ error: 'このシナリオマスタを更新する権限がありません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_masters')
+    .update({ master_status: 'pending' })
+    .eq('id', id)
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[scenario-masters:publish] DB error:', error)
+    return res.status(500).json({ error: '公開申請に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handleApprove(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  if (user.role !== 'license_admin') {
+    return res.status(403).json({ error: 'ライセンス管理者のみ承認できます' })
+  }
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_masters')
+    .update({
+      master_status: 'approved',
+      approved_by: user.userId,
+      approved_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[scenario-masters:approve] DB error:', error)
+    return res.status(500).json({ error: '承認に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handleReject(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  if (user.role !== 'license_admin') {
+    return res.status(403).json({ error: 'ライセンス管理者のみ却下できます' })
+  }
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  const body = (req.body ?? {}) as { reason?: string }
+  const reason = body.reason ?? ''
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('scenario_masters')
+    .update({
+      master_status: 'rejected',
+      rejection_reason: reason,
+    })
+    .eq('id', id)
+    .select(SCENARIO_MASTER_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[scenario-masters:reject] DB error:', error)
+    return res.status(500).json({ error: '却下に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}

--- a/src/lib/api/authorApi.ts
+++ b/src/lib/api/authorApi.ts
@@ -1,219 +1,108 @@
 /**
- * 作者ポータルAPI（メールアドレスベース）
- * 
+ * 作者ポータル / 作者マスタ API
+ *
  * 設計方針:
- * - 作者は自分で登録しない
- * - ログイン中のユーザーのメールアドレスに紐づく報告を取得
- * - 同じメールアドレス宛の全報告が見れる
+ *   - 直接 supabase クライアントを叩かず、バックエンド API (/api/authors) 経由で操作する
+ *   - organization_id は authors テーブルに存在しない（全組織共有マスタ）
+ *   - サーバ側で requireStaff により参照・更新権限を保証
+ *   - 旧 RPC 経由実装（get_all_authors / get_author_by_name / upsert_author）と
+ *     互換のレスポンス形を維持する
  */
+import { apiClient } from '@/lib/apiClient'
 import { logger } from '@/utils/logger'
-import { supabase } from '../supabase'
-import type { RpcGetAuthorByNameParams, RpcUpsertAuthorParams } from '@/lib/rpcTypes'
 import type { Author, AuthorPerformanceReport, AuthorSummary } from '@/types'
 
 // 旧形式の互換性のため
 export type { Author }
 
-// NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
-const AUTHOR_SELECT_FIELDS = 'id, name, email, notes, created_at, updated_at' as const
-
-// ============================================================
-// notes フィールドへの license_organization_name エンコード
-// PostgRESTスキーマキャッシュが更新されないため、新規カラムを
-// 直接使えない。notes に JSON で格納して回避する暫定実装。
-// 形式: {"__org__":"会社名","memo":"振込先情報..."} または プレーンテキスト（旧形式）
-// ============================================================
-const ORG_NOTES_KEY = '__org__'
-const SENT_YM_KEY = '__sent_ym__'
-
-function parseAuthorNotes(rawNotes: string | null | undefined): { orgName: string | null; memo: string | null; sentYm: string | null } {
-  if (!rawNotes) return { orgName: null, memo: null, sentYm: null }
-  try {
-    const parsed = JSON.parse(rawNotes)
-    if (parsed && typeof parsed === 'object' && ORG_NOTES_KEY in parsed) {
-      return {
-        orgName: (parsed[ORG_NOTES_KEY] as string) || null,
-        memo: (parsed.memo as string) || null,
-        sentYm: (parsed[SENT_YM_KEY] as string) || null,
-      }
-    }
-  } catch { /* 非JSON = 旧来のプレーンテキスト */ }
-  return { orgName: null, memo: rawNotes, sentYm: null }
-}
-
-function encodeAuthorNotes(orgName: string | null, memo: string | null, sentYm?: string | null): string | null {
-  if (!orgName && !memo && !sentYm) return null
-  if (!orgName && !sentYm) return memo  // org名もsentYmもない場合はプレーンテキストのまま維持
-  return JSON.stringify({
-    [ORG_NOTES_KEY]: orgName || '',
-    memo: memo || '',
-    ...(sentYm ? { [SENT_YM_KEY]: sentYm } : {}),
-  })
-}
-
-/** RPC/DBから返された生のauthorデータを Author 型に変換（notesデコード込み） */
-function decodeAuthor(raw: Record<string, unknown>): Author {
-  const { orgName, memo, sentYm } = parseAuthorNotes(raw.notes as string | null)
-  return {
-    id: raw.id as string,
-    name: raw.name as string,
-    email: raw.email as string | null ?? null,
-    // license_organization_name は notes から復元（カラムがキャッシュにあればそちらも使う）
-    license_organization_name: orgName ?? (raw.license_organization_name as string | null) ?? null,
-    notes: memo,
-    last_email_sent_ym: sentYm,
-    created_at: raw.created_at as string,
-    updated_at: raw.updated_at as string,
-  }
-}
-const AUTHOR_PERFORMANCE_REPORT_SELECT_FIELDS =
-  'author_email, author_name, scenario_master_id, scenario_title, organization_id, organization_name, report_id, performance_date, performance_count, participant_count, venue_name, report_status, reported_at, license_amount, calculated_license_fee' as const
-const AUTHOR_SUMMARY_SELECT_FIELDS =
-  'author_email, total_scenarios, total_approved_reports, total_performance_count, total_license_fee, organizations_count' as const
-
 export const authorApi = {
   // ================================================
-  // 作者テーブル操作（RPC関数経由でRLSをバイパス）
+  // 作者テーブル操作
   // ================================================
-  
+
   // 全作者を取得
   async getAll(): Promise<Author[]> {
-    const { data, error } = await supabase.rpc('get_all_authors')
-
-    if (error) {
-      logger.warn('get_all_authors error:', error)
+    try {
+      return await apiClient.get<Author[]>('/api/authors?type=list')
+    } catch (error) {
+      logger.warn('authors:list error:', error)
       return []
     }
-
-    // RPC関数はJSONB配列を返す。notesをデコードして license_organization_name を復元
-    if (Array.isArray(data)) {
-      return (data as Record<string, unknown>[]).map(decodeAuthor)
-    }
-    return []
   },
 
   // 作者を名前で取得
   async getByName(name: string): Promise<Author | null> {
-    const getAuthorParams: RpcGetAuthorByNameParams = { p_name: name }
-    const { data, error } = await supabase.rpc('get_author_by_name', getAuthorParams)
-
-    if (error) {
-      logger.warn('get_author_by_name error:', error)
+    try {
+      return await apiClient.get<Author | null>(
+        `/api/authors?type=by-name&name=${encodeURIComponent(name)}`
+      )
+    } catch (error) {
+      logger.warn('authors:by-name error:', error)
       return null
     }
-
-    // RPC関数は { found: boolean, ...author } を返す
-    if (data && data.found) {
-      return decodeAuthor(data as Record<string, unknown>)
-    }
-    return null
   },
 
   // 作者を作成
   async create(author: Omit<Author, 'id' | 'created_at' | 'updated_at'>): Promise<Author> {
     return this.upsertByName(author.name, {
       email: author.email,
-      notes: author.notes
+      notes: author.notes,
     })
   },
 
   // 作者を更新
-  async update(id: string, updates: Partial<Omit<Author, 'id' | 'created_at' | 'updated_at'>>): Promise<Author> {
-    // idから名前を取得して更新（RPC関数はname指定）
-    const { data, error } = await supabase
-      .from('authors')
-      .select('name')
-      .eq('id', id)
-      .single()
-    
-    if (error || !data) {
-      throw new Error('Author not found')
-    }
-    
-    return this.upsertByName(data.name, updates)
+  async update(
+    id: string,
+    updates: Partial<Omit<Author, 'id' | 'created_at' | 'updated_at'>>
+  ): Promise<Author> {
+    return await apiClient.patch<Author>(`/api/authors?type=update`, {
+      id,
+      email: updates.email ?? null,
+      notes: updates.notes ?? null,
+      license_organization_name: updates.license_organization_name ?? null,
+    })
   },
 
-  // 名前で更新または作成（upsert）- RPC関数を使用
-  async upsertByName(name: string, updates: Partial<Omit<Author, 'id' | 'name' | 'created_at' | 'updated_at'>>): Promise<Author> {
-    const upsertAuthorParams: RpcUpsertAuthorParams = {
-      p_name: name,
-      p_email: updates.email ?? null,
-      p_notes: updates.notes ?? null,
-      p_license_organization_name: updates.license_organization_name ?? null
-    }
-    const { data, error } = await supabase.rpc('upsert_author', upsertAuthorParams)
-    
-    if (error) {
-      logger.error('upsert_author error:', error)
-      throw error
-    }
-    
-    if (!data?.success) {
-      throw new Error(data?.error || 'Failed to upsert author')
-    }
-    
-    // 更新後のデータを取得して返す
-    const author = await this.getByName(name)
-    if (!author) {
-      throw new Error('Failed to retrieve updated author')
-    }
-    return author
+  // 名前で更新または作成（upsert）
+  async upsertByName(
+    name: string,
+    updates: Partial<Omit<Author, 'id' | 'name' | 'created_at' | 'updated_at'>>
+  ): Promise<Author> {
+    return await apiClient.post<Author>('/api/authors?type=upsert', {
+      name,
+      email: updates.email ?? null,
+      notes: updates.notes ?? null,
+      license_organization_name: updates.license_organization_name ?? null,
+    })
   },
 
   // 作者のライセンス組織名（会社名）を設定する専用メソッド
-  // license_organization_name カラムの代わりに notes フィールドにエンコードして保存
-  async setOrganizationName(authorName: string, organizationName: string, memo?: string | null): Promise<void> {
-    // memo が undefined の場合は既存のメモを保持
-    let currentMemo = memo
-    let currentSentYm: string | null = null
-    if (memo === undefined) {
-      const current = await this.getByName(authorName)
-      currentMemo = current?.notes ?? null
-      currentSentYm = current?.last_email_sent_ym ?? null
+  async setOrganizationName(
+    authorName: string,
+    organizationName: string,
+    memo?: string | null
+  ): Promise<void> {
+    // memo が undefined の場合はサーバ側で既存メモを保持する
+    const body: Record<string, unknown> = {
+      authorName,
+      organizationName,
     }
-
-    const encodedNotes = encodeAuthorNotes(organizationName, currentMemo ?? null, currentSentYm)
-
-    const { error } = await supabase
-      .from('authors')
-      .update({ notes: encodedNotes })
-      .eq('name', authorName)
-
-    if (error) {
-      logger.error('authors update (setOrganizationName) error:', error)
-      throw error
-    }
+    if (memo !== undefined) body.memo = memo
+    await apiClient.patch('/api/authors?type=set-org-name', body)
   },
 
-  // メール送信済みを記録する（notesのJSONに __sent_ym__ として保存）
+  // メール送信済みを記録する
   async markEmailSent(authorName: string, year: number, month: number): Promise<void> {
-    const sentYm = `${year}-${String(month).padStart(2, '0')}`
-    const current = await this.getByName(authorName)
-    const encodedNotes = encodeAuthorNotes(
-      current?.license_organization_name ?? null,
-      current?.notes ?? null,
-      sentYm
-    )
-
-    const { error } = await supabase
-      .from('authors')
-      .update({ notes: encodedNotes })
-      .eq('name', authorName)
-
-    if (error) {
-      logger.error('authors update (markEmailSent) error:', error)
-      throw error
-    }
+    await apiClient.patch('/api/authors?type=mark-email-sent', {
+      authorName,
+      year,
+      month,
+    })
   },
 
   // 作者を削除
   async delete(id: string): Promise<void> {
-    const { error } = await supabase
-      .from('authors')
-      .delete()
-      .eq('id', id)
-    
-    if (error) throw error
+    await apiClient.delete(`/api/authors?id=${encodeURIComponent(id)}`)
   },
 
   // ================================================
@@ -222,115 +111,75 @@ export const authorApi = {
 
   // ログイン中のユーザーのメールアドレスを取得
   async getCurrentUserEmail(): Promise<string | null> {
-    const { data: { user } } = await supabase.auth.getUser()
-    return user?.email ?? null
+    try {
+      const result = await apiClient.get<{ email: string | null }>(
+        '/api/authors?type=current-email'
+      )
+      return result?.email ?? null
+    } catch (error) {
+      logger.warn('authors:current-email error:', error)
+      return null
+    }
   },
 
   // 作者のシナリオ一覧を取得（メールアドレスベース）
-  async getAuthorScenariosByEmail(email: string): Promise<{ id: string; title: string; author: string; author_email: string | null; play_count: number }[]> {
-    // scenario_masters から作者のシナリオを取得
-    const { data: masters, error: mastersError } = await supabase
-      .from('scenario_masters')
-      .select('id, title, author, author_email')
-      .eq('author_email', email)
-      .order('title')
-    
-    if (mastersError) {
-      if (mastersError.code === 'PGRST204' || mastersError.message?.includes('author_email')) {
-        logger.warn('author_email カラムが存在しません')
-        return []
-      }
-      throw mastersError
+  async getAuthorScenariosByEmail(
+    email: string
+  ): Promise<
+    { id: string; title: string; author: string; author_email: string | null; play_count: number }[]
+  > {
+    try {
+      return await apiClient.get(
+        `/api/authors?type=scenarios-by-email&email=${encodeURIComponent(email)}`
+      )
+    } catch (error) {
+      logger.warn('authors:scenarios-by-email error:', error)
+      return []
     }
-    
-    if (!masters || masters.length === 0) return []
-    
-    // organization_scenarios から play_count を集計
-    const masterIds = masters.map(m => m.id)
-    const { data: orgScenarios } = await supabase
-      .from('organization_scenarios')
-      .select('scenario_master_id, play_count')
-      .in('scenario_master_id', masterIds)
-    
-    const playCountMap = new Map<string, number>()
-    orgScenarios?.forEach(os => {
-      const current = playCountMap.get(os.scenario_master_id) || 0
-      playCountMap.set(os.scenario_master_id, current + (os.play_count || 0))
-    })
-    
-    return masters.map(m => ({
-      id: m.id,
-      title: m.title,
-      author: m.author || '',
-      author_email: m.author_email,
-      play_count: playCountMap.get(m.id) || 0
-    }))
   },
 
   // 作者への公演報告一覧を取得（メールアドレスベース）
-  async getReportsByEmail(email: string, options?: {
-    status?: 'pending' | 'approved' | 'rejected'
-    startDate?: string
-    endDate?: string
-  }): Promise<AuthorPerformanceReport[]> {
-    // author_performance_reports ビューを使用
-    let query = supabase
-      .from('author_performance_reports')
-      .select(AUTHOR_PERFORMANCE_REPORT_SELECT_FIELDS)
-      .eq('author_email', email)
-      .order('reported_at', { ascending: false })
-    
-    if (options?.status) {
-      query = query.eq('report_status', options.status)
+  async getReportsByEmail(
+    email: string,
+    options?: {
+      status?: 'pending' | 'approved' | 'rejected'
+      startDate?: string
+      endDate?: string
     }
-    if (options?.startDate) {
-      query = query.gte('performance_date', options.startDate)
-    }
-    if (options?.endDate) {
-      query = query.lte('performance_date', options.endDate)
-    }
+  ): Promise<AuthorPerformanceReport[]> {
+    const params = new URLSearchParams()
+    params.set('type', 'reports-by-email')
+    params.set('email', email)
+    if (options?.status) params.set('status', options.status)
+    if (options?.startDate) params.set('startDate', options.startDate)
+    if (options?.endDate) params.set('endDate', options.endDate)
 
-    const { data, error } = await query
-    
-    if (error) {
-      // ビューが存在しない場合は空配列を返す
-      if (error.code === 'PGRST204' || error.code === '42P01') return []
-      throw error
+    try {
+      return await apiClient.get<AuthorPerformanceReport[]>(
+        `/api/authors?${params.toString()}`
+      )
+    } catch (error) {
+      logger.warn('authors:reports-by-email error:', error)
+      return []
     }
-    return data || []
   },
 
   // 作者のサマリー情報を取得（メールアドレスベース）
   async getSummaryByEmail(email: string): Promise<AuthorSummary> {
-    // author_summary ビューを使用
-    const { data, error } = await supabase
-      .from('author_summary')
-      .select(AUTHOR_SUMMARY_SELECT_FIELDS)
-      .eq('author_email', email)
-      .single()
-    
-    if (error) {
-      // ビューが存在しない、またはデータがない場合はデフォルト値を返す
-      if (error.code === 'PGRST116' || error.code === '42P01') {
-        return {
-          author_email: email,
-          total_scenarios: 0,
-          total_approved_reports: 0,
-          total_performance_count: 0,
-          total_license_fee: 0,
-          organizations_count: 0
-        }
+    try {
+      return await apiClient.get<AuthorSummary>(
+        `/api/authors?type=summary-by-email&email=${encodeURIComponent(email)}`
+      )
+    } catch (error) {
+      logger.warn('authors:summary-by-email error:', error)
+      return {
+        author_email: email,
+        total_scenarios: 0,
+        total_approved_reports: 0,
+        total_performance_count: 0,
+        total_license_fee: 0,
+        organizations_count: 0,
       }
-      throw error
-    }
-    
-    return {
-      author_email: data.author_email,
-      total_scenarios: data.total_scenarios || 0,
-      total_approved_reports: data.total_approved_reports || 0,
-      total_performance_count: data.total_performance_count || 0,
-      total_license_fee: data.total_license_fee || 0,
-      organizations_count: data.organizations_count || 0
     }
   },
 
@@ -339,47 +188,19 @@ export const authorApi = {
     email: string
     summary: AuthorSummary
     reports: AuthorPerformanceReport[]
-    scenarios: { id: string; title: string; author: string; author_email: string | null; play_count: number }[]
+    scenarios: {
+      id: string
+      title: string
+      author: string
+      author_email: string | null
+      play_count: number
+    }[]
   } | null> {
-    const email = await this.getCurrentUserEmail()
-    if (!email) return null
-
-    // 各API呼び出しを個別にエラーハンドリング（ビューが未作成でも動作）
-    let summary: AuthorSummary = {
-      author_email: email,
-      total_scenarios: 0,
-      total_approved_reports: 0,
-      total_performance_count: 0,
-      total_license_fee: 0,
-      organizations_count: 0
-    }
-    let reports: AuthorPerformanceReport[] = []
-    let scenarios: { id: string; title: string; author: string; author_email: string | null; play_count: number }[] = []
-
-    // シナリオ一覧は scenarios テーブルから直接取得（確実に動作）
     try {
-      scenarios = await this.getAuthorScenariosByEmail(email)
-      // summary の total_scenarios を更新
-      summary.total_scenarios = scenarios.length
-    } catch (e) {
-      logger.warn('シナリオ取得エラー:', e)
+      return await apiClient.get('/api/authors?type=dashboard')
+    } catch (error) {
+      logger.warn('authors:dashboard error:', error)
+      return null
     }
-
-    // 報告一覧（ビューが必要）
-    try {
-      reports = await this.getReportsByEmail(email)
-    } catch (e) {
-      logger.warn('報告取得エラー (ビュー未作成の可能性):', e)
-    }
-
-    // サマリー（ビューが必要）
-    try {
-      const summaryData = await this.getSummaryByEmail(email)
-      summary = summaryData
-    } catch (e) {
-      logger.warn('サマリー取得エラー (ビュー未作成の可能性):', e)
-    }
-
-    return { email, summary, reports, scenarios }
-  }
+  },
 }

--- a/src/lib/api/scenarioAliasApi.ts
+++ b/src/lib/api/scenarioAliasApi.ts
@@ -1,10 +1,13 @@
-import { supabase } from '@/lib/supabase'
+import { apiClient } from '@/lib/apiClient'
 import { logger } from '@/utils/logger'
 
 /**
  * シナリオエイリアスをDBから取得してキャッシュする。
  * 略称・表記ゆれ → 正式名称 のマッピングを scenario_import_aliases テーブルで管理。
  * ハードコードの SCENARIO_ALIAS 定数は廃止し、このモジュールに集約する。
+ *
+ * バックエンド API (/api/scenario-aliases) 経由で取得する。
+ * READ は staff 以上、WRITE は admin のみがサーバ側で許可される。
  */
 
 let cachedAliases: Record<string, string> | null = null
@@ -17,21 +20,14 @@ export async function getScenarioAliases(): Promise<Record<string, string>> {
   if (fetchPromise) return fetchPromise
 
   fetchPromise = (async () => {
-    const { data, error } = await supabase
-      .from('scenario_import_aliases')
-      .select('alias, canonical_name')
-
-    if (error) {
+    try {
+      const map = await apiClient.get<Record<string, string>>('/api/scenario-aliases?type=map')
+      cachedAliases = map ?? {}
+      return cachedAliases
+    } catch (error) {
       logger.warn('scenario_import_aliases の取得に失敗しました。空マップを使用します。', error)
       return {}
     }
-
-    const map: Record<string, string> = {}
-    for (const row of data ?? []) {
-      map[row.alias] = row.canonical_name
-    }
-    cachedAliases = map
-    return map
   })().finally(() => {
     fetchPromise = null
   })
@@ -42,4 +38,65 @@ export async function getScenarioAliases(): Promise<Record<string, string>> {
 /** キャッシュを強制リフレッシュ（テスト・管理画面からの更新後に呼ぶ） */
 export function clearScenarioAliasCache(): void {
   cachedAliases = null
+}
+
+// ─── 管理者向け CRUD（admin のみ。現状フロントから直接呼ぶ画面はないが、将来のために用意）
+
+export interface ScenarioAlias {
+  id: string
+  alias: string
+  canonical_name: string
+  created_at: string
+}
+
+export const scenarioAliasApi = {
+  async list(): Promise<ScenarioAlias[]> {
+    try {
+      return await apiClient.get<ScenarioAlias[]>('/api/scenario-aliases?type=list')
+    } catch (error) {
+      logger.error('Failed to list scenario aliases:', error)
+      throw error
+    }
+  },
+
+  async create(alias: string, canonicalName: string): Promise<ScenarioAlias> {
+    try {
+      const created = await apiClient.post<ScenarioAlias>('/api/scenario-aliases', {
+        alias,
+        canonical_name: canonicalName,
+      })
+      clearScenarioAliasCache()
+      return created
+    } catch (error) {
+      logger.error('Failed to create scenario alias:', error)
+      throw error
+    }
+  },
+
+  async update(
+    id: string,
+    updates: { alias?: string; canonical_name?: string }
+  ): Promise<ScenarioAlias> {
+    try {
+      const updated = await apiClient.patch<ScenarioAlias>(
+        `/api/scenario-aliases?id=${encodeURIComponent(id)}`,
+        updates
+      )
+      clearScenarioAliasCache()
+      return updated
+    } catch (error) {
+      logger.error('Failed to update scenario alias:', error)
+      throw error
+    }
+  },
+
+  async delete(id: string): Promise<void> {
+    try {
+      await apiClient.delete(`/api/scenario-aliases?id=${encodeURIComponent(id)}`)
+      clearScenarioAliasCache()
+    } catch (error) {
+      logger.error('Failed to delete scenario alias:', error)
+      throw error
+    }
+  },
 }

--- a/src/lib/api/scenarioMasterApi.ts
+++ b/src/lib/api/scenarioMasterApi.ts
@@ -1,18 +1,14 @@
 /**
  * シナリオマスタ関連API
  * scenario_masters + organization_scenarios の2層構造に対応
+ *
+ * scenario_masters への read/write はすべてバックエンド API (/api/scenario-masters) 経由。
+ * organization_scenarios は従来通り /api/org-scenarios + supabase 併用。
  */
 import { supabase } from '../supabase'
 import { getCurrentOrganizationId } from '@/lib/organization'
 import { apiClient } from '@/lib/apiClient'
 import { logger } from '@/utils/logger'
-
-// NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
-const SCENARIO_MASTER_SELECT_FIELDS =
-  'id, title, author, author_id, key_visual_url, description, player_count_min, player_count_max, official_duration, genre, difficulty, synopsis, caution, required_items, master_status, submitted_by_organization_id, approved_by, approved_at, rejection_reason, created_at, updated_at, created_by' as const
-
-const ORG_SCENARIO_WITH_MASTER_SELECT_FIELDS =
-  'id, organization_id, scenario_master_id, slug, org_status, pricing_patterns, gm_assignments, created_at, updated_at, title, author, author_id, key_visual_url, description, synopsis, caution, player_count_min, player_count_max, duration, genre, difficulty, participation_fee, extra_preparation_time, master_status' as const
 
 // ============================================================
 // 型定義
@@ -101,125 +97,118 @@ export interface OrganizationScenarioWithMaster {
 export const scenarioMasterApi = {
   /**
    * 全シナリオマスタを取得（検索用）
-   * - approved: 全員が見れる
-   * - pending/rejected: 全員が見れる（利用可能）
-   * - draft: 自組織のみ
+   * サーバ側で権限フィルタ:
+   *   - license_admin: 全件
+   *   - その他: approved 全件 + 自組織提出の draft/pending/rejected
    */
   async getAll(): Promise<ScenarioMaster[]> {
-    const { data, error } = await supabase
-      .from('scenario_masters')
-      .select(SCENARIO_MASTER_SELECT_FIELDS)
-      .order('title', { ascending: true })
-    
-    if (error) {
+    try {
+      return await apiClient.get<ScenarioMaster[]>('/api/scenario-masters?type=list')
+    } catch (error) {
       logger.error('Failed to get scenario masters:', error)
       throw error
     }
-    return data || []
   },
 
   /**
    * 承認済みシナリオマスタのみ取得（MMQトップ用）
    */
   async getApproved(): Promise<ScenarioMaster[]> {
-    const { data, error } = await supabase
-      .from('scenario_masters')
-      .select(SCENARIO_MASTER_SELECT_FIELDS)
-      .eq('master_status', 'approved')
-      .order('title', { ascending: true })
-    
-    if (error) {
+    try {
+      return await apiClient.get<ScenarioMaster[]>('/api/scenario-masters?type=approved')
+    } catch (error) {
       logger.error('Failed to get approved scenario masters:', error)
       throw error
     }
-    return data || []
   },
 
   /**
    * IDでシナリオマスタを取得
+   * 自分が見るべきでないレコードはサーバ側で null として返される
    */
   async getById(id: string): Promise<ScenarioMaster | null> {
-    const { data, error } = await supabase
-      .from('scenario_masters')
-      .select(SCENARIO_MASTER_SELECT_FIELDS)
-      .eq('id', id)
-      .single()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null
+    try {
+      return await apiClient.get<ScenarioMaster | null>(
+        `/api/scenario-masters?type=by-id&id=${encodeURIComponent(id)}`
+      )
+    } catch (error) {
       logger.error('Failed to get scenario master by id:', error)
       throw error
     }
-    return data
   },
 
   /**
    * 新規シナリオマスタを作成（draft状態で作成）
+   * submitted_by_organization_id はサーバ側で JWT から強制される
    */
   async create(data: Partial<ScenarioMaster>): Promise<ScenarioMaster> {
-    const orgId = await getCurrentOrganizationId()
-    
-    const { data: created, error } = await supabase
-      .from('scenario_masters')
-      .insert({
-        ...data,
-        master_status: 'draft',
-        submitted_by_organization_id: orgId,
-      })
-      .select()
-      .single()
-    
-    if (error) {
+    try {
+      return await apiClient.post<ScenarioMaster>('/api/scenario-masters', data)
+    } catch (error) {
       logger.error('Failed to create scenario master:', error)
       throw error
     }
-    return created
   },
 
   /**
-   * シナリオマスタを更新
+   * シナリオマスタを更新（提出元組織のスタッフ または license_admin のみ）
    */
   async update(id: string, data: Partial<ScenarioMaster>): Promise<ScenarioMaster> {
-    const { data: updated, error } = await supabase
-      .from('scenario_masters')
-      .update(data)
-      .eq('id', id)
-      .select()
-      .single()
-    
-    if (error) {
+    try {
+      return await apiClient.patch<ScenarioMaster>(
+        `/api/scenario-masters?type=update&id=${encodeURIComponent(id)}`,
+        data
+      )
+    } catch (error) {
       logger.error('Failed to update scenario master:', error)
       throw error
     }
-    return updated
   },
 
   /**
    * ステータスを変更（draft → pending）
    */
   async publish(id: string): Promise<ScenarioMaster> {
-    return this.update(id, { master_status: 'pending' })
+    try {
+      return await apiClient.patch<ScenarioMaster>(
+        `/api/scenario-masters?type=publish&id=${encodeURIComponent(id)}`,
+        {}
+      )
+    } catch (error) {
+      logger.error('Failed to publish scenario master:', error)
+      throw error
+    }
   },
 
   /**
-   * 承認（pending → approved）※MMQ運営者のみ
+   * 承認（pending → approved）※license_admin のみ
+   * approvedBy はサーバ側で JWT の userId から自動設定される
    */
-  async approve(id: string, approvedBy: string): Promise<ScenarioMaster> {
-    return this.update(id, {
-      master_status: 'approved',
-      approved_by: approvedBy,
-      approved_at: new Date().toISOString(),
-    })
+  async approve(id: string, _approvedBy?: string): Promise<ScenarioMaster> {
+    try {
+      return await apiClient.patch<ScenarioMaster>(
+        `/api/scenario-masters?type=approve&id=${encodeURIComponent(id)}`,
+        {}
+      )
+    } catch (error) {
+      logger.error('Failed to approve scenario master:', error)
+      throw error
+    }
   },
 
   /**
-   * 却下（pending → rejected）※MMQ運営者のみ
+   * 却下（pending → rejected）※license_admin のみ
    */
   async reject(id: string, reason: string): Promise<ScenarioMaster> {
-    return this.update(id, {
-      master_status: 'rejected',
-      rejection_reason: reason,
-    })
+    try {
+      return await apiClient.patch<ScenarioMaster>(
+        `/api/scenario-masters?type=reject&id=${encodeURIComponent(id)}`,
+        { reason }
+      )
+    } catch (error) {
+      logger.error('Failed to reject scenario master:', error)
+      throw error
+    }
   },
 }
 


### PR DESCRIPTION
## Summary

src/lib/api/{authorApi,scenarioMasterApi,scenarioAliasApi}.ts の全 read/write を、新規 Vercel Functions 経由に移行する。service_role による RLS バイパス前提で、マルチテナント境界をサーバ側コードで明示的に強制する。

- 新規バックエンド: \`api/authors.ts\` / \`api/scenario-masters.ts\` / \`api/scenario-aliases.ts\`
- フロント: 該当 3 ファイルを \`apiClient.{get|post|patch|delete}\` 呼び出しに置き換え
- 既存パターン (api/staff.ts, api/coupons.ts, _lib/auth.ts) に準拠

## 追加されたエンドポイント

### /api/authors
| method | type | 説明 |
| --- | --- | --- |
| GET | list | 全作者 (get_all_authors RPC) |
| GET | by-name | 名前で取得 (get_author_by_name RPC) |
| GET | current-email | ログイン中ユーザーのメールアドレス |
| GET | scenarios-by-email | 作者のシナリオ一覧 |
| GET | reports-by-email | 作者への報告一覧 (status/startDate/endDate フィルタ可) |
| GET | summary-by-email | 作者サマリー |
| GET | dashboard | 上記をまとめた作者ダッシュボード |
| POST | upsert | upsert_author RPC ラッパ |
| PATCH | update | id 指定の更新 |
| PATCH | set-org-name | license_organization_name を notes JSON にエンコードして保存 |
| PATCH | mark-email-sent | last_email_sent_ym を更新 |
| DELETE | (id クエリ) | 削除 |

### /api/scenario-masters
| method | type | 説明 |
| --- | --- | --- |
| GET | list | 権限フィルタ付き一覧 (license_admin は全件、それ以外は approved + 自組織提出分) |
| GET | approved | 承認済みのみ |
| GET | by-id | 単一取得（権限外は null） |
| POST | (なし) | 作成 (draft 状態、submitted_by_organization_id は JWT 強制) |
| PATCH | update | 提出元 staff または license_admin |
| PATCH | publish | draft → pending |
| PATCH | approve | pending → approved (license_admin のみ) |
| PATCH | reject | pending → rejected (license_admin のみ) |

### /api/scenario-aliases
| method | type | 説明 |
| --- | --- | --- |
| GET | map | { alias: canonical_name } マップ (フロントのキャッシュ前提) |
| GET | list | レコード一覧 |
| POST | (なし) | 追加 (admin) |
| PATCH | (id クエリ) | 更新 (admin) |
| DELETE | (id クエリ) | 削除 (admin) |

## マルチテナント方針

- \`authors\`: organization_id を持たない全組織共有マスタ。READ/WRITE ともに \`requireStaff\` で絞る（顧客は触れない設計）。
- \`scenario_masters\`: 横断マスタ + \`submitted_by_organization_id\` で提出元を保持。
  - READ: approved は全認証ユーザー / draft・pending・rejected は提出元組織 staff か license_admin。\`canReadMaster\` で判定。
  - CREATE: staff 以上。\`submitted_by_organization_id\` と \`created_by\` は JWT 由来で強制設定（クライアントから受け取らない）。
  - UPDATE: 提出元組織 staff か license_admin。\`canWriteMaster\` で判定。
  - approve/reject: license_admin のみ。
  - 更新可能フィールドは \`ALLOWED_UPDATE_FIELDS\` でホワイトリスト化し、\`master_status\` / \`submitted_by_organization_id\` 等の重要カラムを直接書き換えできないようにする。
- \`scenario_import_aliases\`: organization_id を持たない全組織共有マスタ。READ は \`requireStaff\`（現状の利用箇所は管理画面のみ）、WRITE は admin のみ（既存 RLS の \`is_org_admin\` に合わせる）。

## Test plan

- [ ] Vercel preview 環境で /api/authors?type=list, /api/scenario-masters?type=list, /api/scenario-aliases?type=map がそれぞれ 200 を返すこと
- [ ] スタッフでログイン → 作者ポータル / 作者報告 / ライセンス管理画面で作者一覧・名前検索・upsert・set-org-name・mark-email-sent が動くこと
- [ ] スタッフで ScenarioEditDialogV2 を開き、scenario_masters の getById / update が動くこと
- [ ] license_admin で approve / reject ができ、staff では 403 になること
- [ ] 別組織の staff が他組織提出の draft master を直接 id 指定しても null が返ること
- [ ] スケジュールインポート画面でエイリアス map が反映されること（getScenarioAliases）

🤖 Generated with [Claude Code](https://claude.com/claude-code)