### PR TITLE
feat(api): externalReports/invitations/privateBookingNotifications API をバックエンドに移行（マルチテナント境界強化）

### DIFF
--- a/api/external-reports.ts
+++ b/api/external-reports.ts
@@ -1,0 +1,433 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, requireLicenseAdmin, ApiError, type AuthUser } from './_lib/auth.js'
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+const REPORT_FIELDS = `
+  id,
+  scenario_master_id,
+  organization_id,
+  reported_by,
+  performance_date,
+  performance_count,
+  participant_count,
+  venue_name,
+  notes,
+  status,
+  reviewed_by,
+  reviewed_at,
+  rejection_reason,
+  created_at,
+  updated_at
+`
+
+const REPORT_SELECT_WITH_RELATIONS_MINE = `
+  ${REPORT_FIELDS},
+  scenario_masters:scenario_master_id (id, title, author),
+  reporter:reported_by (id, name),
+  reviewer:reviewed_by (id, name)
+`
+
+const REPORT_SELECT_WITH_RELATIONS_ALL = `
+  ${REPORT_FIELDS},
+  scenario_masters:scenario_master_id (id, title, author),
+  organizations:organization_id (id, name, slug),
+  reporter:reported_by (id, name),
+  reviewer:reviewed_by (id, name)
+`
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+
+    if (req.method === 'GET') {
+      const type = (req.query.type as string | undefined) ?? 'mine'
+      if (type === 'mine') return await handleGetMine(res, user)
+      if (type === 'all') return await handleGetAll(req, res, user)
+      if (type === 'license-summary') return await handleGetLicenseSummary(req, res, user)
+      if (type === 'managed-scenarios') return await handleGetManagedScenarios(res, user)
+      return res.status(400).json({ error: `unknown type: ${type}` })
+    }
+
+    if (req.method === 'POST') {
+      return await handleCreate(req, res, user)
+    }
+
+    if (req.method === 'PATCH') {
+      const action = (req.query.action as string | undefined) ?? 'update'
+      const id = req.query.id as string | undefined
+      if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+      if (action === 'approve') return await handleApprove(req, res, user, id)
+      if (action === 'reject') return await handleReject(req, res, user, id)
+      if (action === 'update') return await handleUpdate(req, res, user, id)
+      return res.status(400).json({ error: `unknown action: ${action}` })
+    }
+
+    if (req.method === 'DELETE') {
+      const id = req.query.id as string | undefined
+      if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+      return await handleDelete(res, user, id)
+    }
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[external-reports] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// 自組織の外部公演報告一覧
+async function handleGetMine(res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('external_performance_reports')
+    .select(REPORT_SELECT_WITH_RELATIONS_MINE)
+    .eq('organization_id', user.orgId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('[external-reports:mine] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// 全件取得（license_admin は全組織、その他は自組織のみ）
+async function handleGetAll(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+
+  const status = req.query.status as 'pending' | 'approved' | 'rejected' | undefined
+  const startDate = req.query.startDate as string | undefined
+  const endDate = req.query.endDate as string | undefined
+  const scenarioId = req.query.scenarioId as string | undefined
+  const requestedOrgId = req.query.organizationId as string | undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let query = (db as any)
+    .from('external_performance_reports')
+    .select(REPORT_SELECT_WITH_RELATIONS_ALL)
+    .order('created_at', { ascending: false })
+
+  // マルチテナント境界:
+  // - license_admin: 全組織を閲覧可能（指定があればそれに絞る）
+  // - その他のスタッフ/管理者: 自組織のみ
+  if (user.role === 'license_admin') {
+    if (requestedOrgId) {
+      query = query.eq('organization_id', requestedOrgId)
+    }
+  } else {
+    // 自組織に強制（クライアントの organizationId 指定を無視）
+    query = query.eq('organization_id', user.orgId)
+  }
+
+  if (status) query = query.eq('status', status)
+  if (startDate) query = query.gte('performance_date', startDate)
+  if (endDate) query = query.lte('performance_date', endDate)
+  if (scenarioId) query = query.eq('scenario_master_id', scenarioId)
+
+  const { data, error } = await query
+  if (error) {
+    console.error('[external-reports:all] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// ライセンス集計サマリー（license_performance_summary ビュー）
+// TODO: ビュー側で組織別フィルタができるか要確認。
+// 現状はビューが集計済みなので、license_admin のみ閲覧可とする。
+// （旧 RLS では is_license_manager() が必要だったため）
+async function handleGetLicenseSummary(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  // license_admin のみアクセス可能（admin も許可した方が業務上望ましいが、
+  // 旧挙動は RLS 任せだったため保守的に license_admin に限定）
+  // TODO: 業務要件に応じて admin も追加するか検討
+  if (user.role !== 'license_admin') {
+    return res.status(403).json({ error: 'ライセンス管理者権限が必要です' })
+  }
+
+  const authorName = req.query.authorName as string | undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('license_performance_summary')
+    .select(
+      'scenario_master_id, scenario_title, author, license_amount, internal_performance_count, external_performance_count, total_performance_count, total_license_fee'
+    )
+
+  if (error) {
+    console.error('[external-reports:summary] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  let result = (data ?? []) as Array<{ author: string }>
+  if (authorName) {
+    result = result.filter((r) => r.author === authorName)
+  }
+  return res.status(200).json(result)
+}
+
+// 管理シナリオ一覧（報告フォーム用）
+async function handleGetManagedScenarios(res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_scenarios_with_master')
+    .select('id, title, author, license_amount')
+    .eq('status', 'available')
+    .eq('organization_id', user.orgId)
+    .order('title')
+
+  if (error) {
+    console.error('[external-reports:managed-scenarios] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// 外部公演報告を作成（自組織として）
+async function handleCreate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+  const body = req.body as {
+    scenario_master_id?: string
+    reported_by?: string
+    performance_date?: string
+    performance_count?: number
+    participant_count?: number | null
+    venue_name?: string | null
+    notes?: string | null
+  }
+
+  if (!body.scenario_master_id || !body.performance_date || body.performance_count == null) {
+    return res.status(400).json({ error: 'scenario_master_id, performance_date, performance_count は必須です' })
+  }
+
+  // マルチテナント境界:
+  // - organization_id は必ず JWT 経由のユーザ所属組織を使用（フロントから受け取らない）
+  // - scenario_master_id が自組織で取り扱い可能かは organization_scenarios_with_master で検証
+  //   （ただし license_admin による他組織分の作成は許可しない＝旧挙動と同じ）
+  //
+  // reported_by はフロントから受け取るが、当該 staff が自組織所属かを最低限検証する
+  if (body.reported_by) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: staffRow, error: staffErr } = await (db as any)
+      .from('staff')
+      .select('id, organization_id')
+      .eq('id', body.reported_by)
+      .maybeSingle()
+    if (staffErr) {
+      console.error('[external-reports:create] staff lookup error:', staffErr)
+      return res.status(500).json({ error: 'スタッフ情報の取得に失敗しました' })
+    }
+    if (!staffRow || staffRow.organization_id !== user.orgId) {
+      return res.status(403).json({ error: 'reported_by が自組織のスタッフではありません' })
+    }
+  }
+
+  // scenario_master_id が自組織で扱えるか検証
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: scn, error: scnErr } = await (db as any)
+    .from('organization_scenarios_with_master')
+    .select('id')
+    .eq('id', body.scenario_master_id)
+    .eq('organization_id', user.orgId)
+    .maybeSingle()
+  if (scnErr) {
+    console.error('[external-reports:create] scenario lookup error:', scnErr)
+    return res.status(500).json({ error: 'シナリオ情報の取得に失敗しました' })
+  }
+  if (!scn) {
+    return res.status(403).json({ error: '指定されたシナリオは自組織で扱えません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('external_performance_reports')
+    .insert({
+      scenario_master_id: body.scenario_master_id,
+      organization_id: user.orgId, // JWT 経由で必ず上書き
+      reported_by: body.reported_by ?? user.userId,
+      performance_date: body.performance_date,
+      performance_count: body.performance_count,
+      participant_count: body.participant_count ?? null,
+      venue_name: body.venue_name ?? null,
+      notes: body.notes ?? null,
+      status: 'pending',
+    })
+    .select()
+    .single()
+
+  if (error) {
+    console.error('[external-reports:create] DB error:', error)
+    return res.status(500).json({ error: '報告の作成に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// 自組織の pending 報告を更新
+async function handleUpdate(req: VercelRequest, res: VercelResponse, user: AuthUser, id: string) {
+  requireStaff(user)
+  const body = req.body as {
+    performance_date?: string
+    performance_count?: number
+    participant_count?: number | null
+    venue_name?: string | null
+    notes?: string | null
+  }
+
+  // 所属組織を検証してから更新
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existing, error: lookupErr } = await (db as any)
+    .from('external_performance_reports')
+    .select('id, organization_id, status')
+    .eq('id', id)
+    .maybeSingle()
+  if (lookupErr) {
+    console.error('[external-reports:update] lookup error:', lookupErr)
+    return res.status(500).json({ error: '報告の取得に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: '報告が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の報告は更新できません' })
+  }
+  if (existing.status !== 'pending') {
+    return res.status(409).json({ error: 'pending 状態の報告のみ更新できます' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updates: Record<string, any> = {}
+  if (body.performance_date !== undefined) updates.performance_date = body.performance_date
+  if (body.performance_count !== undefined) updates.performance_count = body.performance_count
+  if (body.participant_count !== undefined) updates.participant_count = body.participant_count
+  if (body.venue_name !== undefined) updates.venue_name = body.venue_name
+  if (body.notes !== undefined) updates.notes = body.notes
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('external_performance_reports')
+    .update(updates)
+    .eq('id', id)
+    .eq('status', 'pending')
+    .select()
+    .single()
+
+  if (error) {
+    console.error('[external-reports:update] DB error:', error)
+    return res.status(500).json({ error: '報告の更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// 報告を承認（license_admin のみ）
+async function handleApprove(req: VercelRequest, res: VercelResponse, user: AuthUser, id: string) {
+  requireLicenseAdmin(user)
+  const body = req.body as { reviewerId?: string }
+  const reviewerId = body.reviewerId ?? user.userId
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('external_performance_reports')
+    .update({
+      status: 'approved',
+      reviewed_by: reviewerId,
+      reviewed_at: new Date().toISOString(),
+      rejection_reason: null,
+    })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('[external-reports:approve] DB error:', error)
+    return res.status(500).json({ error: '承認に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// 報告を却下（license_admin のみ）
+async function handleReject(req: VercelRequest, res: VercelResponse, user: AuthUser, id: string) {
+  requireLicenseAdmin(user)
+  const body = req.body as { reviewerId?: string; reason?: string }
+  const reviewerId = body.reviewerId ?? user.userId
+  const reason = (body.reason ?? '').trim()
+  if (!reason) {
+    return res.status(400).json({ error: '却下理由 (reason) が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('external_performance_reports')
+    .update({
+      status: 'rejected',
+      reviewed_by: reviewerId,
+      reviewed_at: new Date().toISOString(),
+      rejection_reason: reason,
+    })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('[external-reports:reject] DB error:', error)
+    return res.status(500).json({ error: '却下に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// 自組織の pending 報告を削除
+async function handleDelete(res: VercelResponse, user: AuthUser, id: string) {
+  requireStaff(user)
+
+  // 所属組織を検証
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existing, error: lookupErr } = await (db as any)
+    .from('external_performance_reports')
+    .select('id, organization_id, status')
+    .eq('id', id)
+    .maybeSingle()
+  if (lookupErr) {
+    console.error('[external-reports:delete] lookup error:', lookupErr)
+    return res.status(500).json({ error: '報告の取得に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: '報告が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の報告は削除できません' })
+  }
+  if (existing.status !== 'pending') {
+    return res.status(409).json({ error: 'pending 状態の報告のみ削除できます' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (db as any)
+    .from('external_performance_reports')
+    .delete()
+    .eq('id', id)
+    .eq('status', 'pending')
+
+  if (error) {
+    console.error('[external-reports:delete] DB error:', error)
+    return res.status(500).json({ error: '削除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
+}

--- a/api/invitations.ts
+++ b/api/invitations.ts
@@ -1,0 +1,395 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, ApiError, type AuthUser } from './_lib/auth.js'
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+const INVITATION_FIELDS = `
+  id,
+  organization_id,
+  email,
+  name,
+  role,
+  token,
+  expires_at,
+  accepted_at,
+  staff_id,
+  created_by,
+  created_at,
+  updated_at,
+  organization:organizations(id, name, slug, plan)
+`
+
+function isAdminUser(user: AuthUser): boolean {
+  // 招待管理は組織の admin のみ
+  return user.role === 'admin'
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    // 公開エンドポイント（トークン検証ベース、認証不要）
+    if (req.method === 'GET' && req.query.token) {
+      return await handleGetByToken(res, req.query.token as string)
+    }
+    if (req.method === 'POST' && req.query.action === 'accept') {
+      return await handleAccept(req, res)
+    }
+
+    // ここからは認証必須
+    const user = await requireAuth(req)
+
+    if (req.method === 'GET') {
+      return await handleListByOrg(res, user)
+    }
+    if (req.method === 'POST') {
+      const action = (req.query.action as string | undefined) ?? 'create'
+      if (action === 'create') return await handleCreate(req, res, user)
+      return res.status(400).json({ error: `unknown action: ${action}` })
+    }
+    if (req.method === 'PATCH') {
+      const action = (req.query.action as string | undefined) ?? 'resend'
+      const id = req.query.id as string | undefined
+      if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+      if (action === 'resend') return await handleResend(res, user, id)
+      return res.status(400).json({ error: `unknown action: ${action}` })
+    }
+    if (req.method === 'DELETE') {
+      const id = req.query.id as string | undefined
+      if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+      return await handleDelete(res, user, id)
+    }
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[invitations] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// 公開: トークンで招待を取得（受諾画面用）
+// 未ログインユーザがアクセスするため認証不要。
+// トークン自体が秘密情報なので、トークンを知っているクライアントだけ閲覧可能。
+async function handleGetByToken(res: VercelResponse, token: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_invitations')
+    .select(INVITATION_FIELDS)
+    .eq('token', token)
+    .maybeSingle()
+
+  if (error) {
+    console.error('[invitations:byToken] DB error:', error)
+    return res.status(500).json({ error: '招待の取得に失敗しました', detail: error.message })
+  }
+  if (!data) return res.status(404).json({ error: '招待が見つかりません' })
+  return res.status(200).json(data)
+}
+
+// 自組織の招待一覧（admin のみ）
+async function handleListByOrg(res: VercelResponse, user: AuthUser) {
+  if (!isAdminUser(user)) {
+    return res.status(403).json({ error: '管理者権限が必要です' })
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_invitations')
+    .select(INVITATION_FIELDS)
+    .eq('organization_id', user.orgId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('[invitations:list] DB error:', error)
+    return res.status(500).json({ error: '招待一覧の取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// 招待を作成（admin のみ、必ず自組織として）
+async function handleCreate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  if (!isAdminUser(user)) {
+    return res.status(403).json({ error: '管理者権限が必要です' })
+  }
+
+  const body = req.body as {
+    email?: string
+    name?: string
+    role?: string[]
+  }
+  const email = (body.email ?? '').toLowerCase().trim()
+  const name = (body.name ?? '').trim()
+  if (!email || !name) {
+    return res.status(400).json({ error: 'email, name は必須です' })
+  }
+
+  // マルチテナント境界:
+  // - organization_id は必ず JWT 経由のユーザ所属組織を使用（フロントから受け取らない）
+  // - created_by は JWT の userId を使用
+  const token = crypto.randomUUID() + '-' + Date.now().toString(36)
+  const expires_at = new Date()
+  expires_at.setDate(expires_at.getDate() + 7)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_invitations')
+    .insert({
+      organization_id: user.orgId, // JWT 経由で強制
+      email,
+      name,
+      role: body.role ?? ['スタッフ'],
+      token,
+      expires_at: expires_at.toISOString(),
+      created_by: user.userId,
+    })
+    .select(INVITATION_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[invitations:create] DB error:', error)
+    return res.status(500).json({ error: '招待の作成に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// 招待を再送信（admin のみ、自組織のものに限る）
+async function handleResend(res: VercelResponse, user: AuthUser, id: string) {
+  if (!isAdminUser(user)) {
+    return res.status(403).json({ error: '管理者権限が必要です' })
+  }
+
+  // 所属組織を検証
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existing, error: lookupErr } = await (db as any)
+    .from('organization_invitations')
+    .select('id, organization_id, accepted_at')
+    .eq('id', id)
+    .maybeSingle()
+  if (lookupErr) {
+    console.error('[invitations:resend] lookup error:', lookupErr)
+    return res.status(500).json({ error: '招待の取得に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: '招待が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の招待は操作できません' })
+  }
+  if (existing.accepted_at) {
+    return res.status(409).json({ error: 'この招待は既に受諾済みです' })
+  }
+
+  const token = crypto.randomUUID() + '-' + Date.now().toString(36)
+  const expires_at = new Date()
+  expires_at.setDate(expires_at.getDate() + 7)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_invitations')
+    .update({
+      token,
+      expires_at: expires_at.toISOString(),
+    })
+    .eq('id', id)
+    .select(INVITATION_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[invitations:resend] DB error:', error)
+    return res.status(500).json({ error: '招待の再送信に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// 招待を削除（admin のみ、自組織のものに限る）
+async function handleDelete(res: VercelResponse, user: AuthUser, id: string) {
+  if (!isAdminUser(user)) {
+    return res.status(403).json({ error: '管理者権限が必要です' })
+  }
+
+  // 所属組織を検証
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existing, error: lookupErr } = await (db as any)
+    .from('organization_invitations')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (lookupErr) {
+    console.error('[invitations:delete] lookup error:', lookupErr)
+    return res.status(500).json({ error: '招待の取得に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: '招待が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の招待は削除できません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (db as any)
+    .from('organization_invitations')
+    .delete()
+    .eq('id', id)
+
+  if (error) {
+    console.error('[invitations:delete] DB error:', error)
+    return res.status(500).json({ error: '招待の削除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
+}
+
+// 公開: 招待を受諾（パスワード設定 & ユーザー作成）
+// 未ログインユーザがアクセスするため認証不要。
+// token によりサーバ側で招待を検証する。
+async function handleAccept(req: VercelRequest, res: VercelResponse) {
+  const body = req.body as { token?: string; password?: string }
+  const token = (body.token ?? '').trim()
+  const password = body.password ?? ''
+
+  if (!token || !password) {
+    return res.status(400).json({ error: 'token と password は必須です' })
+  }
+  if (password.length < 8) {
+    return res.status(400).json({ error: 'パスワードは8文字以上で入力してください' })
+  }
+
+  if (!db) return res.status(500).json({ error: 'DB unavailable' })
+
+  // 1. アトミックに招待を受諾（accept_invitation_atomic RPC）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: atomicResult, error: atomicError } = await (db as any).rpc(
+    'accept_invitation_atomic',
+    { p_token: token }
+  )
+
+  if (atomicError) {
+    console.error('[invitations:accept] atomic error:', atomicError)
+    return res.status(500).json({ success: false, error: '招待の処理中にエラーが発生しました' })
+  }
+
+  const invitationResult = Array.isArray(atomicResult) ? atomicResult[0] : atomicResult
+  if (!invitationResult?.success) {
+    return res.status(400).json({
+      success: false,
+      error: invitationResult?.error_message ?? '招待の受諾に失敗しました',
+    })
+  }
+
+  // 2. 招待詳細を取得（受諾時に name などを使うため）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: invitation } = await (db as any)
+    .from('organization_invitations')
+    .select('id, email, name, role, organization_id')
+    .eq('token', token)
+    .maybeSingle()
+
+  const invitationData = invitation ?? {
+    id: invitationResult.id,
+    email: invitationResult.email,
+    role: invitationResult.role,
+    organization_id: invitationResult.organization_id,
+    name: '',
+  }
+
+  // 3. Supabase Auth でユーザを作成（service_role なので admin.createUser を使う）
+  // メール検証無しで作成する（招待リンク経由＝メール確認済みとみなす）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: authData, error: authError } = await (db as any).auth.admin.createUser({
+    email: invitationData.email,
+    password,
+    email_confirm: true,
+  })
+
+  if (authError) {
+    const msg = (authError as { message?: string }).message ?? ''
+    if (msg.includes('already registered') || msg.toLowerCase().includes('already exists')) {
+      return res.status(409).json({
+        success: false,
+        error: 'このメールアドレスは既に登録されています。ログインしてください。',
+      })
+    }
+    console.error('[invitations:accept] auth createUser error:', authError)
+    return res.status(500).json({ success: false, error: msg || 'ユーザの作成に失敗しました' })
+  }
+
+  const userId = authData?.user?.id
+  if (!userId) {
+    return res.status(500).json({ success: false, error: 'ユーザの作成に失敗しました' })
+  }
+
+  // 4. users テーブルにレコードを作成
+  const roleArray = Array.isArray(invitationData.role) ? invitationData.role : []
+  const userRole = roleArray.some((r: string) => r.includes('管理者')) ? 'admin' : 'staff'
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: userError } = await (db as any).from('users').upsert(
+    {
+      id: userId,
+      email: invitationData.email,
+      role: userRole,
+      organization_id: invitationData.organization_id, // 招待の組織を強制
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'id' }
+  )
+
+  if (userError) {
+    console.error('[invitations:accept] user upsert error:', userError)
+  }
+
+  // 5. staff テーブルにレコードを作成
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: staffData, error: staffError } = await (db as any)
+    .from('staff')
+    .insert({
+      name: invitationData.name || invitationData.email?.split('@')[0] || '',
+      email: invitationData.email,
+      user_id: userId,
+      organization_id: invitationData.organization_id, // 招待の組織を強制
+      role: invitationData.role,
+      status: 'active',
+      stores: [],
+      ng_days: [],
+      want_to_learn: [],
+      available_scenarios: [],
+      availability: [],
+      experience: 0,
+      special_scenarios: [],
+    })
+    .select()
+    .single()
+
+  if (staffError) {
+    console.error('[invitations:accept] staff insert error:', staffError)
+    // スタッフ作成失敗でも続行（後で修正可能）
+  }
+
+  // 6. 招待に staff_id を紐付け
+  if (staffData?.id && invitationData.id) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: linkError } = await (db as any)
+      .from('organization_invitations')
+      .update({ staff_id: staffData.id })
+      .eq('id', invitationData.id)
+    if (linkError) {
+      console.error('[invitations:accept] link staff error:', linkError)
+    }
+  }
+
+  return res.status(200).json({ success: true })
+}

--- a/api/private-booking-notifications.ts
+++ b/api/private-booking-notifications.ts
@@ -1,0 +1,144 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError, type AuthUser } from './_lib/auth.js'
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+
+    if (req.method === 'POST') {
+      const action = (req.query.action as string | undefined) ?? 'resend-discord'
+      if (action === 'resend-discord') return await handleResendDiscord(req, res, user)
+      return res.status(400).json({ error: `unknown action: ${action}` })
+    }
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[private-booking-notifications] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// Discord 通知再送信
+// マルチテナント境界:
+// - reservation の organization_id をサーバ側で取得し、ユーザの所属組織と一致を検証
+// - 検証後、service_role 経由で Edge Function (notify-private-booking-discord) を invoke する
+async function handleResendDiscord(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+
+  const body = req.body as {
+    id?: string
+    scenario_master_id?: string
+    scenario_title?: string
+    customer_name?: string
+    customer_email?: string
+    customer_phone?: string
+    participant_count?: number
+    candidate_datetimes?: unknown
+    notes?: string
+    created_at?: string
+  }
+
+  const bookingId = body.id
+  if (!bookingId) {
+    return res.status(400).json({ error: 'id（予約ID）は必須です' })
+  }
+
+  // 予約の組織を検証（フロントから受け取った record はマルチテナント境界の根拠にしない）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: reservation, error: lookupErr } = await (db as any)
+    .from('reservations')
+    .select('id, organization_id, scenario_master_id')
+    .eq('id', bookingId)
+    .maybeSingle()
+  if (lookupErr) {
+    console.error('[pb-notifications:resend] lookup error:', lookupErr)
+    return res.status(500).json({ error: '予約情報の取得に失敗しました' })
+  }
+  if (!reservation) {
+    return res.status(404).json({ error: '予約が見つかりません' })
+  }
+  if (reservation.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の予約は操作できません' })
+  }
+
+  // Edge Function に転送（DB から取得した正規の organization_id / scenario_master_id を付与）
+  // SUPABASE_URL は db.ts と同じ参照
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(500).json({ error: 'Edge Function 呼び出し用の環境変数が未設定です' })
+  }
+
+  const payload = {
+    type: 'resend',
+    table: 'reservations',
+    record: {
+      id: bookingId,
+      organization_id: reservation.organization_id,
+      scenario_id: reservation.scenario_master_id ?? body.scenario_master_id,
+      scenario_title: body.scenario_title,
+      customer_name: body.customer_name,
+      customer_email: body.customer_email,
+      customer_phone: body.customer_phone,
+      participant_count: body.participant_count,
+      candidate_datetimes: body.candidate_datetimes,
+      notes: body.notes,
+      created_at: body.created_at,
+    },
+  }
+
+  try {
+    const fnRes = await fetch(`${supabaseUrl}/functions/v1/notify-private-booking-discord`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // service_role JWT で Edge Function に対して system-call とみなされる
+        'Authorization': `Bearer ${serviceRoleKey}`,
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (!fnRes.ok) {
+      const text = await fnRes.text().catch(() => '')
+      console.error('[pb-notifications:resend] edge fn error:', fnRes.status, text)
+      return res.status(502).json({
+        success: false,
+        error: 'Discord通知の再送信に失敗しました',
+        detail: text || `HTTP ${fnRes.status}`,
+      })
+    }
+
+    const result = await fnRes.json().catch(() => ({}))
+    return res.status(200).json({ success: true, data: result })
+  } catch (err) {
+    console.error('[pb-notifications:resend] fetch error:', err)
+    return res.status(500).json({
+      success: false,
+      error: 'Discord通知の再送信に失敗しました',
+      detail: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/src/lib/api/externalReportsApi.ts
+++ b/src/lib/api/externalReportsApi.ts
@@ -1,173 +1,116 @@
 /**
  * 外部公演報告 API
+ *
+ * バックエンド API (/api/external-reports) 経由で
+ * 全 read/write を実行する。マルチテナント境界は API 側で強制される。
  */
 import { logger } from '@/utils/logger'
-import { supabase } from '@/lib/supabase'
-import { getCurrentOrganizationId } from '@/lib/organization'
+import { apiClient, ApiClientError } from '@/lib/apiClient'
 import type { ExternalPerformanceReport, LicensePerformanceSummary } from '@/types'
 
 /**
  * 外部公演報告を作成
+ * - organization_id はサーバ側で JWT から取得され、リクエストボディの値は無視される
  */
 export async function createExternalReport(
-  report: Omit<ExternalPerformanceReport, 'id' | 'status' | 'reviewed_by' | 'reviewed_at' | 'rejection_reason' | 'created_at' | 'updated_at'>
+  report: Omit<
+    ExternalPerformanceReport,
+    'id' | 'status' | 'reviewed_by' | 'reviewed_at' | 'rejection_reason' | 'created_at' | 'updated_at'
+  >
 ): Promise<ExternalPerformanceReport | null> {
-  const { data, error } = await supabase
-    .from('external_performance_reports')
-    .insert({
+  try {
+    return await apiClient.post<ExternalPerformanceReport>('/api/external-reports', {
       scenario_master_id: report.scenario_master_id,
-      organization_id: report.organization_id,
+      // organization_id はサーバ側で強制されるため送信不要だが互換のため残す
       reported_by: report.reported_by,
       performance_date: report.performance_date,
       performance_count: report.performance_count,
       participant_count: report.participant_count,
       venue_name: report.venue_name,
       notes: report.notes,
-      status: 'pending',
     })
-    .select()
-    .single()
-
-  if (error) {
+  } catch (error) {
     logger.error('Failed to create external report:', error)
     throw error
   }
-
-  return data as ExternalPerformanceReport
 }
 
 /**
  * 外部公演報告一覧を取得（自組織の報告）
  */
 export async function getMyExternalReports(): Promise<ExternalPerformanceReport[]> {
-  const orgId = await getCurrentOrganizationId()
-  
-  let query = supabase
-    .from('external_performance_reports')
-    .select(`
-      *,
-      scenario_masters:scenario_master_id (id, title, author),
-      reporter:reported_by (id, name),
-      reviewer:reviewed_by (id, name)
-    `)
-    .order('created_at', { ascending: false })
-
-  if (orgId) {
-    query = query.eq('organization_id', orgId)
-  }
-
-  const { data, error } = await query
-
-  if (error) {
+  try {
+    return await apiClient.get<ExternalPerformanceReport[]>('/api/external-reports?type=mine')
+  } catch (error) {
     logger.error('Failed to fetch external reports:', error)
     throw error
   }
-
-  return data as ExternalPerformanceReport[]
 }
 
 /**
  * 全ての外部公演報告を取得（ライセンス管理組織用）
+ *
+ * - license_admin は全組織を閲覧可能（organizationId 指定可）
+ * - その他のスタッフは自組織のみ（organizationId 指定は無視される）
  */
-export async function getAllExternalReports(
-  filters?: {
-    status?: 'pending' | 'approved' | 'rejected'
-    startDate?: string
-    endDate?: string
-    scenarioId?: string
-    organizationId?: string
-  }
-): Promise<ExternalPerformanceReport[]> {
-  let query = supabase
-    .from('external_performance_reports')
-    .select(`
-      *,
-      scenario_masters:scenario_master_id (id, title, author),
-      organizations:organization_id (id, name, slug),
-      reporter:reported_by (id, name),
-      reviewer:reviewed_by (id, name)
-    `)
-    .order('created_at', { ascending: false })
-
-  if (filters?.status) {
-    query = query.eq('status', filters.status)
-  }
-  if (filters?.startDate) {
-    query = query.gte('performance_date', filters.startDate)
-  }
-  if (filters?.endDate) {
-    query = query.lte('performance_date', filters.endDate)
-  }
-  if (filters?.scenarioId) {
-    query = query.eq('scenario_master_id', filters.scenarioId)
-  }
-  if (filters?.organizationId) {
-    query = query.eq('organization_id', filters.organizationId)
-  }
-
-  const { data, error } = await query
-
-  if (error) {
+export async function getAllExternalReports(filters?: {
+  status?: 'pending' | 'approved' | 'rejected'
+  startDate?: string
+  endDate?: string
+  scenarioId?: string
+  organizationId?: string
+}): Promise<ExternalPerformanceReport[]> {
+  try {
+    const params = new URLSearchParams({ type: 'all' })
+    if (filters?.status) params.set('status', filters.status)
+    if (filters?.startDate) params.set('startDate', filters.startDate)
+    if (filters?.endDate) params.set('endDate', filters.endDate)
+    if (filters?.scenarioId) params.set('scenarioId', filters.scenarioId)
+    if (filters?.organizationId) params.set('organizationId', filters.organizationId)
+    return await apiClient.get<ExternalPerformanceReport[]>(`/api/external-reports?${params.toString()}`)
+  } catch (error) {
     logger.error('Failed to fetch all external reports:', error)
     throw error
   }
-
-  return data as ExternalPerformanceReport[]
 }
 
 /**
- * 外部公演報告を承認
+ * 外部公演報告を承認（license_admin のみ）
  */
 export async function approveExternalReport(
   reportId: string,
   reviewerId: string
 ): Promise<ExternalPerformanceReport | null> {
-  const { data, error } = await supabase
-    .from('external_performance_reports')
-    .update({
-      status: 'approved',
-      reviewed_by: reviewerId,
-      reviewed_at: new Date().toISOString(),
-      rejection_reason: null,
-    })
-    .eq('id', reportId)
-    .select()
-    .single()
-
-  if (error) {
+  try {
+    const params = new URLSearchParams({ id: reportId, action: 'approve' })
+    return await apiClient.patch<ExternalPerformanceReport>(
+      `/api/external-reports?${params.toString()}`,
+      { reviewerId }
+    )
+  } catch (error) {
     logger.error('Failed to approve external report:', error)
     throw error
   }
-
-  return data as ExternalPerformanceReport
 }
 
 /**
- * 外部公演報告を却下
+ * 外部公演報告を却下（license_admin のみ）
  */
 export async function rejectExternalReport(
   reportId: string,
   reviewerId: string,
   reason: string
 ): Promise<ExternalPerformanceReport | null> {
-  const { data, error } = await supabase
-    .from('external_performance_reports')
-    .update({
-      status: 'rejected',
-      reviewed_by: reviewerId,
-      reviewed_at: new Date().toISOString(),
-      rejection_reason: reason,
-    })
-    .eq('id', reportId)
-    .select()
-    .single()
-
-  if (error) {
+  try {
+    const params = new URLSearchParams({ id: reportId, action: 'reject' })
+    return await apiClient.patch<ExternalPerformanceReport>(
+      `/api/external-reports?${params.toString()}`,
+      { reviewerId, reason }
+    )
+  } catch (error) {
     logger.error('Failed to reject external report:', error)
     throw error
   }
-
-  return data as ExternalPerformanceReport
 }
 
 /**
@@ -175,95 +118,80 @@ export async function rejectExternalReport(
  */
 export async function updateExternalReport(
   reportId: string,
-  updates: Partial<Pick<ExternalPerformanceReport, 'performance_date' | 'performance_count' | 'participant_count' | 'venue_name' | 'notes'>>
+  updates: Partial<
+    Pick<
+      ExternalPerformanceReport,
+      'performance_date' | 'performance_count' | 'participant_count' | 'venue_name' | 'notes'
+    >
+  >
 ): Promise<ExternalPerformanceReport | null> {
-  const { data, error } = await supabase
-    .from('external_performance_reports')
-    .update(updates)
-    .eq('id', reportId)
-    .eq('status', 'pending')  // pending のみ更新可能
-    .select()
-    .single()
-
-  if (error) {
+  try {
+    const params = new URLSearchParams({ id: reportId, action: 'update' })
+    return await apiClient.patch<ExternalPerformanceReport>(
+      `/api/external-reports?${params.toString()}`,
+      updates
+    )
+  } catch (error) {
     logger.error('Failed to update external report:', error)
     throw error
   }
-
-  return data as ExternalPerformanceReport
 }
 
 /**
  * 外部公演報告を削除（pending 状態のみ）
  */
 export async function deleteExternalReport(reportId: string): Promise<boolean> {
-  const { error } = await supabase
-    .from('external_performance_reports')
-    .delete()
-    .eq('id', reportId)
-    .eq('status', 'pending')  // pending のみ削除可能
-
-  if (error) {
+  try {
+    await apiClient.delete<{ success: boolean }>(
+      `/api/external-reports?id=${encodeURIComponent(reportId)}`
+    )
+    return true
+  } catch (error) {
     logger.error('Failed to delete external report:', error)
     throw error
   }
-
-  return true
 }
 
 /**
- * ライセンス集計サマリーを取得
+ * ライセンス集計サマリーを取得（license_admin のみ）
  */
-export async function getLicensePerformanceSummary(
-  filters?: {
-    startDate?: string
-    endDate?: string
-    authorName?: string
-  }
-): Promise<LicensePerformanceSummary[]> {
-  // ビューから取得
-  const { data, error } = await supabase
-    .from('license_performance_summary')
-    .select('scenario_master_id, scenario_title, author, license_amount, internal_performance_count, external_performance_count, total_performance_count, total_license_fee')
-
-  if (error) {
+export async function getLicensePerformanceSummary(filters?: {
+  startDate?: string
+  endDate?: string
+  authorName?: string
+}): Promise<LicensePerformanceSummary[]> {
+  try {
+    const params = new URLSearchParams({ type: 'license-summary' })
+    if (filters?.startDate) params.set('startDate', filters.startDate)
+    if (filters?.endDate) params.set('endDate', filters.endDate)
+    if (filters?.authorName) params.set('authorName', filters.authorName)
+    return await apiClient.get<LicensePerformanceSummary[]>(
+      `/api/external-reports?${params.toString()}`
+    )
+  } catch (error) {
+    // license_admin 以外で 403 が返るケースは旧挙動でも空配列ではないため伝播
+    if (error instanceof ApiClientError && error.status === 403) {
+      logger.warn('License summary requires license_admin role')
+      return []
+    }
     logger.error('Failed to fetch license performance summary:', error)
     throw error
   }
-
-  let result = data as LicensePerformanceSummary[]
-
-  // フィルター適用（クライアント側）
-  if (filters?.authorName) {
-    result = result.filter(r => r.author === filters.authorName)
-  }
-
-  return result
 }
 
 /**
  * 管理シナリオ一覧を取得（報告フォーム用）
  * organization_scenarios_with_master を使用（組織固有の license_amount を含む）
  */
-export async function getManagedScenarios(): Promise<Array<{ id: string; title: string; author: string; license_amount: number }>> {
-  const orgId = await getCurrentOrganizationId()
-  let query = supabase
-    .from('organization_scenarios_with_master')
-    .select('id, title, author, license_amount')
-    .eq('status', 'available')
-    .order('title')
-
-  if (orgId) {
-    query = query.eq('organization_id', orgId)
-  }
-
-  const { data, error } = await query
-
-  if (error) {
+export async function getManagedScenarios(): Promise<
+  Array<{ id: string; title: string; author: string; license_amount: number }>
+> {
+  try {
+    return await apiClient.get<Array<{ id: string; title: string; author: string; license_amount: number }>>(
+      '/api/external-reports?type=managed-scenarios'
+    )
+  } catch (error) {
     logger.error('Failed to fetch managed scenarios:', error)
     throw error
   }
-
-  return data || []
 }
-

--- a/src/lib/api/invitationsApi.ts
+++ b/src/lib/api/invitationsApi.ts
@@ -1,12 +1,39 @@
 /**
  * 組織招待 API
+ *
+ * バックエンド API (/api/invitations) 経由で全ての read/write を実行する。
+ * - 管理者専用エンドポイント（一覧/作成/削除/再送信）は JWT で認証
+ * - 招待受諾画面用エンドポイント（getByToken/accept）は未ログインからもアクセス可能
+ *   （token 自体が秘密情報のため、token を知っているクライアントのみ操作可能）
  */
 import { logger } from '@/utils/logger'
-import { supabase } from '@/lib/supabase'
+import { apiClient } from '@/lib/apiClient'
 import type { OrganizationInvitation } from '@/types'
 
+// ----------------------------------------------------------------------------
+// 公開エンドポイント用の fetch ヘルパー（apiClient は JWT 必須なので使えない）
+// ----------------------------------------------------------------------------
+async function publicFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+    const err = new Error(body?.error ?? `API エラー: ${res.status}`) as Error & { status?: number }
+    err.status = res.status
+    throw err
+  }
+  return res.json() as Promise<T>
+}
+
 /**
- * 招待を作成
+ * 招待を作成（admin 専用）
+ * - organization_id はサーバ側で JWT から取得され、リクエストボディの値は無視される
+ * - created_by もサーバ側で JWT から取得される
  */
 export async function createInvitation(params: {
   organization_id: string
@@ -16,32 +43,16 @@ export async function createInvitation(params: {
   created_by?: string
 }): Promise<{ data: OrganizationInvitation | null; error: Error | null }> {
   try {
-    // トークン生成（クライアント側で生成）
-    const token = crypto.randomUUID() + '-' + Date.now().toString(36)
-    
-    // 有効期限: 7日後
-    const expires_at = new Date()
-    expires_at.setDate(expires_at.getDate() + 7)
-
-    const { data, error } = await supabase
-      .from('organization_invitations')
-      .insert({
-        organization_id: params.organization_id,
-        email: params.email.toLowerCase().trim(),
-        name: params.name.trim(),
-        role: params.role || ['スタッフ'],
-        token,
-        expires_at: expires_at.toISOString(),
-        created_by: params.created_by,
-      })
-      .select(`
-        *,
-        organization:organizations(*)
-      `)
-      .single()
-
-    if (error) throw error
-    return { data: data as OrganizationInvitation, error: null }
+    const data = await apiClient.post<OrganizationInvitation>(
+      '/api/invitations?action=create',
+      {
+        // organization_id / created_by はサーバ側で強制されるため送信不要（互換のため受ける）
+        email: params.email,
+        name: params.name,
+        role: params.role,
+      }
+    )
+    return { data, error: null }
   } catch (error) {
     logger.error('Failed to create invitation:', error)
     return { data: null, error: error as Error }
@@ -49,23 +60,17 @@ export async function createInvitation(params: {
 }
 
 /**
- * トークンで招待を取得
+ * トークンで招待を取得（公開エンドポイント）
+ * 招待受諾画面で未ログインユーザがアクセスする。
  */
 export async function getInvitationByToken(
   token: string
 ): Promise<{ data: OrganizationInvitation | null; error: Error | null }> {
   try {
-    const { data, error } = await supabase
-      .from('organization_invitations')
-      .select(`
-        *,
-        organization:organizations(*)
-      `)
-      .eq('token', token)
-      .single()
-
-    if (error) throw error
-    return { data: data as OrganizationInvitation, error: null }
+    const data = await publicFetch<OrganizationInvitation>(
+      `/api/invitations?token=${encodeURIComponent(token)}`
+    )
+    return { data, error: null }
   } catch (error) {
     logger.error('Failed to get invitation:', error)
     return { data: null, error: error as Error }
@@ -73,123 +78,28 @@ export async function getInvitationByToken(
 }
 
 /**
- * 招待を受諾（パスワード設定 & ユーザー作成）
- * 🔒 アトミック処理により競合状態を防止
+ * 招待を受諾（公開エンドポイント、パスワード設定 & ユーザー作成）
+ *
+ * サーバ側で:
+ *  1. accept_invitation_atomic RPC でアトミックに受諾
+ *  2. auth ユーザ作成（service_role 経由 admin.createUser）
+ *  3. users / staff テーブルにレコード作成（organization_id は招待のものを強制）
+ *  4. 招待に staff_id を紐付け
  */
 export async function acceptInvitation(params: {
   token: string
   password: string
 }): Promise<{ success: boolean; error: string | null }> {
   try {
-    // 🔒 1. アトミックに招待を受諾（競合状態を防止）
-    // この時点で招待が「使用済み」になり、他のリクエストは失敗する
-    const { data: atomicResult, error: atomicError } = await supabase
-      .rpc('accept_invitation_atomic', { p_token: params.token })
-
-    if (atomicError) {
-      logger.error('Failed to accept invitation atomically:', atomicError)
-      return { success: false, error: '招待の処理中にエラーが発生しました' }
-    }
-
-    const invitationResult = atomicResult?.[0] || atomicResult
-    if (!invitationResult?.success) {
-      return { success: false, error: invitationResult?.error_message || '招待の受諾に失敗しました' }
-    }
-
-    // 2. 招待情報を取得（詳細情報が必要な場合）
-    const { data: invitation, error: inviteError } = await getInvitationByToken(params.token)
-    if (inviteError || !invitation) {
-      // アトミック処理は成功しているが、詳細取得に失敗
-      // invitationResultの情報を使用
-      logger.warn('Could not fetch invitation details, using atomic result')
-    }
-
-    const invitationData = invitation || {
-      id: invitationResult.id,
-      email: invitationResult.email,
-      role: invitationResult.role,
-      organization_id: invitationResult.organization_id,
-      name: '',
-    }
-
-    // 3. Supabase Auth でユーザーを作成
-    const { data: authData, error: authError } = await supabase.auth.signUp({
-      email: invitationData.email,
-      password: params.password,
-    })
-
-    if (authError) {
-      // 既存ユーザーの場合
-      if (authError.message.includes('already registered')) {
-        return { success: false, error: 'このメールアドレスは既に登録されています。ログインしてください。' }
+    const data = await publicFetch<{ success: boolean; error?: string }>(
+      '/api/invitations?action=accept',
+      {
+        method: 'POST',
+        body: JSON.stringify({ token: params.token, password: params.password }),
       }
-      throw authError
-    }
-
-    const userId = authData.user?.id
-    if (!userId) {
-      return { success: false, error: 'ユーザーの作成に失敗しました' }
-    }
-
-    // 4. users テーブルにレコードを作成
-    const userRole = Array.isArray(invitationData.role) 
-      ? (invitationData.role.some((r: string) => r.includes('管理者')) ? 'admin' : 'staff')
-      : (typeof invitationData.role === 'string' && invitationData.role.includes('管理者') ? 'admin' : 'staff')
-    
-    const { error: userError } = await supabase
-      .from('users')
-      .upsert({
-        id: userId,
-        email: invitationData.email,
-        role: userRole,
-        organization_id: invitationData.organization_id,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }, { onConflict: 'id' })
-
-    if (userError) {
-      logger.error('Failed to create user record:', userError)
-    }
-
-    // 5. staff テーブルにレコードを作成
-    const { data: staffData, error: staffError } = await supabase
-      .from('staff')
-      .insert({
-        name: invitationData.name || invitationData.email?.split('@')[0] || '',
-        email: invitationData.email,
-        user_id: userId,
-        organization_id: invitationData.organization_id,
-        role: invitationData.role,
-        status: 'active',
-        stores: [],
-        ng_days: [],
-        want_to_learn: [],
-        available_scenarios: [],
-        availability: [],
-        experience: 0,
-        special_scenarios: [],
-      })
-      .select()
-      .single()
-
-    if (staffError) {
-      logger.error('Failed to create staff record:', staffError)
-      // スタッフ作成に失敗しても続行（後で修正可能）
-    }
-
-    // 6. 招待にstaff_idを紐付け（アトミック処理でaccepted_atは既に設定済み）
-    if (staffData?.id && invitationData.id) {
-      const { error: updateError } = await supabase
-        .from('organization_invitations')
-        .update({ staff_id: staffData.id })
-        .eq('id', invitationData.id)
-
-      if (updateError) {
-        logger.error('Failed to link staff to invitation:', updateError)
-      }
-    }
-
-    return { success: true, error: null }
+    )
+    if (data.success) return { success: true, error: null }
+    return { success: false, error: data.error ?? '招待の受諾に失敗しました' }
   } catch (error) {
     logger.error('Failed to accept invitation:', error)
     return { success: false, error: (error as Error).message }
@@ -197,23 +107,16 @@ export async function acceptInvitation(params: {
 }
 
 /**
- * 組織の招待一覧を取得
+ * 組織の招待一覧を取得（admin 専用）
+ *
+ * 引数の organizationId は互換のため受けるが、サーバ側で JWT 経由の自組織に強制されるため無視される。
  */
 export async function getInvitationsByOrganization(
-  organizationId: string
+  _organizationId: string
 ): Promise<{ data: OrganizationInvitation[]; error: Error | null }> {
   try {
-    const { data, error } = await supabase
-      .from('organization_invitations')
-      .select(`
-        *,
-        organization:organizations(*)
-      `)
-      .eq('organization_id', organizationId)
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return { data: data as OrganizationInvitation[], error: null }
+    const data = await apiClient.get<OrganizationInvitation[]>('/api/invitations')
+    return { data, error: null }
   } catch (error) {
     logger.error('Failed to get invitations:', error)
     return { data: [], error: error as Error }
@@ -221,18 +124,15 @@ export async function getInvitationsByOrganization(
 }
 
 /**
- * 招待を削除
+ * 招待を削除（admin 専用、自組織のみ）
  */
 export async function deleteInvitation(
   invitationId: string
 ): Promise<{ success: boolean; error: Error | null }> {
   try {
-    const { error } = await supabase
-      .from('organization_invitations')
-      .delete()
-      .eq('id', invitationId)
-
-    if (error) throw error
+    await apiClient.delete<{ success: boolean }>(
+      `/api/invitations?id=${encodeURIComponent(invitationId)}`
+    )
     return { success: true, error: null }
   } catch (error) {
     logger.error('Failed to delete invitation:', error)
@@ -241,34 +141,20 @@ export async function deleteInvitation(
 }
 
 /**
- * 招待を再送信（新しいトークンを生成）
+ * 招待を再送信（admin 専用、新しいトークンを生成）
  */
 export async function resendInvitation(
   invitationId: string
 ): Promise<{ data: OrganizationInvitation | null; error: Error | null }> {
   try {
-    const token = crypto.randomUUID() + '-' + Date.now().toString(36)
-    const expires_at = new Date()
-    expires_at.setDate(expires_at.getDate() + 7)
-
-    const { data, error } = await supabase
-      .from('organization_invitations')
-      .update({
-        token,
-        expires_at: expires_at.toISOString(),
-      })
-      .eq('id', invitationId)
-      .select(`
-        *,
-        organization:organizations(*)
-      `)
-      .single()
-
-    if (error) throw error
-    return { data: data as OrganizationInvitation, error: null }
+    const params = new URLSearchParams({ id: invitationId, action: 'resend' })
+    const data = await apiClient.patch<OrganizationInvitation>(
+      `/api/invitations?${params.toString()}`,
+      {}
+    )
+    return { data, error: null }
   } catch (error) {
     logger.error('Failed to resend invitation:', error)
     return { data: null, error: error as Error }
   }
 }
-

--- a/src/lib/api/privateBookingNotificationApi.ts
+++ b/src/lib/api/privateBookingNotificationApi.ts
@@ -1,4 +1,11 @@
-import { supabase } from '@/lib/supabase'
+/**
+ * 貸切予約 Discord 通知 API
+ *
+ * バックエンド API (/api/private-booking-notifications) 経由で実行する。
+ * - サーバ側で予約の organization_id がユーザの所属組織と一致するか検証
+ * - 検証後、Edge Function (notify-private-booking-discord) を service_role で invoke
+ */
+import { apiClient } from '@/lib/apiClient'
 import { logger } from '@/utils/logger'
 
 interface ResendBookingData {
@@ -30,35 +37,26 @@ export async function resendPrivateBookingDiscordNotification(
   booking: ResendBookingData
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const { data, error } = await supabase.functions.invoke(
-      'notify-private-booking-discord',
+    const result = await apiClient.post<{ success: boolean; data?: unknown }>(
+      '/api/private-booking-notifications?action=resend-discord',
       {
-        body: {
-          type: 'resend',
-          table: 'reservations',
-          record: {
-            id: booking.id,
-            scenario_id: booking.scenario_master_id,
-            scenario_title: booking.scenario_title,
-            customer_name: booking.customer_name,
-            customer_email: booking.customer_email,
-            customer_phone: booking.customer_phone,
-            participant_count: booking.participant_count,
-            candidate_datetimes: booking.candidate_datetimes,
-            notes: booking.notes,
-            created_at: booking.created_at,
-          },
-        },
+        id: booking.id,
+        scenario_master_id: booking.scenario_master_id,
+        scenario_title: booking.scenario_title,
+        customer_name: booking.customer_name,
+        customer_email: booking.customer_email,
+        customer_phone: booking.customer_phone,
+        participant_count: booking.participant_count,
+        candidate_datetimes: booking.candidate_datetimes,
+        notes: booking.notes,
+        created_at: booking.created_at,
       }
     )
-
-    if (error) {
-      logger.error('Discord通知再送信エラー:', error)
-      return { success: false, error: error.message || 'Discord通知の再送信に失敗しました' }
+    if (result.success) {
+      logger.log('Discord通知再送信成功:', result.data)
+      return { success: true }
     }
-
-    logger.log('Discord通知再送信成功:', data)
-    return { success: true }
+    return { success: false, error: 'Discord通知の再送信に失敗しました' }
   } catch (err) {
     logger.error('Discord通知再送信例外:', err)
     return {


### PR DESCRIPTION
## Summary

3 つのフロント API を全てバックエンド API (/api/*) 経由に切り替え、マルチテナント境界を **サーバ側で強制** する。`organization_id` はフロントから受け取らず、必ず JWT 経由で取得する。

- `externalReportsApi` → `/api/external-reports`
- `invitationsApi` → `/api/invitations`
- `privateBookingNotificationApi` → `/api/private-booking-notifications`

## エンドポイント一覧

### `api/external-reports.ts`
| Method | クエリ | 説明 | 認可 |
| --- | --- | --- | --- |
| GET | `?type=mine` | 自組織レポート一覧 | staff |
| GET | `?type=all&status=&startDate=&endDate=&scenarioId=&organizationId=` | 全レポート | license_admin は全組織 / 他は自組織のみ |
| GET | `?type=license-summary&authorName=` | ライセンス集計サマリー（ビュー） | license_admin のみ |
| GET | `?type=managed-scenarios` | 自組織で報告可能なシナリオ一覧 | staff |
| POST | `(body)` | レポート作成（organization_id は JWT 強制、scenario_master_id と reported_by は自組織所属チェック） | staff |
| PATCH | `?id=&action=update` | pending レポート更新（自組織のみ） | staff |
| PATCH | `?id=&action=approve` | レポート承認 | license_admin のみ |
| PATCH | `?id=&action=reject` | レポート却下（reason 必須） | license_admin のみ |
| DELETE | `?id=` | pending レポート削除（自組織のみ） | staff |

### `api/invitations.ts`
| Method | クエリ | 説明 | 認可 |
| --- | --- | --- | --- |
| GET | `?token=xxx` | トークンで招待取得（受諾画面用） | **公開**（token を知るクライアントのみ） |
| POST | `?action=accept` | 招待受諾（パスワード設定＋ユーザ作成） | **公開**（token ベース） |
| GET | (なし) | 自組織の招待一覧 | admin |
| POST | `?action=create` | 招待作成（organization_id / created_by は JWT 強制） | admin |
| PATCH | `?id=&action=resend` | 招待再送（新トークン発行、自組織のみ） | admin |
| DELETE | `?id=` | 招待削除（自組織のみ） | admin |

### `api/private-booking-notifications.ts`
| Method | クエリ | 説明 | 認可 |
| --- | --- | --- | --- |
| POST | `?action=resend-discord` | Discord 通知再送（予約の organization_id を再取得して自組織一致を検証 → service_role で Edge Function 呼び出し） | staff |

## マルチテナント境界方針

1. **org_id は JWT 経由でサーバ側取得**：フロントから受け取らない。`requireAuth()` が `public.users.organization_id` を必ず参照する。
2. **書き込み前に所有組織を検証**：
   - external_reports: update/delete 前に対象 report の `organization_id` を取得し、`user.orgId` と一致を確認。
   - invitations: resend/delete 前に対象招待の `organization_id` を取得し検証。
   - private_booking_notifications: 予約 `id` で `reservations.organization_id` を取得し検証してから Edge Function に転送。
3. **license_admin 専用権限**：`getAllExternalReports`（他組織閲覧）、`approveExternalReport`、`rejectExternalReport`、`getLicensePerformanceSummary` は `requireLicenseAdmin` で限定。
4. **公開エンドポイントの設計**：
   - `getInvitationByToken` / `acceptInvitation` は未ログインユーザがアクセスするため認証不要。
   - token は秘密情報として扱い、サーバ側で token 検証 → アトミック受諾 → users/staff レコード作成時に **招待の organization_id を強制適用**（フロントから組織 ID を受けない）。
5. **service_role の使用**：RLS バイパスのため、上記の所有組織検証をサーバコードで明示的に実施することで境界を担保。

## TODO / 注意

- `getLicensePerformanceSummary` は旧コードが RLS 任せだったため、保守的に `license_admin` のみに限定（コメント内 TODO）。業務要件に応じて `admin` の追加も検討。
- `accept` フローは service_role の `auth.admin.createUser` を使用。`email_confirm: true` でメール確認をスキップ（招待リンク経由＝確認済みとみなす）。

## Test plan

- [ ] `npx tsc -p tsconfig.json --noEmit` （ローカルで pass 済み）
- [ ] `node scripts/check-security-guardrails.mjs` exit 0（ローカルで pass 済み）
- [ ] `npm run lint` 致命的エラー無し（ローカルで 0 errors / 58 既存 warnings）
- [ ] ステージング環境で
  - [ ] 外部公演報告 一覧取得 / 作成 / 編集（pending） / 削除（pending）
  - [ ] license_admin での承認 / 却下 / license summary 取得
  - [ ] license_admin での全組織横断クエリ、別組織 admin からの組織越境アクセスが拒否されること
  - [ ] 招待一覧取得 / 作成 / 再送 / 削除
  - [ ] 招待受諾フロー（公開リンク → パスワード設定 → ログイン）
  - [ ] 貸切予約 Discord 通知の再送（自組織 / 他組織予約 ID で 403 になること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)