### PR TITLE
feat(api): couponApi の管理者向け read と write 系をバックエンド API に移行（マルチテナント境界強化）

### DIFF
--- a/api/coupons.ts
+++ b/api/coupons.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { db, getMissingEnvError } from './_lib/db.js'
-import { requireAuth, ApiError } from './_lib/auth.js'
+import { requireAuth, requireStaff, ApiError, type AuthUser } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,
@@ -12,7 +12,7 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
@@ -44,6 +44,25 @@ const CUSTOMER_COUPON_FIELDS = `
   )
 `
 
+const COUPON_CAMPAIGN_FIELDS =
+  'id, organization_id, name, description, discount_type, discount_amount, max_uses_per_customer, target_type, target_ids, trigger_type, valid_from, valid_until, coupon_expiry_days, is_active, created_at, updated_at'
+
+const CUSTOMER_COUPON_WITH_CUSTOMER_FIELDS = `
+  id,
+  campaign_id,
+  customer_id,
+  organization_id,
+  uses_remaining,
+  expires_at,
+  status,
+  created_at,
+  updated_at,
+  customers (
+    name,
+    email
+  )
+`
+
 // JWT user.id から customer 行を1件取得（重複行があっても order + limit(1) で安全）
 async function findCustomerByUserId(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -63,7 +82,6 @@ async function findCustomerByUserId(
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
 
   const envError = getMissingEnvError()
   if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
@@ -71,20 +89,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const user = await requireAuth(req)
 
-    const type = (req.query.type as string | undefined) ?? 'available'
-    const requestedOrgId = req.query.organization_id as string | undefined
+    if (req.method === 'GET') return handleGet(req, res, user)
+    if (req.method === 'POST') return handlePost(req, res, user)
+    if (req.method === 'PATCH') return handlePatch(req, res, user)
+    if (req.method === 'DELETE') return handleDelete(req, res, user)
 
-    if (type === 'available') {
-      return await handleAvailable(req, res, user.userId, requestedOrgId ?? user.orgId)
-    }
-    if (type === 'all') {
-      return await handleAll(req, res, user.userId, user.orgId)
-    }
-    if (type === 'usages') {
-      return await handleUsages(req, res, user.userId, user.orgId)
-    }
-
-    return res.status(400).json({ error: `unknown type: ${type}` })
+    return res.status(405).json({ error: 'Method not allowed' })
   } catch (err) {
     if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
     console.error('[coupons] unexpected error:', err)
@@ -92,7 +102,113 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 }
 
-// 利用可能クーポン: status='active' かつ uses_remaining > 0 かつ有効期限内
+// =========================================
+// GET handler
+// =========================================
+async function handleGet(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const type = (req.query.type as string | undefined) ?? 'available'
+  const requestedOrgId = req.query.organization_id as string | undefined
+
+  // 顧客向け read（requireAuth のみで OK）
+  if (type === 'available') {
+    return handleAvailable(req, res, user.userId, requestedOrgId ?? user.orgId)
+  }
+  if (type === 'all') {
+    return handleAll(req, res, user.userId, user.orgId)
+  }
+  if (type === 'usages') {
+    return handleUsages(req, res, user.userId, user.orgId)
+  }
+  if (type === 'current-reservations') {
+    return handleCurrentReservations(req, res, user)
+  }
+
+  // 管理者向け read（requireStaff）
+  if (type === 'campaigns') {
+    requireStaff(user)
+    return handleCampaigns(req, res, user)
+  }
+  if (type === 'campaign-stats') {
+    requireStaff(user)
+    return handleCampaignStats(req, res, user)
+  }
+  if (type === 'admin-usages') {
+    requireStaff(user)
+    return handleAdminUsages(req, res, user)
+  }
+  if (type === 'campaign-coupons') {
+    requireStaff(user)
+    return handleCampaignCoupons(req, res, user)
+  }
+  if (type === 'search-customers') {
+    requireStaff(user)
+    return handleSearchCustomers(req, res, user)
+  }
+
+  return res.status(400).json({ error: `unknown type: ${type}` })
+}
+
+// =========================================
+// POST handler
+// =========================================
+async function handlePost(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = req.query.action as string | undefined
+
+  // 顧客向け write（requireAuth のみで OK）
+  if (action === 'use') {
+    return handleUseCoupon(req, res, user)
+  }
+  if (action === 'grant-registration') {
+    return handleGrantRegistrationCoupon(req, res, user)
+  }
+
+  // 管理者向け write（requireStaff）
+  if (action === 'create-campaign') {
+    requireStaff(user)
+    return handleCreateCampaign(req, res, user)
+  }
+  if (action === 'grant-to-customer') {
+    requireStaff(user)
+    return handleGrantCouponToCustomer(req, res, user)
+  }
+
+  return res.status(400).json({ error: `unknown action: ${action}` })
+}
+
+// =========================================
+// PATCH handler（管理者向けのみ）
+// =========================================
+async function handlePatch(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+  const action = req.query.action as string | undefined
+
+  if (action === 'update-campaign') {
+    return handleUpdateCampaign(req, res, user)
+  }
+  if (action === 'toggle-campaign-active') {
+    return handleToggleCampaignActive(req, res, user)
+  }
+
+  return res.status(400).json({ error: `unknown action: ${action}` })
+}
+
+// =========================================
+// DELETE handler（管理者向けのみ）
+// =========================================
+async function handleDelete(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+  const action = req.query.action as string | undefined
+
+  if (action === 'restore-usage') {
+    return handleRestoreCouponUsage(req, res, user)
+  }
+
+  return res.status(400).json({ error: `unknown action: ${action}` })
+}
+
+// =========================================
+// 顧客向け: 利用可能クーポン
+// =========================================
 async function handleAvailable(
   _req: VercelRequest,
   res: VercelResponse,
@@ -118,7 +234,6 @@ async function handleAvailable(
     return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
   }
 
-  // 有効期限フィルタはサーバ側でも行う（フロントの now と齟齬が出ないように）
   const now = new Date()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const filtered = ((data as any[]) ?? []).filter((coupon: any) => {
@@ -135,7 +250,9 @@ async function handleAvailable(
   return res.status(200).json(filtered)
 }
 
-// マイページ用クーポン一覧（全ステータス・使用履歴付き・店舗名付き）
+// =========================================
+// 顧客向け: マイページ用クーポン一覧
+// =========================================
 async function handleAll(
   _req: VercelRequest,
   res: VercelResponse,
@@ -164,7 +281,6 @@ async function handleAll(
   const couponIds = rows.map((c: any) => c.id)
   if (couponIds.length === 0) return res.status(200).json(rows)
 
-  // 使用履歴 + 紐づく予約
   const { data: usageRows, error: usageError } = await database
     .from('coupon_usages')
     .select(`
@@ -252,7 +368,9 @@ async function handleAll(
   return res.status(200).json(result)
 }
 
-// クーポン使用履歴
+// =========================================
+// 顧客向け: クーポン使用履歴
+// =========================================
 async function handleUsages(
   _req: VercelRequest,
   res: VercelResponse,
@@ -296,7 +414,6 @@ async function handleUsages(
 
   if (error) {
     console.error('[coupons:usages] DB error:', error)
-    // JOIN 失敗のフォールバック（既存実装と同じ挙動）
     const { data: usages, error: usageError } = await database
       .from('coupon_usages')
       .select('id, customer_coupon_id, reservation_id, discount_amount, used_at')
@@ -310,4 +427,929 @@ async function handleUsages(
   }
 
   return res.status(200).json(data ?? [])
+}
+
+// =========================================
+// 顧客向け: 現在進行中の予約（クーポン使用時の紐付け候補）
+// =========================================
+async function handleCurrentReservations(
+  _req: VercelRequest,
+  res: VercelResponse,
+  user: AuthUser
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  const customer = await findCustomerByUserId(database, user.userId, user.orgId, 'id, name, organization_id') as
+    | { id: string; name: string | null; organization_id: string | null }
+    | null
+
+  // スタッフ情報（スタッフ予約のマッチング用）— 組織スコープも検証
+  const { data: staffRows } = await database
+    .from('staff')
+    .select('id, name, organization_id')
+    .eq('user_id', user.userId)
+    .eq('organization_id', user.orgId)
+    .limit(1)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const staffRecord = ((staffRows as any[]) ?? [])[0] ?? null
+
+  if (!customer && !staffRecord) return res.status(200).json([])
+
+  // JSTで今日の日付
+  const now = new Date()
+  const jstOffset = 9 * 60
+  const jstNow = new Date(now.getTime() + (jstOffset + now.getTimezoneOffset()) * 60 * 1000)
+  const todayStr = `${jstNow.getFullYear()}-${String(jstNow.getMonth() + 1).padStart(2, '0')}-${String(jstNow.getDate()).padStart(2, '0')}`
+
+  // 1. 通常予約（自分が customer_id の予約 / 組織スコープも検証）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let directReservations: any[] = []
+  if (customer) {
+    const { data, error } = await database
+      .from('reservations')
+      .select('id, schedule_event_id, organization_id')
+      .eq('customer_id', customer.id)
+      .eq('organization_id', user.orgId)
+      .eq('status', 'confirmed')
+    if (error) console.error('[coupons:current-reservations] direct error:', error)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    directReservations = (data as any[]) ?? []
+  }
+
+  // 2. 貸切公演の参加メンバーとしての予約
+  // SECURITY DEFINER RPC は auth.uid() に依存するためサーバ側からは使えない。
+  // 同等のクエリをサーバで明示的に組み、結果を必ず本人の user_id + 自組織で再検証する。
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const privateGroupReservations: Array<{ reservation_id: string; schedule_event_id: string | null; reservation_status: string; group_status: string }> = []
+  {
+    const { data: members } = await database
+      .from('private_group_members')
+      .select('group_id')
+      .eq('user_id', user.userId)
+      .eq('status', 'joined')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const groupIds = ((members as any[]) ?? []).map((m: any) => m.group_id).filter(Boolean)
+    if (groupIds.length > 0) {
+      const { data: groups } = await database
+        .from('private_groups')
+        .select('id, reservation_id, status, organization_id')
+        .in('id', groupIds)
+        .not('reservation_id', 'is', null)
+        .eq('organization_id', user.orgId)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reservationIds = ((groups as any[]) ?? [])
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .map((g: any) => g.reservation_id)
+        .filter(Boolean)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const groupStatusByRes = new Map<string, string>(((groups as any[]) ?? []).map((g: any) => [g.reservation_id, g.status]))
+
+      if (reservationIds.length > 0) {
+        const { data: reservationRows } = await database
+          .from('reservations')
+          .select('id, schedule_event_id, status, organization_id')
+          .in('id', reservationIds)
+          .eq('organization_id', user.orgId)
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        for (const r of ((reservationRows as any[]) ?? [])) {
+          privateGroupReservations.push({
+            reservation_id: r.id,
+            schedule_event_id: r.schedule_event_id ?? null,
+            reservation_status: r.status,
+            group_status: groupStatusByRes.get(r.id) ?? '',
+          })
+        }
+      }
+    }
+  }
+
+  // 3. スタッフ予約（payment_method='staff' or reservation_source='staff_entry'/'staff_participation'）— 組織スコープ
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let staffReservations: any[] = []
+  {
+    const { data, error } = await database
+      .from('reservations')
+      .select('id, participant_names, schedule_event_id, organization_id')
+      .or('payment_method.eq.staff,reservation_source.eq.staff_entry,reservation_source.eq.staff_participation')
+      .eq('status', 'confirmed')
+      .eq('organization_id', user.orgId)
+    if (error) console.error('[coupons:current-reservations] staff error:', error)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    staffReservations = (data as any[]) ?? []
+  }
+
+  // schedule_event_id を収集して、一括取得（組織スコープ）
+  const eventIds = new Set<string>()
+  directReservations.forEach((r) => { if (r.schedule_event_id) eventIds.add(r.schedule_event_id) })
+  privateGroupReservations.forEach((r) => { if (r.schedule_event_id) eventIds.add(r.schedule_event_id) })
+  staffReservations.forEach((r) => { if (r.schedule_event_id) eventIds.add(r.schedule_event_id) })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const eventsMap: Record<string, any> = {}
+  if (eventIds.size > 0) {
+    const { data: events } = await database
+      .from('schedule_events')
+      .select('id, date, start_time, end_time, scenario, venue, organization_id, stores (name)')
+      .in('id', Array.from(eventIds))
+      .eq('organization_id', user.orgId)
+    if (events) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for (const ev of events as any[]) {
+        eventsMap[ev.id] = ev
+      }
+    }
+  }
+
+  // 結果をマージ
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const allReservations: Array<{ id: string; event: any }> = []
+
+  for (const r of directReservations) {
+    const event = eventsMap[r.schedule_event_id]
+    if (event) allReservations.push({ id: r.id, event })
+  }
+
+  for (const r of privateGroupReservations) {
+    if (r.group_status !== 'confirmed') continue
+    if (r.reservation_status !== 'confirmed') continue
+    const event = r.schedule_event_id ? eventsMap[r.schedule_event_id] : undefined
+    if (event && !allReservations.some(existing => existing.id === r.reservation_id)) {
+      allReservations.push({ id: r.reservation_id, event })
+    }
+  }
+
+  const myNames: string[] = []
+  if (customer?.name) myNames.push(customer.name)
+  if (staffRecord?.name && !myNames.includes(staffRecord.name)) myNames.push(staffRecord.name)
+
+  if (myNames.length > 0) {
+    for (const r of staffReservations) {
+      const names = r.participant_names as string[] | null
+      if (names && names.some((n: string) => myNames.includes(n))) {
+        const event = eventsMap[r.schedule_event_id]
+        if (event && !allReservations.some(existing => existing.id === r.id)) {
+          allReservations.push({ id: r.id, event })
+        }
+      }
+    }
+  }
+
+  // 今日の公演で、開始3時間前〜終了1時間後の範囲のものをフィルタ
+  const currentHour = jstNow.getHours()
+  const currentMinute = jstNow.getMinutes()
+  const currentTotalMinutes = currentHour * 60 + currentMinute
+
+  const filtered = allReservations
+    .filter(({ event }) => {
+      if (!event) return false
+      if (event.date !== todayStr) return false
+
+      const [startHour, startMinute] = event.start_time.split(':').map(Number)
+      const startTotalMinutes = startHour * 60 + startMinute
+
+      if (currentTotalMinutes < startTotalMinutes - 180) return false
+
+      if (event.end_time) {
+        const [endHour, endMinute] = event.end_time.split(':').map(Number)
+        const endTotalMinutes = endHour * 60 + endMinute
+        return currentTotalMinutes <= endTotalMinutes + 60
+      }
+      return currentTotalMinutes <= startTotalMinutes + 180
+    })
+    .map(({ id, event }) => ({
+      id,
+      scenario_title: event.scenario || '不明なシナリオ',
+      store_name: event.stores?.name || event.venue || '不明な店舗',
+      date: event.date,
+      time: event.start_time.substring(0, 5),
+    }))
+
+  return res.status(200).json(filtered)
+}
+
+// =========================================
+// 管理者向け: キャンペーン一覧
+// =========================================
+async function handleCampaigns(_req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('coupon_campaigns')
+    .select(COUPON_CAMPAIGN_FIELDS)
+    .eq('organization_id', user.orgId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('[coupons:campaigns] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// =========================================
+// 管理者向け: キャンペーン統計
+// =========================================
+async function handleCampaignStats(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const campaignId = req.query.campaign_id as string | undefined
+  if (!campaignId) {
+    return res.status(400).json({ error: 'campaign_id クエリパラメータが必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // キャンペーンが自組織のものか検証
+  const { data: campaign, error: campaignError } = await database
+    .from('coupon_campaigns')
+    .select('id, organization_id')
+    .eq('id', campaignId)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (campaignError) {
+    console.error('[coupons:campaign-stats] campaign verify error:', campaignError)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: campaignError.message })
+  }
+  if (!campaign) {
+    return res.status(404).json({ error: 'キャンペーンが見つかりません' })
+  }
+
+  // 付与されたクーポンを取得
+  const { data: coupons, error: couponsError } = await database
+    .from('customer_coupons')
+    .select('id, uses_remaining')
+    .eq('campaign_id', campaignId)
+    .eq('organization_id', user.orgId)
+
+  if (couponsError) {
+    console.error('[coupons:campaign-stats] coupons error:', couponsError)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: couponsError.message })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (coupons as any[]) ?? []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const couponIds = rows.map((c: any) => c.id)
+
+  let totalUsed = 0
+  let totalDiscountAmount = 0
+
+  if (couponIds.length > 0) {
+    const { data: usages, error: usagesError } = await database
+      .from('coupon_usages')
+      .select('discount_amount')
+      .in('customer_coupon_id', couponIds)
+    if (!usagesError && usages) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      totalUsed = (usages as any[]).length
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      totalDiscountAmount = (usages as any[]).reduce((sum: number, u: any) => sum + (u.discount_amount ?? 0), 0)
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const totalGranted = rows.length
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const totalRemaining = rows.reduce((sum: number, c: any) => sum + (c.uses_remaining ?? 0), 0)
+
+  return res.status(200).json({
+    totalGranted,
+    totalUsed,
+    totalRemaining,
+    totalDiscountAmount,
+  })
+}
+
+// =========================================
+// 管理者向け: 顧客クーポンの使用履歴
+// =========================================
+async function handleAdminUsages(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const customerCouponId = req.query.customer_coupon_id as string | undefined
+  if (!customerCouponId) {
+    return res.status(400).json({ error: 'customer_coupon_id クエリパラメータが必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 顧客クーポンが自組織のものか検証
+  const { data: coupon } = await database
+    .from('customer_coupons')
+    .select('id, organization_id')
+    .eq('id', customerCouponId)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (!coupon) return res.status(200).json([])
+
+  const { data, error } = await database
+    .from('coupon_usages')
+    .select(`
+      id,
+      reservation_id,
+      discount_amount,
+      used_at,
+      reservations:reservation_id (title)
+    `)
+    .eq('customer_coupon_id', customerCouponId)
+    .order('used_at', { ascending: false })
+
+  if (error) {
+    console.error('[coupons:admin-usages] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mapped = ((data as any[]) ?? []).map((row: any) => ({
+    id: row.id,
+    reservation_id: row.reservation_id,
+    discount_amount: row.discount_amount,
+    used_at: row.used_at,
+    reservation_title: row.reservations?.title ?? null,
+  }))
+
+  return res.status(200).json(mapped)
+}
+
+// =========================================
+// 管理者向け: キャンペーンに紐づくクーポン一覧（顧客情報付き）
+// =========================================
+async function handleCampaignCoupons(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const campaignId = req.query.campaign_id as string | undefined
+  if (!campaignId) {
+    return res.status(400).json({ error: 'campaign_id クエリパラメータが必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // キャンペーンが自組織のものか検証
+  const { data: campaign } = await database
+    .from('coupon_campaigns')
+    .select('id, organization_id')
+    .eq('id', campaignId)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (!campaign) return res.status(200).json([])
+
+  const { data, error } = await database
+    .from('customer_coupons')
+    .select(CUSTOMER_COUPON_WITH_CUSTOMER_FIELDS)
+    .eq('campaign_id', campaignId)
+    .eq('organization_id', user.orgId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('[coupons:campaign-coupons] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json(data ?? [])
+}
+
+// =========================================
+// 管理者向け: 顧客検索
+// =========================================
+async function handleSearchCustomers(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const q = (req.query.q as string | undefined) ?? ''
+  const trimmed = q.trim()
+  if (!trimmed) return res.status(200).json([])
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  // ilike へ渡す値はサニタイズ（% _ \ をエスケープ）して任意検索による意図せぬマッチを防ぐ
+  const escaped = trimmed.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+  const searchTerm = `%${escaped}%`
+
+  const { data, error } = await database
+    .from('customers')
+    .select('id, name, email, phone, organization_id')
+    .eq('organization_id', user.orgId)
+    .or(`name.ilike.${searchTerm},email.ilike.${searchTerm},phone.ilike.${searchTerm}`)
+    .limit(20)
+
+  if (error) {
+    console.error('[coupons:search-customers] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mapped = ((data as any[]) ?? []).map((c: any) => ({
+    id: c.id,
+    name: c.name,
+    email: c.email,
+    phone: c.phone,
+  }))
+
+  return res.status(200).json(mapped)
+}
+
+// =========================================
+// 顧客向け: クーポンを使用（もぎる）
+// =========================================
+async function handleUseCoupon(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const body = (req.body ?? {}) as { customer_coupon_id?: string; reservation_id?: string | null }
+  const customerCouponId = body.customer_coupon_id
+  const reservationId = body.reservation_id ?? null
+
+  if (!customerCouponId) {
+    return res.status(400).json({ error: 'customer_coupon_id が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  const { data: coupon, error: couponError } = await database
+    .from('customer_coupons')
+    .select(`
+      id,
+      customer_id,
+      organization_id,
+      uses_remaining,
+      status,
+      expires_at,
+      coupon_campaigns (
+        discount_type,
+        discount_amount
+      )
+    `)
+    .eq('id', customerCouponId)
+    .maybeSingle()
+
+  if (couponError) {
+    console.error('[coupons:use] coupon fetch error:', couponError)
+    return res.status(500).json({ success: false, error: 'クーポン取得に失敗しました' })
+  }
+  if (!coupon) {
+    return res.status(404).json({ success: false, error: 'クーポンが見つかりません' })
+  }
+
+  // 本人検証: customer_id が JWT user_id ⇒ customers から引いた本人のもので、
+  // かつ coupon の organization_id と一致することを保証する。
+  let ownerQuery = database
+    .from('customers')
+    .select('id, organization_id')
+    .eq('id', coupon.customer_id)
+    .eq('user_id', user.userId)
+  if (coupon.organization_id) {
+    ownerQuery = ownerQuery.eq('organization_id', coupon.organization_id)
+  }
+  const { data: ownerRows } = await ownerQuery.limit(1)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const customer = ((ownerRows as any[]) ?? [])[0]
+
+  if (!customer) {
+    return res.status(403).json({ success: false, error: 'クーポンが見つかりません' })
+  }
+
+  // 有効性チェック
+  if (coupon.status !== 'active') {
+    return res.status(400).json({ success: false, error: 'このクーポンは利用できません' })
+  }
+  if (coupon.uses_remaining <= 0) {
+    return res.status(400).json({ success: false, error: 'このクーポンは使い切りました' })
+  }
+  if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
+    return res.status(400).json({ success: false, error: 'このクーポンは有効期限が切れています' })
+  }
+
+  // タイトル（シナリオ）に既にクーポン使用済みかチェック
+  if (reservationId) {
+    // 対象予約が自組織のものか軽く検証（NULL の場合は何もしない）
+    const { data: selectedReservation } = await database
+      .from('reservations')
+      .select('schedule_event_id, organization_id')
+      .eq('id', reservationId)
+      .maybeSingle()
+
+    if (selectedReservation?.organization_id && coupon.organization_id && selectedReservation.organization_id !== coupon.organization_id) {
+      return res.status(400).json({ success: false, error: '予約と組織が一致しません' })
+    }
+
+    if (selectedReservation?.schedule_event_id) {
+      const { data: selectedEvent } = await database
+        .from('schedule_events')
+        .select('scenario_master_id, scenario, organization_id')
+        .eq('id', selectedReservation.schedule_event_id)
+        .maybeSingle()
+
+      if (selectedEvent && (selectedEvent.scenario_master_id || selectedEvent.scenario)) {
+        const { data: myCoupons } = await database
+          .from('customer_coupons')
+          .select('id')
+          .eq('customer_id', customer.id)
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const myCouponIds = ((myCoupons as any[]) ?? []).map((c: any) => c.id)
+        if (myCouponIds.length > 0) {
+          const { data: usages } = await database
+            .from('coupon_usages')
+            .select('reservation_id')
+            .in('customer_coupon_id', myCouponIds)
+            .not('reservation_id', 'is', null)
+
+          const usedReservationIds: string[] = [
+            ...new Set(
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              ((usages as any[]) ?? []).map((u: any) => u.reservation_id).filter((x: unknown) => typeof x === 'string'),
+            ),
+          ] as string[]
+          if (usedReservationIds.length > 0) {
+            const { data: usedReservations } = await database
+              .from('reservations')
+              .select('schedule_event_id')
+              .in('id', usedReservationIds)
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const usedEventIds = ((usedReservations as any[]) ?? [])
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .map((r: any) => r.schedule_event_id)
+              .filter((x: unknown): x is string => typeof x === 'string')
+
+            if (usedEventIds.length > 0) {
+              let sameScenarioQuery = database
+                .from('schedule_events')
+                .select('id')
+                .in('id', usedEventIds)
+              if (selectedEvent.scenario_master_id) {
+                sameScenarioQuery = sameScenarioQuery.eq('scenario_master_id', selectedEvent.scenario_master_id)
+              } else if (selectedEvent.scenario) {
+                sameScenarioQuery = sameScenarioQuery.eq('scenario', selectedEvent.scenario)
+              }
+              const { data: sameScenarioEvents } = await sameScenarioQuery
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              if (((sameScenarioEvents as any[]) ?? []).length > 0) {
+                return res.status(400).json({ success: false, error: 'このタイトルには既にクーポンをご利用済みです' })
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const campaign = coupon.coupon_campaigns as any
+  const discountAmount = (Array.isArray(campaign) ? campaign[0]?.discount_amount : campaign?.discount_amount) ?? 0
+
+  // coupon_usages に記録（DB トリガーが uses_remaining と status を更新）
+  const usageData: Record<string, unknown> = {
+    customer_coupon_id: customerCouponId,
+    discount_amount: discountAmount,
+    used_at: new Date().toISOString(),
+  }
+  if (reservationId) usageData.reservation_id = reservationId
+
+  const { error: usageError } = await database
+    .from('coupon_usages')
+    .insert(usageData)
+
+  if (usageError) {
+    console.error('[coupons:use] usage insert error:', usageError)
+    if (usageError.code === '23503' && reservationId) {
+      const { error: retryError } = await database
+        .from('coupon_usages')
+        .insert({
+          customer_coupon_id: customerCouponId,
+          discount_amount: discountAmount,
+          used_at: new Date().toISOString(),
+        })
+      if (retryError) {
+        console.error('[coupons:use] retry error:', retryError)
+        return res.status(500).json({ success: false, error: 'クーポン使用の記録に失敗しました' })
+      }
+    } else {
+      return res.status(500).json({ success: false, error: 'クーポン使用の記録に失敗しました' })
+    }
+  }
+
+  return res.status(200).json({ success: true })
+}
+
+// =========================================
+// 顧客向け: 新規登録クーポンを付与
+// =========================================
+async function handleGrantRegistrationCoupon(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const body = (req.body ?? {}) as { customer_id?: string }
+  const customerId = body.customer_id
+  if (!customerId) {
+    return res.status(400).json({ error: 'customer_id が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 本人検証: customer_id が JWT user_id ⇒ 自組織の customers のものであること
+  const { data: customer } = await database
+    .from('customers')
+    .select('id, organization_id, user_id')
+    .eq('id', customerId)
+    .eq('user_id', user.userId)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (!customer) {
+    return res.status(403).json({ error: '対象の顧客にクーポンを付与する権限がありません' })
+  }
+
+  // 対象キャンペーン取得（JWT 由来の org のみ）
+  const { data: campaigns, error: campaignError } = await database
+    .from('coupon_campaigns')
+    .select(COUPON_CAMPAIGN_FIELDS)
+    .eq('trigger_type', 'registration')
+    .eq('is_active', true)
+    .eq('organization_id', user.orgId)
+    .or('valid_from.is.null,valid_from.lte.now()')
+    .or('valid_until.is.null,valid_until.gte.now()')
+
+  if (campaignError || !campaigns || campaigns.length === 0) {
+    return res.status(200).json({ granted: 0, skipped: true, reason: '対象キャンペーンなし' })
+  }
+
+  let grantedCount = 0
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const campaign of campaigns as any[]) {
+    let expiresAt: string | null = null
+    if (campaign.coupon_expiry_days) {
+      const expiry = new Date()
+      expiry.setDate(expiry.getDate() + campaign.coupon_expiry_days)
+      expiresAt = expiry.toISOString()
+    }
+
+    const { error: insertError } = await database
+      .from('customer_coupons')
+      .insert({
+        campaign_id: campaign.id,
+        customer_id: customerId,
+        organization_id: campaign.organization_id,
+        uses_remaining: campaign.max_uses_per_customer,
+        expires_at: expiresAt,
+        status: 'active',
+      })
+
+    if (insertError) {
+      if (insertError.code === '23505') {
+        // 既に付与済み（UNIQUE 制約）
+      } else {
+        console.error('[coupons:grant-registration] insert error:', insertError)
+      }
+    } else {
+      grantedCount++
+    }
+  }
+
+  return res.status(200).json({ granted: grantedCount, skipped: grantedCount === 0 })
+}
+
+// =========================================
+// 管理者向け: キャンペーン作成
+// =========================================
+async function handleCreateCampaign(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const body = (req.body ?? {}) as Record<string, unknown>
+  // クライアントから organization_id を受け付けない（JWT 由来のみ）
+  const { organization_id: _ignoredOrgId, id: _ignoredId, created_at: _ignoredCreated, updated_at: _ignoredUpdated, ...formData } = body
+  void _ignoredOrgId; void _ignoredId; void _ignoredCreated; void _ignoredUpdated
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('coupon_campaigns')
+    .insert({ ...formData, organization_id: user.orgId })
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error('[coupons:create-campaign] DB error:', error)
+    return res.status(500).json({ success: false, error: error.message })
+  }
+  return res.status(200).json({ success: true, id: data.id })
+}
+
+// =========================================
+// 管理者向け: キャンペーン更新
+// =========================================
+async function handleUpdateCampaign(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) {
+    return res.status(400).json({ success: false, error: 'id クエリパラメータが必要です' })
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  // クライアントから organization_id / id を受け付けない（自組織にバインド）
+  const { organization_id: _ignoredOrgId, id: _ignoredId, created_at: _ignoredCreated, updated_at: _ignoredUpdated, ...formData } = body
+  void _ignoredOrgId; void _ignoredId; void _ignoredCreated; void _ignoredUpdated
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const { data, error } = await database
+    .from('coupon_campaigns')
+    .update(formData)
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+    .select('id')
+
+  if (error) {
+    console.error('[coupons:update-campaign] DB error:', error)
+    return res.status(500).json({ success: false, error: error.message })
+  }
+  if (!data || data.length === 0) {
+    return res.status(404).json({ success: false, error: 'キャンペーンが見つかりません（権限不足の可能性）' })
+  }
+  return res.status(200).json({ success: true })
+}
+
+// =========================================
+// 管理者向け: キャンペーンの有効/無効を切り替え
+// =========================================
+async function handleToggleCampaignActive(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) {
+    return res.status(400).json({ success: false, error: 'id クエリパラメータが必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  const { data: campaign, error: fetchError } = await database
+    .from('coupon_campaigns')
+    .select('is_active')
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (fetchError) {
+    console.error('[coupons:toggle-campaign-active] fetch error:', fetchError)
+    return res.status(500).json({ success: false, error: fetchError.message })
+  }
+  if (!campaign) {
+    return res.status(404).json({ success: false, error: 'キャンペーンが見つかりません' })
+  }
+
+  const newStatus = !campaign.is_active
+  const { error: updateError } = await database
+    .from('coupon_campaigns')
+    .update({ is_active: newStatus })
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+
+  if (updateError) {
+    console.error('[coupons:toggle-campaign-active] update error:', updateError)
+    return res.status(500).json({ success: false, error: updateError.message })
+  }
+
+  return res.status(200).json({ success: true, isActive: newStatus })
+}
+
+// =========================================
+// 管理者向け: 顧客にクーポンを手動付与
+// =========================================
+async function handleGrantCouponToCustomer(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const body = (req.body ?? {}) as { campaign_id?: string; customer_id?: string }
+  const campaignId = body.campaign_id
+  const customerId = body.customer_id
+  if (!campaignId || !customerId) {
+    return res.status(400).json({ success: false, error: 'campaign_id と customer_id が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // キャンペーンが自組織のものか
+  const { data: campaign, error: campaignError } = await database
+    .from('coupon_campaigns')
+    .select(COUPON_CAMPAIGN_FIELDS)
+    .eq('id', campaignId)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (campaignError) {
+    console.error('[coupons:grant-to-customer] campaign fetch error:', campaignError)
+    return res.status(500).json({ success: false, error: campaignError.message })
+  }
+  if (!campaign) {
+    return res.status(404).json({ success: false, error: 'キャンペーンが見つかりません' })
+  }
+
+  // 顧客が自組織のものか
+  const { data: customer, error: customerError } = await database
+    .from('customers')
+    .select('id, organization_id')
+    .eq('id', customerId)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (customerError) {
+    console.error('[coupons:grant-to-customer] customer fetch error:', customerError)
+    return res.status(500).json({ success: false, error: customerError.message })
+  }
+  if (!customer) {
+    return res.status(404).json({ success: false, error: '顧客が見つかりません' })
+  }
+
+  let expiresAt: string | null = null
+  if (campaign.coupon_expiry_days) {
+    const expiry = new Date()
+    expiry.setDate(expiry.getDate() + campaign.coupon_expiry_days)
+    expiresAt = expiry.toISOString()
+  }
+
+  const { data, error } = await database
+    .from('customer_coupons')
+    .insert({
+      campaign_id: campaignId,
+      customer_id: customerId,
+      organization_id: user.orgId,
+      uses_remaining: campaign.max_uses_per_customer,
+      expires_at: expiresAt,
+      status: 'active',
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code === '23505') {
+      return res.status(409).json({ success: false, error: 'この顧客には既にこのクーポンが付与されています' })
+    }
+    console.error('[coupons:grant-to-customer] insert error:', error)
+    return res.status(500).json({ success: false, error: error.message })
+  }
+
+  return res.status(200).json({ success: true, couponId: data.id })
+}
+
+// =========================================
+// 管理者向け: クーポン使用を取り消して残数を復元
+// =========================================
+async function handleRestoreCouponUsage(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const couponUsageId = req.query.usage_id as string | undefined
+  const customerCouponId = req.query.customer_coupon_id as string | undefined
+  if (!couponUsageId || !customerCouponId) {
+    return res.status(400).json({ success: false, error: 'usage_id と customer_coupon_id が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 顧客クーポンが自組織のもので、かつ usage がこのクーポンに属しているか検証
+  const { data: coupon, error: couponError } = await database
+    .from('customer_coupons')
+    .select('id, uses_remaining, status, organization_id')
+    .eq('id', customerCouponId)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+
+  if (couponError) {
+    console.error('[coupons:restore-usage] coupon fetch error:', couponError)
+    return res.status(500).json({ success: false, error: couponError.message })
+  }
+  if (!coupon) {
+    return res.status(404).json({ success: false, error: 'クーポンが見つかりません' })
+  }
+
+  // 使用記録の所属チェック（customer_coupon_id を必ず合わせる）
+  const { data: usage } = await database
+    .from('coupon_usages')
+    .select('id, customer_coupon_id')
+    .eq('id', couponUsageId)
+    .eq('customer_coupon_id', customerCouponId)
+    .maybeSingle()
+
+  if (!usage) {
+    return res.status(404).json({ success: false, error: '使用履歴が見つかりません' })
+  }
+
+  const { error: deleteError } = await database
+    .from('coupon_usages')
+    .delete()
+    .eq('id', couponUsageId)
+    .eq('customer_coupon_id', customerCouponId)
+
+  if (deleteError) {
+    console.error('[coupons:restore-usage] delete error:', deleteError)
+    return res.status(500).json({ success: false, error: '使用記録の削除に失敗しました' })
+  }
+
+  const { error: updateError } = await database
+    .from('customer_coupons')
+    .update({
+      uses_remaining: coupon.uses_remaining + 1,
+      status: 'active',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', customerCouponId)
+    .eq('organization_id', user.orgId)
+
+  if (updateError) {
+    console.error('[coupons:restore-usage] update error:', updateError)
+    return res.status(500).json({ success: false, error: '残数の復元に失敗しました' })
+  }
+
+  return res.status(200).json({ success: true })
 }

--- a/src/lib/api/couponApi.ts
+++ b/src/lib/api/couponApi.ts
@@ -1,39 +1,17 @@
 /**
  * クーポン関連のAPI
  *
- * - 利用可能クーポンの取得
- * - クーポン使用履歴の取得
- * - キャンペーン管理（管理者向け）
+ * read / write はすべて バックエンド API (/api/coupons) 経由。
+ * organization_id はサーバー側で JWT から取得するため、クライアントからは渡さない。
+ * 顧客向け / 管理者向けの両方を含む。
  */
-import { supabase } from '../supabase'
 import { apiClient } from '../apiClient'
-import { getCurrentOrganizationId } from '@/lib/organization'
 import { logger } from '@/utils/logger'
 import type {
   CustomerCoupon,
   CouponUsage,
   CouponCampaign
 } from '@/types'
-
-const COUPON_CAMPAIGN_SELECT_FIELDS =
-  'id, organization_id, name, description, discount_type, discount_amount, max_uses_per_customer, target_type, target_ids, trigger_type, valid_from, valid_until, coupon_expiry_days, is_active, created_at, updated_at' as const
-
-/**
- * user_id で顧客レコードを1件取得（重複レコードがあっても安全に動作する）
- * maybeSingle() は複数行あるとエラーになるため、order + limit(1) を使う
- */
-async function findCustomerByUserId(
-  userId: string,
-  organizationId: string | null,
-  selectFields = 'id'
-): Promise<Record<string, unknown> | null> {
-  let query = supabase.from('customers').select(selectFields).eq('user_id', userId)
-  if (organizationId) {
-    query = query.eq('organization_id', organizationId)
-  }
-  const { data } = await query.order('created_at', { ascending: true }).limit(1)
-  return (data?.[0] as unknown as Record<string, unknown>) ?? null
-}
 
 // キャンペーン統計
 export interface CampaignStats {
@@ -61,10 +39,6 @@ export interface CampaignFormData {
 
 /**
  * ログインユーザーの利用可能クーポン一覧を取得
- * - status = 'active'
- * - uses_remaining > 0
- * - 有効期限内（expires_at が NULL or 未来）
- * - キャンペーンもアクティブ
  *
  * @param organizationId 対象組織ID（予約先の組織でフィルタ。省略時はサーバ側で JWT の orgId を使う）
  */
@@ -98,66 +72,23 @@ export async function getAllCoupons(): Promise<CustomerCoupon[]> {
  * 新規登録クーポンを付与
  * NOTE: 電話番号での重複チェックは廃止（真正性を確認できないため）
  * 重複防止は customer_coupons の UNIQUE 制約 (campaign_id, customer_id) で担保
- * @param customerId 顧客ID
- * @param organizationId 組織ID
+ * @param customerId 顧客ID（サーバ側で JWT の user_id と一致するか検証）
+ * @param _organizationId 互換性のため受け取るが、サーバ側で JWT から決定する
  * @returns 付与されたクーポン数
  */
 export async function grantRegistrationCoupon(
   customerId: string,
-  organizationId: string
+  _organizationId?: string
 ): Promise<{ granted: number; skipped: boolean; reason?: string }> {
-  // 対象キャンペーンを取得
-  const { data: campaigns, error: campaignError } = await supabase
-    .from('coupon_campaigns')
-    .select(COUPON_CAMPAIGN_SELECT_FIELDS)
-    .eq('trigger_type', 'registration')
-    .eq('is_active', true)
-    .eq('organization_id', organizationId)
-    .or('valid_from.is.null,valid_from.lte.now()')
-    .or('valid_until.is.null,valid_until.gte.now()')
-
-  if (campaignError || !campaigns || campaigns.length === 0) {
-    logger.log('クーポン付与スキップ: 対象キャンペーンなし')
-    return { granted: 0, skipped: true, reason: '対象キャンペーンなし' }
+  try {
+    return await apiClient.post<{ granted: number; skipped: boolean; reason?: string }>(
+      '/api/coupons?action=grant-registration',
+      { customer_id: customerId }
+    )
+  } catch (err) {
+    logger.error('クーポン付与エラー:', err)
+    return { granted: 0, skipped: true, reason: '付与に失敗しました' }
   }
-
-  let grantedCount = 0
-
-  for (const campaign of campaigns) {
-    // 有効期限を計算
-    let expiresAt: string | null = null
-    if (campaign.coupon_expiry_days) {
-      const expiry = new Date()
-      expiry.setDate(expiry.getDate() + campaign.coupon_expiry_days)
-      expiresAt = expiry.toISOString()
-    }
-
-    // クーポンを付与（同一顧客への重複付与は UNIQUE 制約で防止）
-    const { error: insertError } = await supabase
-      .from('customer_coupons')
-      .insert({
-        campaign_id: campaign.id,
-        customer_id: customerId,
-        organization_id: campaign.organization_id,
-        uses_remaining: campaign.max_uses_per_customer,
-        expires_at: expiresAt,
-        status: 'active'
-      })
-
-    if (insertError) {
-      // 重複エラーは無視
-      if (insertError.code === '23505') {
-        logger.log(`クーポン付与スキップ: 既に付与済み (campaign=${campaign.id}, customer=${customerId})`)
-      } else {
-        logger.error('クーポン付与エラー:', insertError)
-      }
-    } else {
-      grantedCount++
-      logger.log(`✅ クーポン付与成功: campaign=${campaign.name}, customer=${customerId}`)
-    }
-  }
-
-  return { granted: grantedCount, skipped: grantedCount === 0 }
 }
 
 /**
@@ -170,167 +101,24 @@ export async function useCoupon(
   customerCouponId: string,
   reservationId?: string
 ): Promise<{ success: boolean; error?: string }> {
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return { success: false, error: 'ログインが必要です' }
-
-  // クーポンを先に取得し、customer_id + organization_id で本人の顧客行か検証（多組織の取り違え防止）
-  const { data: coupon, error: couponError } = await supabase
-    .from('customer_coupons')
-    .select(`
-      id,
-      customer_id,
-      organization_id,
-      uses_remaining,
-      status,
-      expires_at,
-      coupon_campaigns (
-        discount_type,
-        discount_amount
-      )
-    `)
-    .eq('id', customerCouponId)
-    .single()
-
-  if (couponError || !coupon) {
-    logger.error('クーポン取得エラー:', couponError)
-    return { success: false, error: 'クーポンが見つかりません' }
-  }
-
-  let ownerQuery = supabase
-    .from('customers')
-    .select('id')
-    .eq('id', coupon.customer_id)
-    .eq('user_id', user.id)
-  if (coupon.organization_id) {
-    ownerQuery = ownerQuery.eq('organization_id', coupon.organization_id)
-  }
-  const { data: customer } = await ownerQuery.maybeSingle()
-
-  if (!customer) {
-    return { success: false, error: 'クーポンが見つかりません' }
-  }
-
-  // 有効性チェック
-  if (coupon.status !== 'active') {
-    return { success: false, error: 'このクーポンは利用できません' }
-  }
-  if (coupon.uses_remaining <= 0) {
-    return { success: false, error: 'このクーポンは使い切りました' }
-  }
-  if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
-    return { success: false, error: 'このクーポンは有効期限が切れています' }
-  }
-
-  // タイトル（シナリオ）に既にクーポンを使用していないかチェック
-  if (reservationId) {
-    // 選択した予約のシナリオ情報を取得
-    const { data: selectedReservation } = await supabase
-      .from('reservations')
-      .select('schedule_event_id')
-      .eq('id', reservationId)
-      .maybeSingle()
-
-    if (selectedReservation?.schedule_event_id) {
-      const { data: selectedEvent } = await supabase
-        .from('schedule_events')
-        .select('scenario_master_id, scenario')
-        .eq('id', selectedReservation.schedule_event_id)
-        .maybeSingle()
-
-      if (selectedEvent && (selectedEvent.scenario_master_id || selectedEvent.scenario)) {
-        // このお客さんの全クーポン使用履歴の reservation_id を取得
-        const { data: myCoupons } = await supabase
-          .from('customer_coupons')
-          .select('id')
-          .eq('customer_id', customer.id)
-
-        if (myCoupons && myCoupons.length > 0) {
-          const { data: usages } = await supabase
-            .from('coupon_usages')
-            .select('reservation_id')
-            .in('customer_coupon_id', myCoupons.map(c => c.id))
-            .not('reservation_id', 'is', null)
-
-          if (usages && usages.length > 0) {
-            const usedReservationIds = usages.map(u => u.reservation_id).filter(Boolean) as string[]
-            const { data: usedReservations } = await supabase
-              .from('reservations')
-              .select('schedule_event_id')
-              .in('id', usedReservationIds)
-
-            if (usedReservations && usedReservations.length > 0) {
-              const usedEventIds = usedReservations.map(r => r.schedule_event_id).filter(Boolean) as string[]
-              let sameScenarioQuery = supabase
-                .from('schedule_events')
-                .select('id')
-                .in('id', usedEventIds)
-
-              if (selectedEvent.scenario_master_id) {
-                sameScenarioQuery = sameScenarioQuery.eq('scenario_master_id', selectedEvent.scenario_master_id)
-              } else if (selectedEvent.scenario) {
-                sameScenarioQuery = sameScenarioQuery.eq('scenario', selectedEvent.scenario)
-              }
-
-              const { data: sameScenarioEvents } = await sameScenarioQuery
-              if (sameScenarioEvents && sameScenarioEvents.length > 0) {
-                return { success: false, error: 'このタイトルには既にクーポンをご利用済みです' }
-              }
-            }
-          }
-        }
+  try {
+    return await apiClient.post<{ success: boolean; error?: string }>(
+      '/api/coupons?action=use',
+      {
+        customer_coupon_id: customerCouponId,
+        reservation_id: reservationId ?? null,
       }
-    }
+    )
+  } catch (err) {
+    logger.error('クーポン使用エラー:', err)
+    const message = err instanceof Error ? err.message : 'クーポン使用に失敗しました'
+    return { success: false, error: message }
   }
-
-  const campaign = coupon.coupon_campaigns as any
-  const discountAmount = campaign?.discount_amount || 0
-
-  // トランザクション的に処理
-  // 1. coupon_usages に記録
-  const usageData: Record<string, unknown> = {
-    customer_coupon_id: customerCouponId,
-    discount_amount: discountAmount,
-    used_at: new Date().toISOString()
-  }
-  // reservation_id は外部キー制約があるため、有効な場合のみ設定
-  if (reservationId) {
-    usageData.reservation_id = reservationId
-  }
-
-  const { error: usageError } = await supabase
-    .from('coupon_usages')
-    .insert(usageData)
-
-  if (usageError) {
-    console.error('クーポン使用記録エラー:', usageError)
-    // reservation_id の外部キー制約エラーの場合、reservation_id なしでリトライ
-    if (usageError.code === '23503' && reservationId) {
-      console.warn('reservation_id の外部キー制約エラー。reservation_id なしでリトライ')
-      const { error: retryError } = await supabase
-        .from('coupon_usages')
-        .insert({
-          customer_coupon_id: customerCouponId,
-          discount_amount: discountAmount,
-          used_at: new Date().toISOString()
-        })
-      if (retryError) {
-        console.error('クーポン使用記録リトライエラー:', retryError)
-        return { success: false, error: 'クーポン使用の記録に失敗しました' }
-      }
-    } else {
-      return { success: false, error: 'クーポン使用の記録に失敗しました' }
-    }
-  }
-
-  // coupon_usages への INSERT 後、DB トリガーが自動で
-  // customer_coupons の uses_remaining と status を更新する
-
-  return { success: true }
 }
 
 /**
  * 現在進行中の予約を取得（クーポン使用時の紐付け用）
- * 本日の公演で、開始前〜開始後3時間以内のものを対象
+ * 本日の公演で、開始3時間前〜終了1時間後の範囲のものを対象
  * 通常予約、貸切公演（参加メンバー含む）、スタッフ予約の全てに対応
  */
 export async function getCurrentReservations(): Promise<Array<{
@@ -340,167 +128,18 @@ export async function getCurrentReservations(): Promise<Array<{
   date: string
   time: string
 }>> {
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return []
-
-  const orgForCustomer = await getCurrentOrganizationId()
-  const customer = await findCustomerByUserId(user.id, orgForCustomer, 'id, name') as { id: string; name: string | null } | null
-
-  // スタッフ情報を取得（スタッフ予約のマッチングに使用）
-  const { data: staffRecord } = await supabase
-    .from('staff')
-    .select('id, name')
-    .eq('user_id', user.id)
-    .maybeSingle()
-
-  // 顧客もスタッフも見つからない場合は空を返す
-  if (!customer && !staffRecord) return []
-
-  // JSTで今日の日付を取得
-  const now = new Date()
-  const jstOffset = 9 * 60
-  const jstNow = new Date(now.getTime() + (jstOffset + now.getTimezoneOffset()) * 60 * 1000)
-  const todayStr = `${jstNow.getFullYear()}-${String(jstNow.getMonth() + 1).padStart(2, '0')}-${String(jstNow.getDate()).padStart(2, '0')}`
-
-  // 1. 通常予約を取得（自分がcustomer_idの予約）
-  // schedule_event_id で明示的にJOINを指定（reservationsとschedule_eventsに複数の外部キーがあるため）
-  let directReservations: any[] | null = null
-  if (customer) {
-    const { data, error } = await supabase
-      .from('reservations')
-      .select(`
-        id,
-        schedule_event_id
-      `)
-      .eq('customer_id', customer.id)
-      .eq('status', 'confirmed')
-    if (error) console.error('[クーポン予約検索] directReservations error:', error)
-    directReservations = data
+  try {
+    return await apiClient.get<Array<{
+      id: string
+      scenario_title: string
+      store_name: string
+      date: string
+      time: string
+    }>>('/api/coupons?type=current-reservations')
+  } catch (err) {
+    logger.error('現在進行中の予約取得エラー:', err)
+    return []
   }
-
-  // 2. 貸切公演の参加メンバーとしての予約を取得
-  // SECURITY DEFINER RPC 経由で必要最小限の情報（id, schedule_event_id, status）のみ取得。
-  // reservations テーブルを直接 SELECT すると staff_notes・料金・個人情報等が漏洩するため RPC を使用。
-  const { data: privateGroupReservations } = await supabase
-    .rpc('get_private_group_reservation_info')
-
-  // 3. スタッフ予約を取得（payment_method='staff' または reservation_source='staff_entry'/'staff_participation'）
-  const { data: staffReservations, error: staffError } = await supabase
-    .from('reservations')
-    .select(`
-      id,
-      participant_names,
-      schedule_event_id
-    `)
-    .or('payment_method.eq.staff,reservation_source.eq.staff_entry,reservation_source.eq.staff_participation')
-    .eq('status', 'confirmed')
-  if (staffError) console.error('[クーポン予約検索] staffReservations error:', staffError)
-
-  // schedule_event_id を収集して、一括でschedule_eventsを取得
-  const eventIds = new Set<string>()
-  if (directReservations) {
-    directReservations.forEach((r: any) => { if (r.schedule_event_id) eventIds.add(r.schedule_event_id) })
-  }
-  if (privateGroupReservations) {
-    privateGroupReservations.forEach((r: any) => {
-      if (r.schedule_event_id) eventIds.add(r.schedule_event_id)
-    })
-  }
-  if (staffReservations) {
-    staffReservations.forEach((r: any) => { if (r.schedule_event_id) eventIds.add(r.schedule_event_id) })
-  }
-
-  // schedule_events を一括取得
-  const eventsMap: Record<string, any> = {}
-  if (eventIds.size > 0) {
-    const { data: events } = await supabase
-      .from('schedule_events')
-      .select('id, date, start_time, end_time, scenario, venue, stores (name)')
-      .in('id', Array.from(eventIds))
-    if (events) {
-      for (const ev of events) {
-        eventsMap[ev.id] = ev
-      }
-    }
-  }
-
-  // 結果をマージ（eventsMapからイベント情報を取得）
-  const allReservations: Array<{ id: string; event: any }> = []
-
-  // 通常予約
-  if (directReservations) {
-    for (const r of directReservations) {
-      const event = eventsMap[r.schedule_event_id]
-      if (event) {
-        allReservations.push({ id: r.id, event })
-      }
-    }
-  }
-
-  // 貸切公演（参加メンバー）
-  if (privateGroupReservations) {
-    for (const r of privateGroupReservations) {
-      if (r.group_status !== 'confirmed') continue
-      if (r.reservation_status !== 'confirmed') continue
-      const event = eventsMap[r.schedule_event_id]
-      if (event && !allReservations.some(existing => existing.id === r.reservation_id)) {
-        allReservations.push({ id: r.reservation_id, event })
-      }
-    }
-  }
-
-  // スタッフ予約（participant_namesに自分の名前が含まれる場合）
-  const myNames: string[] = []
-  if (customer?.name) myNames.push(customer.name)
-  if (staffRecord?.name && !myNames.includes(staffRecord.name)) myNames.push(staffRecord.name)
-  
-  if (staffReservations && myNames.length > 0) {
-    for (const r of staffReservations) {
-      const names = r.participant_names as string[] | null
-      if (names && names.some(n => myNames.includes(n))) {
-        const event = eventsMap[r.schedule_event_id]
-        if (event && !allReservations.some(existing => existing.id === r.id)) {
-          allReservations.push({ id: r.id, event })
-        }
-      }
-    }
-  }
-
- 
-
-  // 今日の公演で、開始3時間前〜終了1時間後の範囲のものをフィルタ
-  const currentHour = jstNow.getHours()
-  const currentMinute = jstNow.getMinutes()
-  const currentTotalMinutes = currentHour * 60 + currentMinute
-
-  const filtered = allReservations
-    .filter(({ event }) => {
-      if (!event) return false
-      if (event.date !== todayStr) return false
-
-      const [startHour, startMinute] = event.start_time.split(':').map(Number)
-      const startTotalMinutes = startHour * 60 + startMinute
-
-      // 開始3時間前より前はNG
-      if (currentTotalMinutes < startTotalMinutes - 180) return false
-
-      // end_time がある場合は終了1時間後まで、ない場合は開始3時間後まで（フォールバック）
-      if (event.end_time) {
-        const [endHour, endMinute] = event.end_time.split(':').map(Number)
-        const endTotalMinutes = endHour * 60 + endMinute
-        return currentTotalMinutes <= endTotalMinutes + 60
-      }
-      return currentTotalMinutes <= startTotalMinutes + 180
-    })
-    .map(({ id, event }) => ({
-      id,
-      scenario_title: event.scenario || '不明なシナリオ',
-      store_name: event.stores?.name || event.venue || '不明な店舗',
-      date: event.date,
-      time: event.start_time.substring(0, 5)
-    }))
-
-  return filtered
 }
 
 /**
@@ -523,24 +162,12 @@ export async function getCouponUsageHistory(): Promise<CouponUsage[]> {
  * キャンペーン一覧を取得（組織単位）
  */
 export async function getCampaigns(): Promise<CouponCampaign[]> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
-    logger.error('組織IDが取得できません')
+  try {
+    return await apiClient.get<CouponCampaign[]>('/api/coupons?type=campaigns')
+  } catch (err) {
+    logger.error('キャンペーン一覧取得エラー:', err)
     return []
   }
-
-  const { data, error } = await supabase
-    .from('coupon_campaigns')
-    .select(COUPON_CAMPAIGN_SELECT_FIELDS)
-    .eq('organization_id', orgId)
-    .order('created_at', { ascending: false })
-
-  if (error) {
-    logger.error('キャンペーン一覧取得エラー:', error)
-    return []
-  }
-
-  return (data as CouponCampaign[]) || []
 }
 
 /**
@@ -549,26 +176,16 @@ export async function getCampaigns(): Promise<CouponCampaign[]> {
 export async function createCampaign(
   formData: CampaignFormData
 ): Promise<{ success: boolean; id?: string; error?: string }> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
-    return { success: false, error: '組織IDが取得できません' }
+  try {
+    return await apiClient.post<{ success: boolean; id?: string; error?: string }>(
+      '/api/coupons?action=create-campaign',
+      formData
+    )
+  } catch (err) {
+    logger.error('キャンペーン作成エラー:', err)
+    const message = err instanceof Error ? err.message : '作成に失敗しました'
+    return { success: false, error: message }
   }
-
-  const { data, error } = await supabase
-    .from('coupon_campaigns')
-    .insert({
-      ...formData,
-      organization_id: orgId
-    })
-    .select('id')
-    .single()
-
-  if (error) {
-    logger.error('キャンペーン作成エラー:', error)
-    return { success: false, error: error.message }
-  }
-
-  return { success: true, id: data.id }
 }
 
 /**
@@ -578,32 +195,17 @@ export async function updateCampaign(
   id: string,
   formData: Partial<CampaignFormData>
 ): Promise<{ success: boolean; error?: string }> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
-    return { success: false, error: '組織IDが取得できません' }
+  try {
+    const params = new URLSearchParams({ action: 'update-campaign', id })
+    return await apiClient.patch<{ success: boolean; error?: string }>(
+      `/api/coupons?${params}`,
+      formData
+    )
+  } catch (err) {
+    logger.error('キャンペーン更新エラー:', err)
+    const message = err instanceof Error ? err.message : '更新に失敗しました'
+    return { success: false, error: message }
   }
-
-  logger.log('キャンペーン更新:', { id, orgId, formData })
-
-  const { data, error, count } = await supabase
-    .from('coupon_campaigns')
-    .update(formData)
-    .eq('id', id)
-    .eq('organization_id', orgId)
-    .select()
-
-  if (error) {
-    logger.error('キャンペーン更新エラー:', error)
-    return { success: false, error: error.message }
-  }
-
-  if (!data || data.length === 0) {
-    logger.error('キャンペーン更新: 対象レコードなし', { id, orgId })
-    return { success: false, error: 'キャンペーンが見つかりません（権限不足の可能性）' }
-  }
-
-  logger.log('キャンペーン更新成功:', data)
-  return { success: true }
 }
 
 /**
@@ -612,38 +214,17 @@ export async function updateCampaign(
 export async function toggleCampaignActive(
   id: string
 ): Promise<{ success: boolean; isActive?: boolean; error?: string }> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
-    return { success: false, error: '組織IDが取得できません' }
+  try {
+    const params = new URLSearchParams({ action: 'toggle-campaign-active', id })
+    return await apiClient.patch<{ success: boolean; isActive?: boolean; error?: string }>(
+      `/api/coupons?${params}`,
+      {}
+    )
+  } catch (err) {
+    logger.error('キャンペーン状態更新エラー:', err)
+    const message = err instanceof Error ? err.message : '状態の変更に失敗しました'
+    return { success: false, error: message }
   }
-
-  // 現在の状態を取得
-  const { data: campaign, error: fetchError } = await supabase
-    .from('coupon_campaigns')
-    .select('is_active')
-    .eq('id', id)
-    .eq('organization_id', orgId)
-    .single()
-
-  if (fetchError || !campaign) {
-    logger.error('キャンペーン取得エラー:', fetchError)
-    return { success: false, error: 'キャンペーンが見つかりません' }
-  }
-
-  const newStatus = !campaign.is_active
-
-  const { error } = await supabase
-    .from('coupon_campaigns')
-    .update({ is_active: newStatus })
-    .eq('id', id)
-    .eq('organization_id', orgId)
-
-  if (error) {
-    logger.error('キャンペーン状態更新エラー:', error)
-    return { success: false, error: error.message }
-  }
-
-  return { success: true, isActive: newStatus }
 }
 
 /**
@@ -653,55 +234,16 @@ export async function grantCouponToCustomer(
   campaignId: string,
   customerId: string
 ): Promise<{ success: boolean; couponId?: string; error?: string }> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
-    return { success: false, error: '組織IDが取得できません' }
+  try {
+    return await apiClient.post<{ success: boolean; couponId?: string; error?: string }>(
+      '/api/coupons?action=grant-to-customer',
+      { campaign_id: campaignId, customer_id: customerId }
+    )
+  } catch (err) {
+    logger.error('クーポン付与エラー:', err)
+    const message = err instanceof Error ? err.message : '付与に失敗しました'
+    return { success: false, error: message }
   }
-
-  // キャンペーン情報を取得
-  const { data: campaign, error: campaignError } = await supabase
-    .from('coupon_campaigns')
-    .select(COUPON_CAMPAIGN_SELECT_FIELDS)
-    .eq('id', campaignId)
-    .eq('organization_id', orgId)
-    .single()
-
-  if (campaignError || !campaign) {
-    logger.error('キャンペーン取得エラー:', campaignError)
-    return { success: false, error: 'キャンペーンが見つかりません' }
-  }
-
-  // 有効期限を計算
-  let expiresAt: string | null = null
-  if (campaign.coupon_expiry_days) {
-    const expiry = new Date()
-    expiry.setDate(expiry.getDate() + campaign.coupon_expiry_days)
-    expiresAt = expiry.toISOString()
-  }
-
-  // クーポンを付与
-  const { data, error } = await supabase
-    .from('customer_coupons')
-    .insert({
-      campaign_id: campaignId,
-      customer_id: customerId,
-      organization_id: orgId,
-      uses_remaining: campaign.max_uses_per_customer,
-      expires_at: expiresAt,
-      status: 'active'
-    })
-    .select('id')
-    .single()
-
-  if (error) {
-    if (error.code === '23505') {
-      return { success: false, error: 'この顧客には既にこのクーポンが付与されています' }
-    }
-    logger.error('クーポン付与エラー:', error)
-    return { success: false, error: error.message }
-  }
-
-  return { success: true, couponId: data.id }
 }
 
 /**
@@ -710,50 +252,12 @@ export async function grantCouponToCustomer(
 export async function getCampaignStats(
   campaignId: string
 ): Promise<CampaignStats | null> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
-    logger.error('組織IDが取得できません')
+  try {
+    const params = new URLSearchParams({ type: 'campaign-stats', campaign_id: campaignId })
+    return await apiClient.get<CampaignStats>(`/api/coupons?${params}`)
+  } catch (err) {
+    logger.error('キャンペーン統計取得エラー:', err)
     return null
-  }
-
-  // 付与されたクーポン数・残り回数を取得
-  const { data: coupons, error: couponsError } = await supabase
-    .from('customer_coupons')
-    .select('id, uses_remaining')
-    .eq('campaign_id', campaignId)
-    .eq('organization_id', orgId)
-
-  if (couponsError) {
-    logger.error('クーポン取得エラー:', couponsError)
-    return null
-  }
-
-  const couponIds = coupons?.map(c => c.id) || []
-
-  // 使用履歴を取得
-  let totalUsed = 0
-  let totalDiscountAmount = 0
-
-  if (couponIds.length > 0) {
-    const { data: usages, error: usagesError } = await supabase
-      .from('coupon_usages')
-      .select('discount_amount')
-      .in('customer_coupon_id', couponIds)
-
-    if (!usagesError && usages) {
-      totalUsed = usages.length
-      totalDiscountAmount = usages.reduce((sum, u) => sum + u.discount_amount, 0)
-    }
-  }
-
-  const totalGranted = coupons?.length || 0
-  const totalRemaining = coupons?.reduce((sum, c) => sum + c.uses_remaining, 0) || 0
-
-  return {
-    totalGranted,
-    totalUsed,
-    totalRemaining,
-    totalDiscountAmount
   }
 }
 
@@ -763,26 +267,15 @@ export async function getCampaignStats(
 export async function searchCustomers(
   query: string
 ): Promise<Array<{ id: string; name: string; email: string; phone: string | null }>> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
+  try {
+    const params = new URLSearchParams({ type: 'search-customers', q: query })
+    return await apiClient.get<Array<{ id: string; name: string; email: string; phone: string | null }>>(
+      `/api/coupons?${params}`
+    )
+  } catch (err) {
+    logger.error('顧客検索エラー:', err)
     return []
   }
-
-  const searchTerm = `%${query}%`
-
-  const { data, error } = await supabase
-    .from('customers')
-    .select('id, name, email, phone')
-    .eq('organization_id', orgId)
-    .or(`name.ilike.${searchTerm},email.ilike.${searchTerm},phone.ilike.${searchTerm}`)
-    .limit(20)
-
-  if (error) {
-    logger.error('顧客検索エラー:', error)
-    return []
-  }
-
-  return data || []
 }
 
 /**
@@ -793,51 +286,18 @@ export async function restoreCouponUsage(
   couponUsageId: string,
   customerCouponId: string
 ): Promise<{ success: boolean; error?: string }> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
-    return { success: false, error: '組織IDが取得できません' }
-  }
-
-  const { data: coupon, error: couponError } = await supabase
-    .from('customer_coupons')
-    .select('id, uses_remaining, status')
-    .eq('id', customerCouponId)
-    .eq('organization_id', orgId)
-    .single()
-
-  if (couponError || !coupon) {
-    logger.error('クーポン取得エラー:', couponError)
-    return { success: false, error: 'クーポンが見つかりません' }
-  }
-
-  const { error: deleteError } = await supabase
-    .from('coupon_usages')
-    .delete()
-    .eq('id', couponUsageId)
-    .eq('customer_coupon_id', customerCouponId)
-
-  if (deleteError) {
-    logger.error('クーポン使用記録削除エラー:', deleteError)
-    return { success: false, error: '使用記録の削除に失敗しました' }
-  }
-
-  const { error: updateError } = await supabase
-    .from('customer_coupons')
-    .update({
-      uses_remaining: coupon.uses_remaining + 1,
-      status: 'active',
-      updated_at: new Date().toISOString()
+  try {
+    const params = new URLSearchParams({
+      action: 'restore-usage',
+      usage_id: couponUsageId,
+      customer_coupon_id: customerCouponId,
     })
-    .eq('id', customerCouponId)
-    .eq('organization_id', orgId)
-
-  if (updateError) {
-    logger.error('クーポン残数復元エラー:', updateError)
-    return { success: false, error: '残数の復元に失敗しました' }
+    return await apiClient.delete<{ success: boolean; error?: string }>(`/api/coupons?${params}`)
+  } catch (err) {
+    logger.error('クーポン使用取り消しエラー:', err)
+    const message = err instanceof Error ? err.message : '復元に失敗しました'
+    return { success: false, error: message }
   }
-
-  logger.log(`✅ クーポン使用取り消し: usage=${couponUsageId}, coupon=${customerCouponId}`)
-  return { success: true }
 }
 
 /**
@@ -852,42 +312,19 @@ export async function getCouponUsagesForAdmin(
   used_at: string
   reservation_title: string | null
 }>> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) return []
-
-  const { data: coupon } = await supabase
-    .from('customer_coupons')
-    .select('id')
-    .eq('id', customerCouponId)
-    .eq('organization_id', orgId)
-    .single()
-
-  if (!coupon) return []
-
-  const { data, error } = await supabase
-    .from('coupon_usages')
-    .select(`
-      id,
-      reservation_id,
-      discount_amount,
-      used_at,
-      reservations:reservation_id (title)
-    `)
-    .eq('customer_coupon_id', customerCouponId)
-    .order('used_at', { ascending: false })
-
-  if (error) {
-    logger.error('クーポン使用履歴取得エラー:', error)
+  try {
+    const params = new URLSearchParams({ type: 'admin-usages', customer_coupon_id: customerCouponId })
+    return await apiClient.get<Array<{
+      id: string
+      reservation_id: string | null
+      discount_amount: number
+      used_at: string
+      reservation_title: string | null
+    }>>(`/api/coupons?${params}`)
+  } catch (err) {
+    logger.error('クーポン使用履歴取得エラー:', err)
     return []
   }
-
-  return (data || []).map((row: any) => ({
-    id: row.id,
-    reservation_id: row.reservation_id,
-    discount_amount: row.discount_amount,
-    used_at: row.used_at,
-    reservation_title: row.reservations?.title || null
-  }))
 }
 
 /**
@@ -895,29 +332,14 @@ export async function getCouponUsagesForAdmin(
  */
 export async function getCampaignCoupons(
   campaignId: string
-): Promise<Array<CustomerCoupon & { customer?: { name: string; email: string } }>> {
-  const orgId = await getCurrentOrganizationId()
-  if (!orgId) {
+): Promise<Array<CustomerCoupon & { customers?: { name: string; email: string } }>> {
+  try {
+    const params = new URLSearchParams({ type: 'campaign-coupons', campaign_id: campaignId })
+    return await apiClient.get<Array<CustomerCoupon & { customers?: { name: string; email: string } }>>(
+      `/api/coupons?${params}`
+    )
+  } catch (err) {
+    logger.error('キャンペーンクーポン取得エラー:', err)
     return []
   }
-
-  const { data, error } = await supabase
-    .from('customer_coupons')
-    .select(`
-      *,
-      customers (
-        name,
-        email
-      )
-    `)
-    .eq('campaign_id', campaignId)
-    .eq('organization_id', orgId)
-    .order('created_at', { ascending: false })
-
-  if (error) {
-    logger.error('キャンペーンクーポン取得エラー:', error)
-    return []
-  }
-
-  return (data as any) || []
 }


### PR DESCRIPTION
## Summary
`couponApi.ts` の管理者向け read 12 メソッドと write 系を `/api/coupons` の拡張でバックエンド経由に切り替え。フロントから `organization_id` を一切受け取らず、JWT 由来で強制。`customer_id` 等の参照も所有組織で検証。

## 新規エンドポイント
- GET: `?type=campaigns` / `?type=campaign-stats&campaign_id=...` / `?type=admin-usages&customer_coupon_id=...` / `?type=campaign-coupons&campaign_id=...` / `?type=search-customers&q=...` / `?type=current-reservations`
- POST: `?action=create-campaign` / `?action=grant-to-customer` / `?action=use` / `?action=grant-registration`
- PATCH: `?action=update-campaign&id=...` / `?action=toggle-campaign-active&id=...`
- DELETE: `?action=restore-usage&customer_coupon_id=...&usage_id=...`

## セキュリティ強化点
- `organization_id` は JWT 経由でサーバ側のみで取得（クライアント値を一切信用しない）
- `updateCampaign` / `toggleCampaignActive` / `grantCouponToCustomer` / `restoreCouponUsage` すべて対象レコードの所有組織を検証
- `useCoupon` は `customer_coupons.customer_id ⇒ customers.user_id == JWT.user_id` を必須チェック（本人検証）
- `grantRegistrationCoupon` は `customer_id` が JWT.user_id ⇒ 自組織の顧客のものか検証
- `getCurrentReservations` は SECURITY DEFINER RPC（auth.uid 依存）を使わず、サーバ側で `private_group_members → private_groups → reservations` を組み立て、すべて `user.orgId` スコープで再検証
- `searchCustomers` は ilike の値を `%_\\` をエスケープしてサニタイズ

## 検証
- `npx tsc -p tsconfig.json --noEmit` → エラーなし
- `node scripts/check-security-guardrails.mjs` → exit 0
- `npm run lint` → 0 errors（既存 warnings のみ）

## Test plan
- [ ] 管理画面のキャンペーン一覧が表示される
- [ ] キャンペーン作成・更新・有効化トグルが動く
- [ ] 顧客にクーポン手動付与が動く
- [ ] クーポン使用取り消し（管理者）が動く
- [ ] 顧客がマイページでクーポンを使用できる
- [ ] 新規登録時にクーポンが自動付与される
- [ ] 進行中予約一覧が表示される
- [ ] 認証なし / 他組織アクセスは 401 / 403 が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)