### PR TITLE
feat(api): customerApi/organizationSettingsApi の write 系をバックエンドに移行（マルチテナント境界強化）

### DIFF
--- a/api/customers.ts
+++ b/api/customers.ts
@@ -12,7 +12,7 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
@@ -20,10 +20,63 @@ function setCors(req: VercelRequest, res: VercelResponse) {
 const SELECT_FIELDS =
   'id, organization_id, user_id, name, nickname, email, email_verified, phone, address, line_id, notes, avatar_url, visit_count, total_spent, last_visit, preferences, notification_settings, created_at, updated_at'
 
+// 作成時に受け取れるフィールドのホワイトリスト
+// organization_id は受け取らない（JWT から強制）
+// user_id は受け取らない（他人/他組織の顧客を勝手に作るのを防ぐ。
+//   どうしても紐付けたい場合は管理画面側で別 API を作る）
+const CUSTOMER_CREATE_FIELDS = [
+  'name',
+  'nickname',
+  'email',
+  'email_verified',
+  'phone',
+  'address',
+  'line_id',
+  'notes',
+  'avatar_url',
+  'preferences',
+  'notification_settings',
+] as const
+
+// 更新可能フィールドのホワイトリスト（Mass Assignment 防止）
+// organization_id / user_id / id / created_at / updated_at / visit_count / total_spent
+// は更新不可（DB 側のトリガまたは集計関数が更新する想定）
+const CUSTOMER_UPDATABLE_FIELDS = [
+  'name',
+  'nickname',
+  'email',
+  'email_verified',
+  'phone',
+  'address',
+  'line_id',
+  'notes',
+  'avatar_url',
+  'preferences',
+  'notification_settings',
+  'last_visit',
+] as const
+
+function pickFields<T extends readonly string[]>(
+  source: Record<string, unknown>,
+  allowed: T,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(source)) {
+    if ((allowed as readonly string[]).includes(key)) {
+      out[key] = source[key]
+    }
+  }
+  return out
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  const method = req.method
+  if (method !== 'GET' && method !== 'POST' && method !== 'PATCH' && method !== 'DELETE') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
 
   const envError = getMissingEnvError()
   if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
@@ -32,22 +85,203 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const user = await requireAuth(req)
     requireStaff(user)
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data, error } = await (db as any)
-      .from('customers')
-      .select(SELECT_FIELDS)
-      .eq('organization_id', user.orgId)
-      .order('created_at', { ascending: false })
-
-    if (error) {
-      console.error('[customers] DB error:', error)
-      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
-    }
-
-    return res.status(200).json(data ?? [])
+    if (method === 'GET') return await routeGet(req, res, user.orgId)
+    if (method === 'POST') return await routePost(req, res, user.orgId)
+    if (method === 'PATCH') return await routePatch(req, res, user.orgId)
+    if (method === 'DELETE') return await routeDelete(req, res, user.orgId)
   } catch (err) {
     if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
     console.error('[customers] unexpected error:', err)
     return res.status(500).json({ error: 'サーバーエラーが発生しました' })
   }
+}
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+// /api/customers                  → 自組織の全顧客
+// /api/customers?action=findByEmail&email=...  → メールで自組織内検索
+// /api/customers?action=findByPhone&phone=...  → 電話で自組織内検索
+async function routeGet(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const action = req.query.action as string | undefined
+
+  if (action === 'findByEmail') {
+    const email = req.query.email as string | undefined
+    if (!email) return res.status(400).json({ error: 'email が必要です' })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (db as any)
+      .from('customers')
+      .select(SELECT_FIELDS)
+      .eq('organization_id', orgId)
+      .eq('email', email)
+      .maybeSingle()
+
+    if (error) {
+      console.error('[customers:findByEmail] DB error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? null)
+  }
+
+  if (action === 'findByPhone') {
+    const phone = req.query.phone as string | undefined
+    if (!phone) return res.status(400).json({ error: 'phone が必要です' })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (db as any)
+      .from('customers')
+      .select(SELECT_FIELDS)
+      .eq('organization_id', orgId)
+      .eq('phone', phone)
+      .maybeSingle()
+
+    if (error) {
+      console.error('[customers:findByPhone] DB error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? null)
+  }
+
+  // デフォルト: 自組織の全顧客
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('customers')
+    .select(SELECT_FIELDS)
+    .eq('organization_id', orgId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('[customers] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json(data ?? [])
+}
+
+// ─── POST: create ────────────────────────────────────────────────────────────
+// 自組織の顧客のみ作成可能（organization_id は JWT から強制）
+async function routePost(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const customer = (body.customer ?? body) as Record<string, unknown>
+  if (!customer || typeof customer !== 'object') {
+    return res.status(400).json({ error: 'customer が必要です' })
+  }
+
+  const name = customer.name as string | undefined
+  if (!name || typeof name !== 'string') {
+    return res.status(400).json({ error: 'name が必要です' })
+  }
+
+  // ホワイトリストでフィルタ（クライアントが organization_id / user_id を渡してきても無視）
+  const safe = pickFields(customer, CUSTOMER_CREATE_FIELDS)
+  // organization_id は JWT 由来で強制
+  ;(safe as Record<string, unknown>).organization_id = orgId
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('customers')
+    .insert([safe])
+    .select(SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[customers:create] DB error:', error)
+    return res.status(500).json({ error: '顧客の作成に失敗しました', detail: error.message })
+  }
+  return res.status(201).json(data)
+}
+
+// ─── PATCH: update ───────────────────────────────────────────────────────────
+// /api/customers?id=<uuid>
+// 自組織が所有する顧客のみ更新可能
+async function routePatch(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updates = (body.updates ?? body) as Record<string, unknown>
+  if (!updates || typeof updates !== 'object') {
+    return res.status(400).json({ error: 'updates が必要です' })
+  }
+
+  // マルチテナント境界チェック: 自組織が所有する顧客か確認
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existing, error: existingError } = await (db as any)
+    .from('customers')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (existingError) {
+    console.error('[customers:update] existence check error:', existingError)
+    return res.status(500).json({ error: '更新対象の確認に失敗しました', detail: existingError.message })
+  }
+  if (!existing || existing.organization_id !== orgId) {
+    return res.status(404).json({ error: '顧客が見つかりません' })
+  }
+
+  // ホワイトリストでフィルタ
+  const safeUpdates = pickFields(updates, CUSTOMER_UPDATABLE_FIELDS)
+  if (Object.keys(safeUpdates).length === 0) {
+    return res.status(400).json({ error: '更新可能なフィールドがありません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('customers')
+    .update(safeUpdates)
+    .eq('id', id)
+    .eq('organization_id', orgId) // 念のため二重ガード
+    .select(SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[customers:update] DB error:', error)
+    return res.status(500).json({ error: '顧客の更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// ─── DELETE ──────────────────────────────────────────────────────────────────
+// /api/customers?id=<uuid>
+// 自組織が所有する顧客のみ削除可能
+async function routeDelete(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  // マルチテナント境界チェック
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existing, error: existingError } = await (db as any)
+    .from('customers')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (existingError) {
+    console.error('[customers:delete] existence check error:', existingError)
+    return res.status(500).json({ error: '削除対象の確認に失敗しました', detail: existingError.message })
+  }
+  if (!existing || existing.organization_id !== orgId) {
+    return res.status(404).json({ error: '顧客が見つかりません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (db as any)
+    .from('customers')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', orgId) // 念のため二重ガード
+
+  if (error) {
+    console.error('[customers:delete] DB error:', error)
+    return res.status(500).json({ error: '顧客の削除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
 }

--- a/api/org-settings.ts
+++ b/api/org-settings.ts
@@ -12,7 +12,7 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, PATCH, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
@@ -25,10 +25,52 @@ const ORG_SETTINGS_SELECT_FIELDS =
 const ORG_SETTINGS_ALL_FIELDS =
   'id, organization_id, discord_bot_token, discord_webhook_url, discord_channel_id, discord_private_booking_channel_id, discord_shift_channel_id, discord_public_key, resend_api_key, sender_email, sender_name, reply_to_email, line_channel_access_token, line_channel_secret, google_sheets_id, google_service_account_key, notification_settings, time_slot_settings, custom_holidays, created_at, updated_at'
 
+// PATCH で更新可能な「非機密」フィールド（通常更新ルート）
+const NON_SECRET_UPDATABLE_FIELDS = [
+  'discord_webhook_url',
+  'discord_channel_id',
+  'discord_private_booking_channel_id',
+  'discord_shift_channel_id',
+  'discord_public_key',
+  'sender_email',
+  'sender_name',
+  'reply_to_email',
+  'google_sheets_id',
+  'notification_settings',
+  'time_slot_settings',
+  'custom_holidays',
+] as const
+
+// 機密フィールド（with_secrets=true 時のみ更新可能）
+const SECRET_UPDATABLE_FIELDS = [
+  'discord_bot_token',
+  'resend_api_key',
+  'line_channel_access_token',
+  'line_channel_secret',
+  'google_service_account_key',
+] as const
+
+function pickFields<T extends readonly string[]>(
+  source: Record<string, unknown>,
+  allowed: T,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(source)) {
+    if ((allowed as readonly string[]).includes(key)) {
+      out[key] = source[key]
+    }
+  }
+  return out
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  const method = req.method
+  if (method !== 'GET' && method !== 'PATCH') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
 
   const envError = getMissingEnvError()
   if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
@@ -37,25 +79,96 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const user = await requireAuth(req)
     requireStaff(user)
 
-    const withSecrets = req.query.with_secrets === 'true'
-    const fields = withSecrets ? ORG_SETTINGS_ALL_FIELDS : ORG_SETTINGS_SELECT_FIELDS
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data, error } = await (db as any)
-      .from('organization_settings')
-      .select(fields)
-      .eq('organization_id', user.orgId)
-      .maybeSingle()
-
-    if (error) {
-      console.error('[org-settings] DB error:', error)
-      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
-    }
-
-    return res.status(200).json(data ?? null)
+    if (method === 'GET') return await routeGet(req, res, user.orgId)
+    if (method === 'PATCH') return await routePatch(req, res, user.orgId)
   } catch (err) {
     if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
     console.error('[org-settings] unexpected error:', err)
     return res.status(500).json({ error: 'サーバーエラーが発生しました' })
   }
+}
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+async function routeGet(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const withSecrets = req.query.with_secrets === 'true'
+  const fields = withSecrets ? ORG_SETTINGS_ALL_FIELDS : ORG_SETTINGS_SELECT_FIELDS
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_settings')
+    .select(fields)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('[org-settings] DB error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json(data ?? null)
+}
+
+// ─── PATCH (upsert) ──────────────────────────────────────────────────────────
+// /api/org-settings                   → 非機密フィールドのみ部分更新（upsert）
+// /api/org-settings?with_secrets=true → 機密トークンも含めて更新可
+//
+// マルチテナント境界: organization_id は JWT 由来。クライアントが
+// payload に含めてきても無視する。
+async function routePatch(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const withSecrets = req.query.with_secrets === 'true'
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updates = (body.updates ?? body) as Record<string, unknown>
+  if (!updates || typeof updates !== 'object') {
+    return res.status(400).json({ error: 'updates が必要です' })
+  }
+
+  // 機密フィールド以外のフィルタ
+  const allowedFields = withSecrets
+    ? ([...NON_SECRET_UPDATABLE_FIELDS, ...SECRET_UPDATABLE_FIELDS] as const)
+    : NON_SECRET_UPDATABLE_FIELDS
+  const safeUpdates = pickFields(updates, allowedFields as readonly string[])
+
+  // with_secrets=false で機密フィールドが渡された場合は明示的にエラーで返す
+  // （無音で落とすと「保存できたつもり」になり危ない）
+  if (!withSecrets) {
+    const submittedSecretKeys = Object.keys(updates).filter((k) =>
+      (SECRET_UPDATABLE_FIELDS as readonly string[]).includes(k),
+    )
+    if (submittedSecretKeys.length > 0) {
+      return res.status(400).json({
+        error: '機密フィールドの更新には with_secrets=true が必要です',
+        detail: `secret fields: ${submittedSecretKeys.join(', ')}`,
+      })
+    }
+  }
+
+  if (Object.keys(safeUpdates).length === 0) {
+    return res.status(400).json({ error: '更新可能なフィールドがありません' })
+  }
+
+  // upsert: 1組織1行（organization_id に UNIQUE 制約あり）。
+  // organization_id は JWT 由来で強制。
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_settings')
+    .upsert(
+      {
+        ...safeUpdates,
+        organization_id: orgId,
+      },
+      { onConflict: 'organization_id' },
+    )
+    .select(withSecrets ? ORG_SETTINGS_ALL_FIELDS : ORG_SETTINGS_SELECT_FIELDS)
+    .single()
+
+  if (error) {
+    console.error('[org-settings:update] DB error:', error)
+    return res.status(500).json({ error: '設定の更新に失敗しました', detail: error.message })
+  }
+
+  return res.status(200).json(data)
 }

--- a/src/lib/api/organizationSettingsApi.ts
+++ b/src/lib/api/organizationSettingsApi.ts
@@ -1,19 +1,19 @@
 /**
  * 組織設定API
  * Discord/メール/通知設定を組織ごとに管理
+ *
+ * write 系（upsert / updateDiscordSettings / updateEmailSettings /
+ * updateNotificationSettings / updateTimeSlotSettings / updateCustomHolidays /
+ * addCustomHoliday / removeCustomHoliday）は全てバックエンド API
+ * (/api/org-settings) 経由で実行する。
+ *
+ * - organization_id はフロントから渡さず、サーバー側で JWT から強制取得（マルチテナント境界）
+ * - 機密フィールド（discord_bot_token / resend_api_key / line_channel_access_token /
+ *   line_channel_secret / google_service_account_key）の更新には with_secrets=true が必須
+ * - 非機密フィールドのみの更新ルートでは、誤って機密フィールドが渡された場合は
+ *   サーバー側で 400 エラーになる（無音で落とさない）
  */
-import { supabase } from '../supabase'
-import { getCurrentOrganizationId } from '@/lib/organization'
 import { apiClient } from '@/lib/apiClient'
-
-// NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
-// ⚠️ P1-17: 通常の取得では機密トークンを含めない（XSS 時の漏洩防止）
-const ORG_SETTINGS_SELECT_FIELDS =
-  'id, organization_id, discord_webhook_url, discord_channel_id, discord_private_booking_channel_id, discord_shift_channel_id, discord_public_key, sender_email, sender_name, reply_to_email, google_sheets_id, notification_settings, time_slot_settings, custom_holidays, created_at, updated_at' as const
-
-// 機密トークンを含む全フィールド（設定保存画面専用）
-const ORG_SETTINGS_ALL_FIELDS =
-  'id, organization_id, discord_bot_token, discord_webhook_url, discord_channel_id, discord_private_booking_channel_id, discord_shift_channel_id, discord_public_key, resend_api_key, sender_email, sender_name, reply_to_email, line_channel_access_token, line_channel_secret, google_sheets_id, google_service_account_key, notification_settings, time_slot_settings, custom_holidays, created_at, updated_at' as const
 
 // 時間帯設定の型
 export interface TimeSlotSetting {
@@ -35,7 +35,7 @@ export interface TimeSlotSettings {
 export interface OrganizationSettings {
   id: string
   organization_id: string
-  
+
   // Discord設定
   discord_bot_token?: string | null
   discord_webhook_url?: string | null
@@ -43,21 +43,21 @@ export interface OrganizationSettings {
   discord_private_booking_channel_id?: string | null
   discord_shift_channel_id?: string | null
   discord_public_key?: string | null
-  
+
   // メール設定
   resend_api_key?: string | null
   sender_email?: string | null
   sender_name?: string | null
   reply_to_email?: string | null
-  
+
   // LINE設定
   line_channel_access_token?: string | null
   line_channel_secret?: string | null
-  
+
   // Google設定
   google_sheets_id?: string | null
   google_service_account_key?: Record<string, unknown> | null
-  
+
   // 通知設定
   notification_settings?: {
     new_reservation_email?: boolean
@@ -67,15 +67,33 @@ export interface OrganizationSettings {
     shift_request_discord?: boolean
     reminder_email?: boolean
   }
-  
+
   // 公演時間帯設定
   time_slot_settings?: TimeSlotSettings
-  
+
   // カスタム休日（GW、年末年始など）
   custom_holidays?: string[]
-  
+
   created_at: string
   updated_at: string
+}
+
+// upsert 用ペイロード（id / created_at / updated_at は除外）
+type OrgSettingsUpsertPayload = Partial<Omit<OrganizationSettings, 'id' | 'created_at' | 'updated_at'>>
+
+// 機密フィールドのキー（クライアント側でも宣言してルーティングに利用）
+const SECRET_FIELD_KEYS = [
+  'discord_bot_token',
+  'resend_api_key',
+  'line_channel_access_token',
+  'line_channel_secret',
+  'google_service_account_key',
+] as const
+
+function hasSecretField(payload: Record<string, unknown>): boolean {
+  return Object.keys(payload).some((k) =>
+    (SECRET_FIELD_KEYS as readonly string[]).includes(k),
+  )
 }
 
 export const organizationSettingsApi = {
@@ -91,44 +109,30 @@ export const organizationSettingsApi = {
     return apiClient.get<OrganizationSettings | null>('/api/org-settings?with_secrets=true')
   },
 
-  // 組織IDで設定を取得
-  async getByOrganizationId(organizationId: string): Promise<OrganizationSettings | null> {
-    const { data, error } = await supabase
-      .from('organization_settings')
-      .select(ORG_SETTINGS_SELECT_FIELDS)
-      .eq('organization_id', organizationId)
-      .single()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null
-      throw error
+  // 設定を作成または更新（upsert）
+  // バックエンド API (/api/org-settings) PATCH 経由。organization_id は JWT 由来で強制。
+  // クライアントが payload に organization_id を渡しても無視される。
+  // 機密フィールドが含まれる場合は自動的に with_secrets=true を付与する。
+  async upsert(
+    settings: OrgSettingsUpsertPayload,
+  ): Promise<OrganizationSettings> {
+    // organization_id をクライアントから渡しても無視される（サーバー側で JWT から強制）
+    // 念のためここで剥がしておく
+    const { organization_id: _ignored, ...rest } = settings as OrgSettingsUpsertPayload & {
+      organization_id?: string
     }
-    return data
+    void _ignored
+
+    const updates = rest as Record<string, unknown>
+    const path = hasSecretField(updates)
+      ? '/api/org-settings?with_secrets=true'
+      : '/api/org-settings'
+    return apiClient.patch<OrganizationSettings>(path, { updates })
   },
-  
-  // 設定を作成または更新
-  async upsert(settings: Partial<Omit<OrganizationSettings, 'id' | 'created_at' | 'updated_at'>>): Promise<OrganizationSettings> {
-    const organizationId = settings.organization_id || await getCurrentOrganizationId()
-    if (!organizationId) {
-      throw new Error('組織情報が取得できません。再ログインしてください。')
-    }
-    
-    const { data, error } = await supabase
-      .from('organization_settings')
-      .upsert({
-        ...settings,
-        organization_id: organizationId
-      }, {
-        onConflict: 'organization_id'
-      })
-      .select()
-      .single()
-    
-    if (error) throw error
-    return data
-  },
-  
+
   // Discord設定のみ更新
+  // discord_bot_token が含まれる場合は機密フィールドのため、サーバー側で
+  // with_secrets=true が要求される（upsert 内で自動判定）。
   async updateDiscordSettings(settings: {
     discord_bot_token?: string
     discord_webhook_url?: string
@@ -139,8 +143,9 @@ export const organizationSettingsApi = {
   }): Promise<OrganizationSettings> {
     return this.upsert(settings)
   },
-  
+
   // メール設定のみ更新
+  // resend_api_key が含まれる場合は機密フィールド扱い。
   async updateEmailSettings(settings: {
     resend_api_key?: string
     sender_email?: string
@@ -149,17 +154,17 @@ export const organizationSettingsApi = {
   }): Promise<OrganizationSettings> {
     return this.upsert(settings)
   },
-  
-  // 通知設定のみ更新
+
+  // 通知設定のみ更新（非機密）
   async updateNotificationSettings(settings: OrganizationSettings['notification_settings']): Promise<OrganizationSettings> {
     return this.upsert({ notification_settings: settings })
   },
-  
-  // 公演時間帯設定のみ更新
+
+  // 公演時間帯設定のみ更新（非機密）
   async updateTimeSlotSettings(settings: TimeSlotSettings): Promise<OrganizationSettings> {
     return this.upsert({ time_slot_settings: settings })
   },
-  
+
   // 公演時間帯設定を取得（デフォルト値付き）
   async getTimeSlotSettings(): Promise<TimeSlotSettings> {
     const settings = await this.get()
@@ -177,38 +182,36 @@ export const organizationSettingsApi = {
     }
     return settings?.time_slot_settings || defaultSettings
   },
-  
+
   // カスタム休日を取得
   async getCustomHolidays(): Promise<string[]> {
     const settings = await this.get()
     return settings?.custom_holidays || []
   },
-  
-  // カスタム休日を更新
+
+  // カスタム休日を更新（非機密）
   async updateCustomHolidays(holidays: string[]): Promise<OrganizationSettings> {
     // 日付をソートして重複を除去
     const uniqueHolidays = [...new Set(holidays)].sort()
     return this.upsert({ custom_holidays: uniqueHolidays })
   },
-  
+
   // 特定の日付を休日として追加
   async addCustomHoliday(date: string): Promise<OrganizationSettings> {
     const current = await this.getCustomHolidays()
     if (current.includes(date)) return this.get() as Promise<OrganizationSettings>
     return this.updateCustomHolidays([...current, date])
   },
-  
+
   // 特定の日付を休日から削除
   async removeCustomHoliday(date: string): Promise<OrganizationSettings> {
     const current = await this.getCustomHolidays()
     return this.updateCustomHolidays(current.filter(d => d !== date))
   },
-  
+
   // 日付がカスタム休日かどうか判定
   async isCustomHoliday(date: string): Promise<boolean> {
     const holidays = await this.getCustomHolidays()
     return holidays.includes(date)
   }
 }
-
-

--- a/src/lib/reservationApi.ts
+++ b/src/lib/reservationApi.ts
@@ -82,6 +82,11 @@ type CreateReservationWithLockParams = Omit<
 }
 
 // 顧客関連のAPI
+// 顧客関連のAPI
+//
+// 全メソッドがバックエンド API (/api/customers) 経由。organization_id は
+// サーバー側で JWT から強制取得し、自組織が所有する顧客のみ操作できる。
+// クライアントが渡した organization_id / user_id は無視される（マルチテナント境界）。
 export const customerApi = {
   // 全顧客を取得
   // バックエンド API (/api/customers) 経由で org_id をサーバー側で強制フィルタ
@@ -91,87 +96,39 @@ export const customerApi = {
   },
 
   // 顧客を作成
+  // バックエンド API 経由。organization_id はサーバー側で JWT から強制設定。
+  // クライアントが他組織の組織 ID を渡しても無視される。
   async create(customer: Omit<Customer, 'id' | 'created_at' | 'updated_at' | 'visit_count' | 'total_spent'>): Promise<Customer> {
-    // organization_idを自動取得（マルチテナント対応）
-    const organizationId = await getCurrentOrganizationId()
-    if (!organizationId) {
-      throw new Error('組織情報が取得できません。再ログインしてください。')
-    }
-    
-    const { data, error } = await supabase
-      .from('customers')
-      .insert([{ ...customer, organization_id: organizationId }])
-      .select(CUSTOMER_SELECT_FIELDS)
-      .single()
-    
-    if (error) throw error
-    return data
+    return apiClient.post<Customer>('/api/customers', { customer })
   },
 
   // 顧客を更新
+  // バックエンド API 経由。自組織が所有する顧客のみ更新可能（サーバー側でガード）。
+  // 更新可能フィールドはサーバー側のホワイトリストでフィルタされる（Mass Assignment 防止）。
   async update(id: string, updates: Partial<Customer>): Promise<Customer> {
-    // ⚠️ Mass Assignment 防止: 更新可能フィールドのホワイトリスト
-    const CUSTOMER_UPDATABLE_FIELDS = [
-      'name', 'email', 'phone', 'nickname', 'line_name', 'notes', 'status',
-      'preferred_staff', 'visit_count', 'last_visit_date', 'reservation_count',
-      'discord_user_id', 'avatar_url',
-    ] as const
-    const safeUpdates: Record<string, unknown> = {}
-    for (const key of Object.keys(updates)) {
-      if ((CUSTOMER_UPDATABLE_FIELDS as readonly string[]).includes(key)) {
-        safeUpdates[key] = (updates as Record<string, unknown>)[key]
-      }
-    }
-
-    const { data, error } = await supabase
-      .from('customers')
-      .update(safeUpdates)
-      .eq('id', id)
-      .select(CUSTOMER_SELECT_FIELDS)
-      .single()
-    
-    if (error) throw error
-    return data
+    const params = new URLSearchParams({ id })
+    return apiClient.patch<Customer>(`/api/customers?${params}`, { updates })
   },
 
-  // メールアドレスで検索
+  // メールアドレスで自組織内の顧客を検索（バックエンド経由）
+  // サーバー側で organization_id を JWT から強制フィルタするため、
+  // 他組織の同一メールアドレス顧客は返らない（マルチテナント境界）。
   async findByEmail(email: string): Promise<Customer | null> {
-    const { data, error } = await supabase
-      .from('customers')
-      .select(CUSTOMER_SELECT_FIELDS)
-      .eq('email', email)
-      .single()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null // Not found
-      throw error
-    }
-    return data
+    const params = new URLSearchParams({ action: 'findByEmail', email })
+    return apiClient.get<Customer | null>(`/api/customers?${params}`)
   },
 
-  // 電話番号で検索
+  // 電話番号で自組織内の顧客を検索（バックエンド経由）
   async findByPhone(phone: string): Promise<Customer | null> {
-    const { data, error } = await supabase
-      .from('customers')
-      .select(CUSTOMER_SELECT_FIELDS)
-      .eq('phone', phone)
-      .single()
-    
-    if (error) {
-      if (error.code === 'PGRST116') return null // Not found
-      throw error
-    }
-    return data
+    const params = new URLSearchParams({ action: 'findByPhone', phone })
+    return apiClient.get<Customer | null>(`/api/customers?${params}`)
   },
 
   // 顧客を削除
+  // バックエンド API 経由。自組織が所有する顧客のみ削除可能（サーバー側でガード）。
   async delete(id: string): Promise<void> {
-    const { error } = await supabase
-      .from('customers')
-      .delete()
-      .eq('id', id)
-    
-    if (error) throw error
+    const params = new URLSearchParams({ id })
+    await apiClient.delete<{ success: boolean }>(`/api/customers?${params}`)
   }
 }
 


### PR DESCRIPTION
## Summary

- **customerApi** の write 系（`create` / `update` / `delete`）と残り read 系（`findByEmail` / `findByPhone`）を `/api/customers` 経由に切り替え。`organization_id` はサーバ側で JWT から取得して強制し、`user_id` 等もクライアントから受け取らない。
- **organizationSettingsApi** の write 系（`upsert` / `updateDiscordSettings` / `updateEmailSettings` / `updateNotificationSettings` / `updateTimeSlotSettings` / `updateCustomHolidays` / `addCustomHoliday` / `removeCustomHoliday`）を `/api/org-settings` PATCH 経由に切り替え。`organization_id` はサーバ側で JWT 強制。
- マルチテナント境界を完璧に詰める（自組織所有チェック・機密フィールド分離・Mass Assignment ホワイトリスト）。

## 新規エンドポイント

### `/api/customers`
- `GET` → 自組織の全顧客（既存、変更なし）
- `GET ?action=findByEmail&email=...` → 自組織内のメール検索（新規）
- `GET ?action=findByPhone&phone=...` → 自組織内の電話検索（新規）
- `POST` → 顧客作成（新規）。`organization_id` は JWT 強制、`user_id` は無視。`name` 必須。
- `PATCH ?id=...` → 顧客更新（新規）。自組織所有チェック + 更新フィールドのホワイトリスト（`name`, `nickname`, `email`, `email_verified`, `phone`, `address`, `line_id`, `notes`, `avatar_url`, `preferences`, `notification_settings`, `last_visit`）。
- `DELETE ?id=...` → 顧客削除（新規）。自組織所有チェック必須。

### `/api/org-settings`
- `GET` / `GET ?with_secrets=true` → 既存、変更なし
- `PATCH` → 非機密フィールドの部分更新（upsert）。`organization_id` は JWT 由来で強制。
- `PATCH ?with_secrets=true` → 機密トークン（`discord_bot_token` / `resend_api_key` / `line_channel_access_token` / `line_channel_secret` / `google_service_account_key`）も含めて更新可。
- 機密フィールドが `with_secrets=false` で渡された場合は `400` で明示的に拒否（無音で落とさない）。

## セキュリティ強化点

1. **`organization_id` の信頼境界**: クライアントが payload に渡しても無視し、必ず JWT → `users` テーブル参照で取得した `orgId` を使う。
2. **自組織所有チェック（customers PATCH/DELETE）**: 書き込み前に `customers.organization_id === orgId` を SELECT で検証し、他組織の顧客を更新/削除できないようにする。`UPDATE/DELETE ... WHERE id = ? AND organization_id = ?` の二重ガードも追加。
3. **Mass Assignment 防止**: customers の作成/更新で受け取れるフィールドをサーバ側ホワイトリストで明示。`organization_id` / `user_id` / `visit_count` / `total_spent` 等は更新不可。
4. **機密フィールドのルート分離（org-settings PATCH）**: `discord_bot_token` 等はデフォルトでは PATCH ペイロードから drop せず `400` で拒否し、`with_secrets=true` を明示した場合のみ書き込みを許可（既存 `GET ?with_secrets=true` の読み出し権限と対称）。
5. **`findByEmail` / `findByPhone` の組織境界**: 旧実装は組織フィルタなしだったため、別組織の同じメール/電話番号の顧客を返してしまう可能性があったが、サーバ側で `organization_id = orgId` を必須化。
6. **service_role による RLS バイパス**: バックエンドは `service_role` で動作するため RLS をバイパスする想定だが、上記の通り `.eq('organization_id', orgId)` を全クエリに明示的に付与してアプリケーション層で組織境界を担保。
7. **`requireStaff` 必須**: customers / org-settings の全操作で `requireStaff` を通し、`admin` / `staff` / `license_admin` 以外を弾く。

## Test plan

- [ ] `npx tsc -p tsconfig.json --noEmit` がエラーなしで通る（手元で確認済み）
- [ ] `node scripts/check-security-guardrails.mjs` が exit 0 で通る（手元で確認済み: `[SECURITY_GUARDRAILS] OK` / `[RLS_CHECK] OK`）
- [ ] `npm run lint` が致命的エラーなしで通る（手元で確認済み: 0 errors, 既存 58 warnings のみ）
- [ ] ステージング環境で以下を手動確認:
  - [ ] 自組織の顧客一覧が取得できる
  - [ ] 顧客作成 → 自分の orgId が付くこと、`organization_id` を payload に渡しても無視されること
  - [ ] 顧客更新 → 他組織の顧客 ID を指定したら 404 になること
  - [ ] 顧客削除 → 他組織の顧客 ID を指定したら 404 になること
  - [ ] `findByEmail` / `findByPhone` で別組織の顧客が漏れないこと
  - [ ] 設定編集画面で Discord/メール/通知/時間帯/カスタム休日が保存できる
  - [ ] `with_secrets=true` の保存ルートで `discord_bot_token` / `resend_api_key` が更新できる
  - [ ] 機密フィールドを `with_secrets=false` で送ると 400 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)