### PR TITLE
feat(api): staffApi/storeApi の write 系をバックエンドに移行（マルチテナント境界強化）

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -70,6 +70,12 @@ export function requireStaff(user: AuthUser): void {
   }
 }
 
+export function requireAdmin(user: AuthUser): void {
+  if (!['admin', 'license_admin'].includes(user.role)) {
+    throw new ApiError(403, '管理者権限が必要です')
+  }
+}
+
 export function requireLicenseAdmin(user: AuthUser): void {
   if (user.role !== 'license_admin') {
     throw new ApiError(403, 'ライセンス管理者権限が必要です')

--- a/api/staff.ts
+++ b/api/staff.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { db, getMissingEnvError } from './_lib/db.js'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
+import { requireAuth, requireStaff, requireAdmin, ApiError, type AuthUser } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,
@@ -12,7 +12,7 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
@@ -21,10 +21,40 @@ function setCors(req: VercelRequest, res: VercelResponse) {
 const STAFF_SELECT_FIELDS =
   'id, organization_id, name, line_name, x_account, discord_id:discord_user_id, discord_channel_id, role, stores, ng_days, want_to_learn, available_scenarios, notes, phone, email, user_id, availability, experience, special_scenarios, status, avatar_url, avatar_color, created_at, updated_at'
 
+// 作成可能フィールドのホワイトリスト（Mass Assignment 防止）
+const STAFF_CREATABLE_FIELDS = [
+  'name', 'line_name', 'x_account', 'discord_user_id', 'discord_channel_id',
+  'role', 'stores', 'ng_days', 'want_to_learn', 'available_scenarios',
+  'notes', 'phone', 'email', 'user_id', 'availability', 'experience',
+  'special_scenarios', 'status', 'avatar_url', 'avatar_color',
+] as const
+
+// 更新可能フィールドのホワイトリスト（Mass Assignment 防止）
+const STAFF_UPDATABLE_FIELDS = [
+  'name', 'line_name', 'x_account', 'discord_user_id', 'discord_channel_id',
+  'role', 'stores', 'ng_days', 'want_to_learn', 'available_scenarios',
+  'notes', 'phone', 'email', 'availability', 'experience',
+  'special_scenarios', 'status', 'avatar_url', 'avatar_color',
+] as const
+
+function pickFields<T extends readonly string[]>(
+  src: Record<string, unknown>,
+  allowed: T,
+  renameMap?: Record<string, string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(src)) {
+    const targetKey = renameMap?.[key] ?? key
+    if ((allowed as readonly string[]).includes(targetKey)) {
+      out[targetKey] = src[key]
+    }
+  }
+  return out
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
 
   const envError = getMissingEnvError()
   if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
@@ -33,22 +63,381 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const user = await requireAuth(req)
     requireStaff(user)
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data, error } = await (db as any)
-      .from('staff')
-      .select(STAFF_SELECT_FIELDS)
-      .eq('organization_id', user.orgId)
-      .order('name', { ascending: true })
-
-    if (error) {
-      console.error('[staff] DB error:', error)
-      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
-    }
-
-    return res.status(200).json(data ?? [])
+    if (req.method === 'GET') return await handleGet(req, res, user)
+    if (req.method === 'POST') return await handlePost(req, res, user)
+    if (req.method === 'PATCH') return await handlePatch(req, res, user)
+    if (req.method === 'DELETE') return await handleDelete(req, res, user)
+    return res.status(405).json({ error: 'Method not allowed' })
   } catch (err) {
     if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
     console.error('[staff] unexpected error:', err)
     return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+async function handleGet(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  const userId = req.query.user_id as string | undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  if (id) {
+    const { data, error } = await database
+      .from('staff')
+      .select(STAFF_SELECT_FIELDS)
+      .eq('id', id)
+      .eq('organization_id', user.orgId)
+      .maybeSingle()
+    if (error && error.code !== 'PGRST116') {
+      console.error('[staff:getById] DB error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? null)
+  }
+
+  if (userId) {
+    const { data, error } = await database
+      .from('staff')
+      .select(STAFF_SELECT_FIELDS)
+      .eq('user_id', userId)
+      .eq('organization_id', user.orgId)
+      .maybeSingle()
+    if (error && error.code !== 'PGRST116') {
+      console.error('[staff:getByUserId] DB error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? null)
+  }
+
+  const { data, error } = await database
+    .from('staff')
+    .select(STAFF_SELECT_FIELDS)
+    .eq('organization_id', user.orgId)
+    .order('name', { ascending: true })
+
+  if (error) {
+    console.error('[staff] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// ─── POST: スタッフ作成（admin 専用）────────────────────────────────────────
+async function handlePost(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireAdmin(user)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const body = (req.body ?? {}) as Record<string, unknown>
+
+  // discord_id → discord_user_id への alias を解決
+  const renameMap: Record<string, string> = { discord_id: 'discord_user_id' }
+  const insertRow = pickFields(body, STAFF_CREATABLE_FIELDS, renameMap)
+
+  // 名前は必須
+  if (!insertRow.name || typeof insertRow.name !== 'string') {
+    return res.status(400).json({ error: 'name は必須です' })
+  }
+
+  // user_id を指定する場合、自組織のユーザーかチェック（別組織のユーザーを strap しない）
+  if (insertRow.user_id) {
+    if (typeof insertRow.user_id !== 'string') {
+      return res.status(400).json({ error: 'user_id が不正です' })
+    }
+    const { data: targetUser, error: userErr } = await database
+      .from('users')
+      .select('id, organization_id')
+      .eq('id', insertRow.user_id)
+      .maybeSingle()
+    if (userErr) {
+      console.error('[staff:create] user lookup error:', userErr)
+      return res.status(500).json({ error: 'ユーザー情報の確認に失敗しました' })
+    }
+    if (!targetUser) {
+      return res.status(400).json({ error: '指定された user_id のユーザーが存在しません' })
+    }
+    if (targetUser.organization_id && targetUser.organization_id !== user.orgId) {
+      return res.status(403).json({ error: '他組織のユーザーをスタッフとして登録できません' })
+    }
+  }
+
+  // organization_id はサーバー側で強制（フロントからの上書きを許可しない）
+  insertRow.organization_id = user.orgId
+
+  const { data, error } = await database
+    .from('staff')
+    .insert([insertRow])
+    .select(STAFF_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[staff:create] DB error:', error)
+    return res.status(500).json({ error: 'スタッフの作成に失敗しました', detail: error.message })
+  }
+  return res.status(201).json(data)
+}
+
+// ─── PATCH: スタッフ更新 ─────────────────────────────────────────────────────
+async function handlePatch(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  const action = req.query.action as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 自組織のスタッフであることを必ず確認
+  const { data: existing, error: existingErr } = await database
+    .from('staff')
+    .select('id, organization_id, name, user_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (existingErr) {
+    console.error('[staff:update] existing lookup error:', existingErr)
+    return res.status(500).json({ error: 'スタッフ情報の確認に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: 'スタッフが見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織のスタッフは編集できません' })
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+
+  // ─── action=updateSpecialScenarios（担当シナリオ + organization_scenarios.available_gms 同期）
+  if (action === 'updateSpecialScenarios') {
+    const special = body.special_scenarios
+    if (!Array.isArray(special) || !special.every((s) => typeof s === 'string')) {
+      return res.status(400).json({ error: 'special_scenarios は string[] 必須です' })
+    }
+    return await handleUpdateSpecialScenarios(res, database, user.orgId, id, existing.name, special)
+  }
+
+  // ─── 通常の update
+  const renameMap: Record<string, string> = { discord_id: 'discord_user_id' }
+  const updateRow = pickFields(body, STAFF_UPDATABLE_FIELDS, renameMap)
+
+  // role 変更は admin のみ
+  if ('role' in updateRow) {
+    requireAdmin(user)
+  }
+
+  if (Object.keys(updateRow).length === 0) {
+    return res.status(400).json({ error: '更新可能なフィールドがありません' })
+  }
+
+  const { data, error } = await database
+    .from('staff')
+    .update(updateRow)
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+    .select(STAFF_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[staff:update] DB error:', error)
+    return res.status(500).json({ error: 'スタッフの更新に失敗しました', detail: error.message })
+  }
+
+  // ─── 名前変更時の副作用: schedule_events.gms / reservations.assigned_staff・gm_staff の同期
+  const newName = typeof updateRow.name === 'string' ? updateRow.name : null
+  const oldName = existing.name as string | null
+  if (newName && oldName && newName !== oldName) {
+    await syncRenamedStaffReferences(database, user.orgId, oldName, newName)
+  }
+
+  // ─── role 変更時の副作用: users.role の同期
+  if ('role' in updateRow && existing.user_id) {
+    await syncStaffRoleToUser(database, existing.user_id as string, updateRow.role)
+  }
+
+  return res.status(200).json(data)
+}
+
+// ─── DELETE: スタッフ削除（admin 専用）───────────────────────────────────────
+async function handleDelete(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireAdmin(user)
+
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 自組織のスタッフであることを必ず確認
+  const { data: existing, error: existingErr } = await database
+    .from('staff')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (existingErr) {
+    console.error('[staff:delete] existing lookup error:', existingErr)
+    return res.status(500).json({ error: 'スタッフ情報の確認に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: 'スタッフが見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織のスタッフは削除できません' })
+  }
+
+  const { error } = await database
+    .from('staff')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+
+  if (error) {
+    console.error('[staff:delete] DB error:', error)
+    return res.status(500).json({ error: 'スタッフの削除に失敗しました', detail: error.message })
+  }
+  return res.status(204).end()
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+async function handleUpdateSpecialScenarios(
+  res: VercelResponse,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  database: any,
+  orgId: string,
+  staffId: string,
+  staffName: string,
+  specialScenarios: string[],
+) {
+  // 1. スタッフの special_scenarios を更新
+  const { data: updatedStaff, error: updErr } = await database
+    .from('staff')
+    .update({ special_scenarios: specialScenarios })
+    .eq('id', staffId)
+    .eq('organization_id', orgId)
+    .select(STAFF_SELECT_FIELDS)
+    .single()
+
+  if (updErr) {
+    console.error('[staff:updateSpecialScenarios] DB error:', updErr)
+    return res.status(500).json({ error: '担当シナリオの更新に失敗しました', detail: updErr.message })
+  }
+
+  // 2. 自組織のシナリオを取得して available_gms を同期
+  const { data: scenarios, error: scErr } = await database
+    .from('organization_scenarios')
+    .select('id, scenario_master_id, available_gms')
+    .eq('organization_id', orgId)
+
+  if (scErr) {
+    console.error('[staff:updateSpecialScenarios] scenarios fetch error:', scErr)
+    // 部分成功: スタッフ自体は更新済みなので 200 で返す
+    return res.status(200).json(updatedStaff)
+  }
+
+  const updatePromises = (scenarios ?? []).map(
+    async (s: { id: string; scenario_master_id: string; available_gms: string[] | null }) => {
+      const current: string[] = s.available_gms ?? []
+      const shouldHaveStaff = specialScenarios.includes(s.scenario_master_id)
+      const hasStaff = current.includes(staffName)
+      let next: string[] = current
+      if (shouldHaveStaff && !hasStaff) next = [...current, staffName]
+      else if (!shouldHaveStaff && hasStaff) next = current.filter((g) => g !== staffName)
+      else return
+      if (JSON.stringify([...next].sort()) === JSON.stringify([...current].sort())) return
+      await database
+        .from('organization_scenarios')
+        .update({ available_gms: next })
+        .eq('id', s.id)
+        .eq('organization_id', orgId)
+    },
+  )
+  await Promise.all(updatePromises)
+
+  return res.status(200).json(updatedStaff)
+}
+
+async function syncRenamedStaffReferences(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  database: any,
+  orgId: string,
+  oldName: string,
+  newName: string,
+) {
+  // schedule_events.gms 配列の同期
+  try {
+    const { data: events } = await database
+      .from('schedule_events')
+      .select('id, gms')
+      .eq('organization_id', orgId)
+      .contains('gms', [oldName])
+    if (events && events.length > 0) {
+      await Promise.all(
+        events.map((ev: { id: string; gms: string[] | null }) => {
+          const nextGms = (ev.gms ?? []).map((g) => (g === oldName ? newName : g))
+          return database
+            .from('schedule_events')
+            .update({ gms: nextGms })
+            .eq('id', ev.id)
+            .eq('organization_id', orgId)
+        }),
+      )
+    }
+  } catch (e) {
+    console.warn('[staff:syncRenamed] schedule_events sync warn:', e)
+  }
+
+  // reservations.assigned_staff / gm_staff の同期
+  try {
+    // PostgREST フィルタ用のサニタイズ（カンマ・括弧・ダブルクオートのみエスケープ）
+    const safe = oldName.replace(/[",()]/g, ' ')
+    const { data: reservations } = await database
+      .from('reservations')
+      .select('id, assigned_staff, gm_staff')
+      .eq('organization_id', orgId)
+      .or(`assigned_staff.cs.{${safe}},gm_staff.eq.${safe}`)
+    if (reservations && reservations.length > 0) {
+      await Promise.all(
+        reservations.map(
+          async (r: { id: string; assigned_staff: string[] | null; gm_staff: string | null }) => {
+            const updates: Record<string, unknown> = {}
+            if (r.assigned_staff && r.assigned_staff.includes(oldName)) {
+              updates.assigned_staff = r.assigned_staff.map((s) => (s === oldName ? newName : s))
+            }
+            if (r.gm_staff === oldName) {
+              updates.gm_staff = newName
+            }
+            if (Object.keys(updates).length === 0) return
+            await database.rpc('admin_update_reservation_fields', {
+              p_reservation_id: r.id,
+              p_updates: updates,
+            })
+          },
+        ),
+      )
+    }
+  } catch (e) {
+    console.warn('[staff:syncRenamed] reservations sync warn:', e)
+  }
+}
+
+async function syncStaffRoleToUser(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  database: any,
+  userId: string,
+  role: unknown,
+) {
+  const roles = Array.isArray(role) ? role : [role]
+  const isAdmin = roles.some((r) => r === 'admin' || r === '管理者')
+  const userRole = isAdmin ? 'admin' : 'staff'
+
+  try {
+    const { data: existingUser } = await database
+      .from('users')
+      .select('role')
+      .eq('id', userId)
+      .maybeSingle()
+    // 既存が admin で、更新後が staff なら降格しない
+    if (existingUser?.role === 'admin' && userRole === 'staff') return
+    await database
+      .from('users')
+      .update({ role: userRole, updated_at: new Date().toISOString() })
+      .eq('id', userId)
+  } catch (e) {
+    console.warn('[staff:syncRole] users.role sync warn:', e)
   }
 }

--- a/api/stores.ts
+++ b/api/stores.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { db, getMissingEnvError } from './_lib/db.js'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
+import { requireAuth, requireStaff, requireAdmin, ApiError, type AuthUser } from './_lib/auth.js'
 
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,
@@ -12,7 +12,7 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
@@ -20,10 +20,34 @@ function setCors(req: VercelRequest, res: VercelResponse) {
 const STORE_SELECT_FIELDS =
   'id, organization_id, name, short_name, address, access_info, phone_number, email, opening_date, manager_name, status, ownership_type, franchise_fee, capacity, rooms, notes, color, fixed_costs, venue_cost_per_performance, is_temporary, temporary_date, temporary_dates, temporary_venue_names, display_order, region, transport_allowance, kit_group_id, created_at, updated_at'
 
+// 作成可能フィールドのホワイトリスト
+const STORE_CREATABLE_FIELDS = [
+  'name', 'short_name', 'address', 'access_info', 'phone_number', 'email',
+  'opening_date', 'manager_name', 'status', 'ownership_type', 'franchise_fee',
+  'capacity', 'rooms', 'notes', 'color', 'fixed_costs', 'venue_cost_per_performance',
+  'is_temporary', 'temporary_date', 'temporary_dates', 'temporary_venue_names',
+  'display_order', 'region', 'transport_allowance', 'kit_group_id',
+] as const
+
+// 更新可能フィールドのホワイトリスト（Mass Assignment 防止）
+const STORE_UPDATABLE_FIELDS = STORE_CREATABLE_FIELDS
+
+function pickFields<T extends readonly string[]>(
+  src: Record<string, unknown>,
+  allowed: T,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(src)) {
+    if ((allowed as readonly string[]).includes(key)) {
+      out[key] = src[key]
+    }
+  }
+  return out
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
 
   const envError = getMissingEnvError()
   if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
@@ -32,21 +56,232 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const user = await requireAuth(req)
     requireStaff(user)
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data, error } = await (db as any)
-      .from('stores')
-      .select(STORE_SELECT_FIELDS)
-      .eq('organization_id', user.orgId)
-
-    if (error) {
-      console.error('[stores] DB error:', error)
-      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
-    }
-
-    return res.status(200).json(data ?? [])
+    if (req.method === 'GET') return await handleGet(req, res, user)
+    if (req.method === 'POST') return await handlePost(req, res, user)
+    if (req.method === 'PATCH') return await handlePatch(req, res, user)
+    if (req.method === 'DELETE') return await handleDelete(req, res, user)
+    return res.status(405).json({ error: 'Method not allowed' })
   } catch (err) {
     if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
     console.error('[stores] unexpected error:', err)
     return res.status(500).json({ error: 'サーバーエラーが発生しました' })
   }
+}
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+async function handleGet(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  if (id) {
+    const { data, error } = await database
+      .from('stores')
+      .select(STORE_SELECT_FIELDS)
+      .eq('id', id)
+      .eq('organization_id', user.orgId)
+      .maybeSingle()
+    if (error && error.code !== 'PGRST116') {
+      console.error('[stores:getById] DB error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? null)
+  }
+
+  const { data, error } = await database
+    .from('stores')
+    .select(STORE_SELECT_FIELDS)
+    .eq('organization_id', user.orgId)
+
+  if (error) {
+    console.error('[stores] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// ─── POST: 店舗作成（admin 専用）─────────────────────────────────────────────
+async function handlePost(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireAdmin(user)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const insertRow = pickFields(body, STORE_CREATABLE_FIELDS)
+
+  if (!insertRow.name || typeof insertRow.name !== 'string') {
+    return res.status(400).json({ error: 'name は必須です' })
+  }
+
+  // organization_id はサーバー側で強制
+  insertRow.organization_id = user.orgId
+
+  const { data, error } = await database
+    .from('stores')
+    .insert([insertRow])
+    .select(STORE_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[stores:create] DB error:', error)
+    return res.status(500).json({ error: '店舗の作成に失敗しました', detail: error.message })
+  }
+  return res.status(201).json(data)
+}
+
+// ─── PATCH ───────────────────────────────────────────────────────────────────
+async function handlePatch(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = req.query.action as string | undefined
+
+  // ─── action=updateDisplayOrder（一括更新）
+  if (action === 'updateDisplayOrder') {
+    requireAdmin(user)
+    return await handleUpdateDisplayOrder(req, res, user)
+  }
+
+  requireAdmin(user)
+
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 自組織の店舗であることを必ず確認
+  const { data: existing, error: existingErr } = await database
+    .from('stores')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (existingErr) {
+    console.error('[stores:update] existing lookup error:', existingErr)
+    return res.status(500).json({ error: '店舗情報の確認に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: '店舗が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の店舗は編集できません' })
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updateRow = pickFields(body, STORE_UPDATABLE_FIELDS)
+  if (Object.keys(updateRow).length === 0) {
+    return res.status(400).json({ error: '更新可能なフィールドがありません' })
+  }
+
+  const { data, error } = await database
+    .from('stores')
+    .update(updateRow)
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+    .select(STORE_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[stores:update] DB error:', error)
+    return res.status(500).json({ error: '店舗の更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// ─── DELETE: 店舗削除（admin 専用）───────────────────────────────────────────
+async function handleDelete(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireAdmin(user)
+
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  const { data: existing, error: existingErr } = await database
+    .from('stores')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (existingErr) {
+    console.error('[stores:delete] existing lookup error:', existingErr)
+    return res.status(500).json({ error: '店舗情報の確認に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: '店舗が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の店舗は削除できません' })
+  }
+
+  const { error } = await database
+    .from('stores')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+
+  if (error) {
+    console.error('[stores:delete] DB error:', error)
+    return res.status(500).json({ error: '店舗の削除に失敗しました', detail: error.message })
+  }
+  return res.status(204).end()
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+async function handleUpdateDisplayOrder(
+  req: VercelRequest,
+  res: VercelResponse,
+  user: AuthUser,
+) {
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const orders = body.orders
+  if (!Array.isArray(orders)) {
+    return res.status(400).json({ error: 'orders は配列必須です' })
+  }
+  for (const o of orders) {
+    if (
+      !o || typeof o !== 'object' ||
+      typeof (o as { id?: unknown }).id !== 'string' ||
+      typeof (o as { display_order?: unknown }).display_order !== 'number'
+    ) {
+      return res.status(400).json({ error: 'orders の要素は { id: string; display_order: number } である必要があります' })
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 対象 ID を一度に取得し、全て自組織のものか検証
+  const ids = (orders as Array<{ id: string }>).map((o) => o.id)
+  const { data: existingStores, error: lookupErr } = await database
+    .from('stores')
+    .select('id, organization_id')
+    .in('id', ids)
+  if (lookupErr) {
+    console.error('[stores:updateDisplayOrder] lookup error:', lookupErr)
+    return res.status(500).json({ error: '店舗情報の確認に失敗しました' })
+  }
+  const orgIds = new Set(
+    (existingStores ?? []).map((s: { id: string; organization_id: string }) => s.organization_id),
+  )
+  if (orgIds.size > 1 || (orgIds.size === 1 && !orgIds.has(user.orgId))) {
+    return res.status(403).json({ error: '他組織の店舗が含まれています' })
+  }
+  const foundIds = new Set((existingStores ?? []).map((s: { id: string }) => s.id))
+  for (const id of ids) {
+    if (!foundIds.has(id)) {
+      return res.status(404).json({ error: `店舗が見つかりません: ${id}` })
+    }
+  }
+
+  // 並列で更新（organization_id チェックを必ず付ける）
+  const updates = (orders as Array<{ id: string; display_order: number }>).map(
+    ({ id, display_order }) =>
+      database
+        .from('stores')
+        .update({ display_order })
+        .eq('id', id)
+        .eq('organization_id', user.orgId),
+  )
+  const results = await Promise.all(updates)
+  const errors = results.filter((r) => r.error)
+  if (errors.length > 0) {
+    console.error('[stores:updateDisplayOrder] update errors:', errors.map((e) => e.error))
+    return res.status(500).json({ error: '表示順序の更新に失敗しました' })
+  }
+  return res.status(204).end()
 }

--- a/src/lib/api/staffApi.ts
+++ b/src/lib/api/staffApi.ts
@@ -1,26 +1,24 @@
 /**
  * スタッフ関連API
+ *
+ * 通常時はバックエンド API (/api/staff) 経由で取得・更新し、
+ * organization_id はサーバー側で JWT から強制取得する（マルチテナント境界）。
+ *
+ * skipOrgFilter=true（ライセンス管理者の全組織取得）のみ Supabase 直接クエリを使う。
  */
 import { supabase } from '../supabase'
-import type { RpcAdminUpdateReservationFieldsParams } from '@/lib/rpcTypes'
-import { getCurrentOrganizationId } from '@/lib/organization'
 import { apiClient } from '@/lib/apiClient'
-import { sanitizeForPostgRestFilter } from '@/lib/utils'
-import { logger } from '@/utils/logger'
 import type { Staff } from '@/types'
 
 // NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
 const STAFF_SELECT_FIELDS =
   // DB側は discord_user_id。フロントの既存実装（discord_id）に合わせて alias する。
-  // NOTE: staff.display_name がDBに無い環境があるため、selectに含めない（含めるとPostgRESTが400になる）
   'id, organization_id, name, line_name, x_account, discord_id:discord_user_id, discord_channel_id, role, stores, ng_days, want_to_learn, available_scenarios, notes, phone, email, user_id, availability, experience, special_scenarios, status, avatar_url, avatar_color, created_at, updated_at' as const
 
 export const staffApi = {
   // 全スタッフを取得
   // organizationId: 後方互換のため引数は残すがバックエンド経由ではサーバー側で JWT から取得するため未使用
   // skipOrgFilter: trueの場合、組織フィルタをスキップ（全組織のデータを取得、Supabase 直接クエリ）
-  //
-  // 通常時はバックエンド API (/api/staff) 経由で取得し、org_id をサーバー側で強制フィルタする。
   async getAll(organizationId?: string, skipOrgFilter?: boolean): Promise<Staff[]> {
     if (skipOrgFilter) {
       // skipOrgFilter=true（ライセンス管理者の全組織取得）は Supabase 直接クエリ
@@ -36,269 +34,39 @@ export const staffApi = {
     return apiClient.get<Staff[]>('/api/staff')
   },
 
-  // スタッフを作成
+  // スタッフを作成（admin 権限が必要）
   async create(staff: Omit<Staff, 'id' | 'created_at' | 'updated_at'>): Promise<Staff> {
-    // organization_idを自動取得（マルチテナント対応）
-    const organizationId = await getCurrentOrganizationId()
-    if (!organizationId) {
-      throw new Error('組織情報が取得できません。再ログインしてください。')
-    }
-    
-    // DBカラム名へ変換（後方互換）
-    const { discord_id, ...rest } = staff as Staff & { discord_id?: string }
-    const insertRow: Record<string, unknown> = { ...rest, organization_id: organizationId }
-    if (discord_id !== undefined) insertRow.discord_user_id = discord_id
-
-    const { data, error } = await supabase
-      .from('staff')
-      .insert([insertRow])
-      .select()
-      .single()
-    
-    if (error) throw error
-    return data
+    return apiClient.post<Staff>('/api/staff', staff)
   },
 
-  // スタッフを更新
+  // スタッフを更新（role 変更は admin 権限が必要）
+  //
+  // 名前変更時は、サーバー側で schedule_events.gms / reservations.assigned_staff・gm_staff
+  // を自動で同期する。
   async update(id: string, updates: Partial<Staff>): Promise<Staff> {
-    // 名前が変更される場合、古い名前を取得
-    let oldName: string | null = null
-    if (updates.name) {
-      const { data: oldData, error: fetchError } = await supabase
-        .from('staff')
-        .select('name')
-        .eq('id', id)
-        .single()
-      
-      if (fetchError) throw fetchError
-      oldName = oldData.name
-    }
-    
-    // DBに存在しないフィールドを除外（UIで追加される仮想フィールド）
-    const { experienced_scenarios, discord_id, ...dbUpdates } = updates as Staff & {
-      experienced_scenarios?: string[]
-      discord_id?: string
-    }
-
-    // ⚠️ Mass Assignment 防止: 更新可能フィールドのホワイトリスト
-    const STAFF_UPDATABLE_FIELDS = [
-      'name', 'line_name', 'x_account', 'discord_user_id', 'discord_channel_id',
-      'role', 'stores', 'ng_days', 'want_to_learn', 'available_scenarios',
-      'notes', 'phone', 'email', 'availability', 'experience',
-      'special_scenarios', 'status', 'avatar_url', 'avatar_color', 'display_name',
-    ] as const
-    const updateRow: Record<string, unknown> = {}
-    if (discord_id !== undefined) updateRow.discord_user_id = discord_id
-    for (const key of Object.keys(dbUpdates)) {
-      if ((STAFF_UPDATABLE_FIELDS as readonly string[]).includes(key)) {
-        updateRow[key] = (dbUpdates as Record<string, unknown>)[key]
-      }
-    }
-    
-    // スタッフ情報を更新
-    const { data, error } = await supabase
-      .from('staff')
-      .update(updateRow)
-      .eq('id', id)
-      .select()
-      .single()
-    
-    if (error) throw error
-    
-    // 名前が変更された場合、スケジュールと予約も更新
-    if (oldName && updates.name && oldName !== updates.name) {
-      const newName = updates.name
-      // ⚠️ P1-15: 組織IDでフィルタして他組織のデータを変更しない
-      const orgId = await getCurrentOrganizationId()
-      
-      // 1. schedule_eventsのgms配列を更新
-      let scheduleQuery = supabase
-        .from('schedule_events_staff_view')
-        .select('id, gms')
-        .contains('gms', [oldName])
-      if (orgId) scheduleQuery = scheduleQuery.eq('organization_id', orgId)
-
-      const { data: scheduleEvents, error: scheduleError } = await scheduleQuery
-      
-      if (!scheduleError && scheduleEvents && scheduleEvents.length > 0) {
-        const updatePromises = scheduleEvents.map(event => {
-          const newGms = (event.gms || []).map((gm: string) => gm === oldName ? newName : gm)
-          return supabase
-            .from('schedule_events')
-            .update({ gms: newGms })
-            .eq('id', event.id)
-        })
-        
-        await Promise.all(updatePromises)
-      }
-      
-      // 2. reservationsのassigned_staff配列を更新
-      // ⚠️ P1-16: サニタイズ — 名前に特殊文字が含まれる場合に備えてエスケープ
-      const safeOldName = sanitizeForPostgRestFilter(oldName) || oldName
-      let resQuery = supabase
-        .from('reservations')
-        .select('id, assigned_staff, gm_staff')
-        .or(`assigned_staff.cs.{${safeOldName}},gm_staff.eq.${safeOldName}`)
-      if (orgId) resQuery = resQuery.eq('organization_id', orgId)
-
-      const { data: reservations, error: resError } = await resQuery
-      
-      if (!resError && reservations && reservations.length > 0) {
-        const updatePromises = reservations.map(reservation => {
-          const updates: { assigned_staff?: string[]; gm_staff?: string } = {}
-          
-          // assigned_staff配列を更新
-          if (reservation.assigned_staff && reservation.assigned_staff.includes(oldName)) {
-            updates.assigned_staff = reservation.assigned_staff.map((s: string) => s === oldName ? newName : s)
-          }
-          
-          // gm_staffを更新
-          if (reservation.gm_staff === oldName) {
-            updates.gm_staff = newName
-          }
-          
-          const params: RpcAdminUpdateReservationFieldsParams = {
-            p_reservation_id: reservation.id,
-            p_updates: updates,
-          }
-          return supabase.rpc('admin_update_reservation_fields', params)
-        })
-        
-        await Promise.all(updatePromises)
-      }
-    }
-    
-    // 役割が変更された場合、usersテーブルのroleも更新
-    if (updates.role !== undefined && data.user_id) {
-      // スタッフの役割に応じてユーザーロールを決定
-      // role配列に「admin」または「管理者」が含まれていればadmin
-      const roles = Array.isArray(updates.role) ? updates.role : [updates.role]
-      const isAdmin = roles.some(r => r === 'admin' || r === '管理者')
-      const userRole = isAdmin ? 'admin' : 'staff'
-      
-      // 🚨 重要: 既存のadminロールを持つユーザーをstaffに降格させない
-      // usersテーブルの既存ロールを確認
-      const { data: existingUserData, error: existingUserError } = await supabase
-        .from('users')
-        .select('role')
-        .eq('id', data.user_id)
-        .maybeSingle()
-      
-      if (existingUserError) {
-        logger.warn('既存ユーザーロールの確認に失敗しました:', existingUserError)
-      }
-      
-      // 既存ロールがadminで、更新後がstaffの場合は降格をスキップ
-      if (existingUserData?.role === 'admin' && userRole === 'staff') {
-        logger.log(`スタッフ「${data.name}」の既存ロールがadminのため、staffへの降格をスキップしました`)
-      } else {
-        const { error: userRoleError } = await supabase
-          .from('users')
-          .update({ role: userRole, updated_at: new Date().toISOString() })
-          .eq('id', data.user_id)
-        
-        if (userRoleError) {
-          logger.warn('ユーザーロールの更新に失敗しました:', userRoleError)
-        } else {
-          logger.log(`スタッフ「${data.name}」の役割変更に伴い、ユーザーロールを${userRole}に更新しました`)
-        }
-      }
-    }
-    
-    return data
+    return apiClient.patch<Staff>(`/api/staff?id=${encodeURIComponent(id)}`, updates)
   },
 
-  // スタッフの担当シナリオを更新（シナリオのavailable_gmsも同期更新）
+  // スタッフの担当シナリオを更新（シナリオの available_gms も同期更新）
   async updateSpecialScenarios(id: string, specialScenarios: string[]): Promise<Staff> {
-    // スタッフ情報を取得
-    const { data: staffData, error: staffError } = await supabase
-      .from('staff')
-      .select('name, organization_id')
-      .eq('id', id)
-      .single()
-    
-    if (staffError) throw staffError
-    if (!staffData) throw new Error('スタッフが見つかりません')
+    return apiClient.patch<Staff>(
+      `/api/staff?id=${encodeURIComponent(id)}&action=updateSpecialScenarios`,
+      { special_scenarios: specialScenarios },
+    )
+  },
 
-    // スタッフの担当シナリオを更新
-    const { data: updatedStaff, error: updateError } = await supabase
-      .from('staff')
-      .update({ special_scenarios: specialScenarios })
-      .eq('id', id)
-      .select()
-      .single()
-    
-    if (updateError) throw updateError
-
-    // 組織のシナリオを取得して、各シナリオのavailable_gmsを更新
-    const { data: allScenarios, error: scenariosError } = await supabase
-      .from('organization_scenarios')
-      .select('id, scenario_master_id, available_gms')
-      .eq('organization_id', staffData.organization_id)
-    
-    if (scenariosError) throw scenariosError
-
-    // 各シナリオのavailable_gmsを更新
-    const updatePromises = allScenarios?.map(async (scenario) => {
-      const currentGms = scenario.available_gms || []
-      const staffName = staffData.name
-      
-      // specialScenarios には scenario_master_id が含まれる
-      const isAssigned = specialScenarios.includes(scenario.scenario_master_id)
-      const isCurrentlyAssigned = currentGms.includes(staffName)
-      
-      let newGms = [...currentGms]
-      
-      if (isAssigned && !isCurrentlyAssigned) {
-        newGms.push(staffName)
-      } else if (!isAssigned && isCurrentlyAssigned) {
-        newGms = newGms.filter(gm => gm !== staffName)
-      }
-      
-      // 変更がある場合のみ更新
-      if (JSON.stringify(newGms.sort()) !== JSON.stringify(currentGms.sort())) {
-        return supabase
-          .from('organization_scenarios')
-          .update({ available_gms: newGms })
-          .eq('id', scenario.id)
-      }
-      
-      return Promise.resolve()
-    }) || []
-
-    await Promise.all(updatePromises)
-
-    return updatedStaff
+  // スタッフを削除（admin 権限が必要）
+  async delete(id: string): Promise<void> {
+    await apiClient.delete<void>(`/api/staff?id=${encodeURIComponent(id)}`)
   },
 
   // IDでスタッフを取得
   async getById(id: string): Promise<Staff | null> {
-    const { data, error } = await supabase
-      .from('staff')
-      .select(STAFF_SELECT_FIELDS)
-      .eq('id', id)
-      .maybeSingle()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null
-      throw error
-    }
-    return data
+    return apiClient.get<Staff | null>(`/api/staff?id=${encodeURIComponent(id)}`)
   },
 
   // ユーザーIDでスタッフを取得
   async getByUserId(userId: string): Promise<Staff | null> {
-    const { data, error } = await supabase
-      .from('staff')
-      .select(STAFF_SELECT_FIELDS)
-      .eq('user_id', userId)
-      .maybeSingle()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null
-      throw error
-    }
-    return data
-  }
+    return apiClient.get<Staff | null>(`/api/staff?user_id=${encodeURIComponent(userId)}`)
+  },
 }
-

--- a/src/lib/api/storeApi.ts
+++ b/src/lib/api/storeApi.ts
@@ -1,8 +1,13 @@
 /**
  * 店舗関連API
+ *
+ * 通常時はバックエンド API (/api/stores) 経由で取得・更新し、
+ * organization_id はサーバー側で JWT から強制取得する（マルチテナント境界）。
+ *
+ * getAllPublic は未認証のお客様向け公開ページで使用するため、
+ * RLS で保護された stores_public ビューを Supabase 直接で読む。
  */
 import { supabase } from '../supabase'
-import { getCurrentOrganizationId } from '@/lib/organization'
 import { apiClient } from '@/lib/apiClient'
 import type { Store } from '@/types'
 
@@ -55,7 +60,7 @@ export const storeApi = {
         if (orderA !== orderB) return orderA - orderB
         return a.name.localeCompare(b.name, 'ja')
       }
-      
+
       // 通常の店舗同士はdisplay_order順
       const orderA = a.display_order ?? 999
       const orderB = b.display_order ?? 999
@@ -63,106 +68,44 @@ export const storeApi = {
       // 同じ順序の場合は名前順
       return a.name.localeCompare(b.name, 'ja')
     })
-    
+
     return sortedData
   },
 
   // 公開ページ用: 店舗一覧を取得（コスト情報を除外）
   // @param organizationId - 組織ID（必須）
+  // NOTE: 未認証の公開ページから呼ばれるため、RLS で保護された stores_public ビューを直接読む
   async getAllPublic(organizationId: string): Promise<Store[]> {
     const { data, error } = await supabase
       .from('stores_public')
       .select('id, organization_id, name, short_name, address, access_info, opening_date, status, ownership_type, capacity, rooms, color, is_temporary, temporary_date, temporary_dates, temporary_venue_names, display_order, region, kit_group_id, created_at, updated_at')
       .eq('organization_id', organizationId)
       .order('display_order', { ascending: true, nullsFirst: false })
-    
+
     if (error) throw error
     return (data || []) as Store[]
   },
 
-  // 店舗の表示順序を一括更新
+  // 店舗の表示順序を一括更新（admin 権限が必要）
   async updateDisplayOrder(storeOrders: { id: string; display_order: number }[]): Promise<void> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('組織情報が取得できません。再ログインしてください。')
-
-    // 並列で更新
-    const updates = storeOrders.map(({ id, display_order }) =>
-      supabase
-        .from('stores')
-        .update({ display_order })
-        .eq('id', id)
-        .eq('organization_id', orgId)
+    await apiClient.patch<void>(
+      '/api/stores?action=updateDisplayOrder',
+      { orders: storeOrders },
     )
-    
-    const results = await Promise.all(updates)
-    const errors = results.filter(r => r.error)
-    if (errors.length > 0) {
-      throw new Error('表示順序の更新に失敗しました')
-    }
   },
 
-  // 店舗を作成
+  // 店舗を作成（admin 権限が必要）
   async create(store: Omit<Store, 'id' | 'created_at' | 'updated_at'>): Promise<Store> {
-    // organization_idを自動取得（マルチテナント対応）
-    const organizationId = await getCurrentOrganizationId()
-    if (!organizationId) {
-      throw new Error('組織情報が取得できません。再ログインしてください。')
-    }
-    
-    const { data, error } = await supabase
-      .from('stores')
-      .insert([{ ...store, organization_id: organizationId }])
-      .select()
-      .single()
-    
-    if (error) throw error
-    return data
+    return apiClient.post<Store>('/api/stores', store)
   },
 
-  // 店舗を更新
+  // 店舗を更新（admin 権限が必要）
   async update(id: string, updates: Partial<Store>): Promise<Store> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('組織情報が取得できません。再ログインしてください。')
-
-    // ⚠️ Mass Assignment 防止: 更新可能フィールドのホワイトリスト
-    const STORE_UPDATABLE_FIELDS = [
-      'name', 'short_name', 'address', 'access_info', 'phone_number', 'email',
-      'opening_date', 'manager_name', 'status', 'ownership_type', 'franchise_fee',
-      'capacity', 'rooms', 'notes', 'color', 'fixed_costs', 'venue_cost_per_performance',
-      'is_temporary', 'temporary_date', 'temporary_dates', 'temporary_venue_names',
-      'display_order', 'region', 'transport_allowance', 'kit_group_id',
-    ] as const
-    const safeUpdates: Record<string, unknown> = {}
-    for (const key of Object.keys(updates)) {
-      if ((STORE_UPDATABLE_FIELDS as readonly string[]).includes(key)) {
-        safeUpdates[key] = (updates as Record<string, unknown>)[key]
-      }
-    }
-
-    const { data, error } = await supabase
-      .from('stores')
-      .update(safeUpdates)
-      .eq('id', id)
-      .eq('organization_id', orgId)
-      .select()
-      .single()
-    
-    if (error) throw error
-    return data
+    return apiClient.patch<Store>(`/api/stores?id=${encodeURIComponent(id)}`, updates)
   },
 
-  // 店舗を削除
+  // 店舗を削除（admin 権限が必要）
   async delete(id: string): Promise<void> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('組織情報が取得できません。再ログインしてください。')
-
-    const { error } = await supabase
-      .from('stores')
-      .delete()
-      .eq('id', id)
-      .eq('organization_id', orgId)
-    
-    if (error) throw error
-  }
+    await apiClient.delete<void>(`/api/stores?id=${encodeURIComponent(id)}`)
+  },
 }
-


### PR DESCRIPTION
## Summary

- `api/staff.ts` と `api/stores.ts` に POST / PATCH / DELETE ハンドラを追加し、フロントの `staffApi.create/update/delete/updateSpecialScenarios/getById/getByUserId` と `storeApi.create/update/delete/updateDisplayOrder` をすべてバックエンド API 経由に切り替えました。
- `organization_id` は JWT から取得した値でサーバー側で必ず上書き、対象レコードが自組織のものかを毎回検証することで、マルチテナント境界（service_role 利用時の RLS バイパス）を明示的に塞ぎました。
- スタッフ・店舗の作成/更新/削除と role 変更には新設の `requireAdmin` を強制。フィールドはホワイトリスト経由（Mass Assignment 防止）でのみ流し込みます。

## 新規エンドポイント

### `/api/staff`
- `GET /api/staff` — 自組織スタッフ一覧（既存）
- `GET /api/staff?id=<uuid>` — 自組織スタッフを ID で取得（新）
- `GET /api/staff?user_id=<uuid>` — 自組織スタッフを user_id で取得（新）
- `POST /api/staff` — スタッフ作成（admin 必須、`organization_id` はサーバー上書き、`user_id` 指定時は他組織のユーザーを strap しないかチェック）
- `PATCH /api/staff?id=<uuid>` — スタッフ更新（`role` 変更時は admin 必須、`discord_id` → `discord_user_id` の alias 解決、名前変更時は `schedule_events.gms` と `reservations.assigned_staff/gm_staff` を `admin_update_reservation_fields` RPC 経由で同期、`role` 変更時は `users.role` も同期）
- `PATCH /api/staff?id=<uuid>&action=updateSpecialScenarios` — 担当シナリオ更新 + 自組織の `organization_scenarios.available_gms` を同期
- `DELETE /api/staff?id=<uuid>` — スタッフ削除（admin 必須）

### `/api/stores`
- `GET /api/stores` — 自組織店舗一覧（既存）
- `GET /api/stores?id=<uuid>` — 自組織店舗を ID で取得（新）
- `POST /api/stores` — 店舗作成（admin 必須、`organization_id` はサーバー上書き）
- `PATCH /api/stores?id=<uuid>` — 店舗更新（admin 必須）
- `PATCH /api/stores?action=updateDisplayOrder` — 店舗の表示順序を一括更新（admin 必須、対象 ID が全て自組織のものかを事前検証）
- `DELETE /api/stores?id=<uuid>` — 店舗削除（admin 必須）

## セキュリティ強化点

- **org_id の強制サーバー取得**: フロントから受け取った `organization_id` は一切信用せず、`requireAuth` 経由で JWT から取得した値で必ず上書き。
- **対象レコードの org_id 検証**: update / delete は必ず対象を取得して `organization_id !== user.orgId` なら 403。`updateDisplayOrder` は一括取得して全件分検証。
- **権限分離**: `requireStaff` に加え新規 `requireAdmin` を導入。staff role 変更・staff/store の create/update/delete は admin のみ許可。
- **Mass Assignment 防止**: 作成・更新は `STAFF_CREATABLE_FIELDS` / `STAFF_UPDATABLE_FIELDS` / `STORE_CREATABLE_FIELDS` ホワイトリスト経由でのみ流し込み。
- **`user_id` の組織帰属チェック**: スタッフ作成時に他組織所属の `user_id` を割り当てられないようガード。
- **role 降格の保護**: 既存の admin ユーザーが staff に降格されないよう、`users.role` 同期時に分岐（既存ロジックを保持）。
- **`getAllPublic` は対象外**: 未認証の公開ページから呼ぶため、引き続き Supabase の RLS 保護された `stores_public` ビューを直接読む（コスト情報は含まない設計）。

## Test plan

- [ ] スタッフ一覧 / ID 取得 / user_id 取得が正しく自組織分のみ返ること
- [ ] スタッフ作成（admin で OK / 一般 staff で 403）
- [ ] スタッフ更新で role 変更が admin のみ通ること、一般 staff の通常項目更新は通ること
- [ ] スタッフ名変更で schedule_events.gms と reservations.assigned_staff/gm_staff が更新されること
- [ ] スタッフ削除が admin のみ通ること
- [ ] 担当シナリオ更新で `organization_scenarios.available_gms` が同期されること
- [ ] 他組織のスタッフ/店舗を id 指定で update/delete しようとして 403 になること
- [ ] 店舗作成 / 更新 / 削除 / display_order 一括更新が admin のみ通ること
- [ ] `updateDisplayOrder` で他組織の id を混ぜると 403 になること
- [ ] 公開ページ（PrivateBookingRequestPage 等）の `getAllPublic` は引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)