### PR TITLE
feat(api): reservationApi の write 系と残り read 系をバックエンド API に移行（マルチテナント境界強化）

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,4 +1,5 @@
 import type { VercelRequest } from '@vercel/node'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { db, getMissingEnvError } from './db.js'
 
 export type ApiRole = 'admin' | 'staff' | 'customer' | 'license_admin'
@@ -7,6 +8,11 @@ export type AuthUser = {
   userId: string
   orgId: string
   role: ApiRole
+  /**
+   * 元の JWT。SECURITY DEFINER な RPC で auth.uid() を必要とする場合、
+   * createUserScopedClient(jwt) で user-scoped クライアントを作って渡す。
+   */
+  jwt: string
 }
 
 export class ApiError extends Error {
@@ -61,6 +67,7 @@ export async function requireAuth(req: VercelRequest): Promise<AuthUser> {
     userId: user.id,
     orgId: profile.organization_id as string,
     role: profile.role as ApiRole,
+    jwt,
   }
 }
 
@@ -74,4 +81,42 @@ export function requireLicenseAdmin(user: AuthUser): void {
   if (user.role !== 'license_admin') {
     throw new ApiError(403, 'ライセンス管理者権限が必要です')
   }
+}
+
+/**
+ * ユーザー JWT を Authorization ヘッダにセットした Supabase クライアントを生成する。
+ *
+ * 用途:
+ *   - SECURITY DEFINER な RPC（admin_update_reservation_fields 等）は
+ *     内部で auth.uid() / get_user_organization_id() / is_org_admin() を参照する。
+ *     service_role クライアントだと auth.uid() が NULL になり、組織境界チェックで弾かれる。
+ *   - そのため、ユーザー文脈で RPC を呼ぶ必要があるときはこの user-scoped クライアントを使う。
+ *
+ * 注意:
+ *   - RLS は通常通り効くので、SELECT 系で「自組織以外のレコードも見たい」場合は
+ *     service_role クライアント（_lib/db.ts の db）を使うこと。
+ *   - SECURITY DEFINER RPC は RLS をバイパスする（権限関数の中で auth.uid() を使うだけ）。
+ */
+export function createUserScopedClient(jwt: string): SupabaseClient {
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
+  // service_role ではなく anon / publishable を使うことで JWT が尊重される
+  const publicKey =
+    process.env.SUPABASE_PUBLISHABLE_KEY ||
+    process.env.VITE_SUPABASE_PUBLISHABLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.VITE_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !publicKey) {
+    throw new ApiError(
+      500,
+      'SUPABASE_URL / SUPABASE_(ANON|PUBLISHABLE)_KEY が設定されていません（user-scoped クライアントを作れません）',
+    )
+  }
+  return createClient(supabaseUrl, publicKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+    },
+  })
 }

--- a/api/reservations.ts
+++ b/api/reservations.ts
@@ -1,7 +1,8 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { db, getMissingEnvError } from './_lib/db.js'
-import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
+import { requireAuth, requireStaff, createUserScopedClient, ApiError, type AuthUser } from './_lib/auth.js'
 
+// ─── CORS ────────────────────────────────────────────────────────────────────
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,
   'http://localhost:5173',
@@ -12,52 +13,943 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
 
+// ─── 共通 SELECT 文字列 ──────────────────────────────────────────────────────
 const RESERVATION_SELECT_FIELDS =
   'id, organization_id, reservation_number, reservation_page_id, title, scenario_id, scenario_master_id, store_id, customer_id, schedule_event_id, requested_datetime, actual_datetime, duration, participant_count, participant_names, assigned_staff, gm_staff, base_price, options_price, total_price, discount_amount, final_price, unit_price, payment_status, payment_method, payment_datetime, status, customer_notes, staff_notes, special_requests, cancellation_reason, cancelled_at, external_reservation_id, reservation_source, created_by, created_at, updated_at, customer_name, customer_email, customer_phone, private_group_id, candidate_datetimes'
 
+const CUSTOMER_SELECT_FIELDS =
+  'id, organization_id, user_id, name, nickname, email, email_verified, phone, address, line_id, notes, avatar_url, visit_count, total_spent, last_visit, preferences, notification_settings, created_at, updated_at'
+
+const RESERVATION_WITH_CUSTOMER_SELECT_FIELDS = `${RESERVATION_SELECT_FIELDS}, customers(${CUSTOMER_SELECT_FIELDS})`
+
+const SCHEDULE_EVENT_EMBED_FOR_CANCEL =
+  'schedule_events!schedule_event_id(id, date, start_time, end_time, venue, scenario, organization_id, is_private_booking, gms, store_id)'
+
+const RESERVATION_WITH_CUSTOMER_AND_EVENT_SELECT_FIELDS = `${RESERVATION_WITH_CUSTOMER_SELECT_FIELDS}, ${SCHEDULE_EVENT_EMBED_FOR_CANCEL}`
+
+const SCHEDULE_EVENT_EMBED_FOR_UPDATE_EMAIL =
+  'schedule_events!schedule_event_id(date, start_time, end_time, venue, scenario, store_id)'
+
+const RESERVATION_FOR_UPDATE_EMAIL_SELECT_FIELDS = `${RESERVATION_WITH_CUSTOMER_SELECT_FIELDS}, ${SCHEDULE_EVENT_EMBED_FOR_UPDATE_EMAIL}`
+
+const RESERVATION_SUMMARY_SELECT_FIELDS =
+  'schedule_event_id, date, venue, scenario, start_time, end_time, max_participants, current_reservations, available_seats, reservation_count'
+
+// reservation_source の有効値（クライアントから来た値を検証する用）
+const ACTIVE_STATUSES = ['pending', 'confirmed', 'gm_confirmed', 'checked_in', 'cancelled'] as const
+const RESERVATION_SOURCE_STAFF_ENTRY = 'staff_entry'
+
+// ─── ハンドラ ─────────────────────────────────────────────────────────────────
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  const method = req.method
+  if (method !== 'GET' && method !== 'POST' && method !== 'PATCH' && method !== 'DELETE') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
 
   const envError = getMissingEnvError()
   if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
 
-  const start = req.query.start as string | undefined
-  const end = req.query.end as string | undefined
-
   try {
     const user = await requireAuth(req)
-    requireStaff(user)
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let query: any = (db as any)
-      .from('reservations')
-      .select(RESERVATION_SELECT_FIELDS)
-      .eq('organization_id', user.orgId)
-
-    if (start && end) {
-      query = query.gte('requested_datetime', start).lte('requested_datetime', end).order('requested_datetime', { ascending: true })
-    } else {
-      query = query.order('requested_datetime', { ascending: false })
-    }
-
-    const { data, error } = await query
-
-    if (error) {
-      console.error('[reservations] DB error:', error)
-      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
-    }
-
-    return res.status(200).json(data ?? [])
+    if (method === 'GET') return await routeGet(req, res, user)
+    if (method === 'POST') return await routePost(req, res, user)
+    if (method === 'PATCH') return await routePatch(req, res, user)
+    if (method === 'DELETE') return await routeDelete(req, res, user)
   } catch (err) {
     if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
     console.error('[reservations] unexpected error:', err)
-    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+    return res.status(500).json({
+      error: 'サーバーエラーが発生しました',
+      detail: err instanceof Error ? err.message : String(err),
+    })
   }
+}
+
+// ─── GET ルーティング ─────────────────────────────────────────────────────────
+async function routeGet(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const type = req.query.type as string | undefined
+
+  // ?type なし → 既存挙動（一覧 or 期間内一覧）。スタッフ以上のみ。
+  if (!type) {
+    requireStaff(user)
+    return await handleGetAllOrRange(req, res, user.orgId)
+  }
+
+  switch (type) {
+    case 'by-schedule-event':
+      // 顧客でも自分の予約を見るために呼びうるが、現状クライアントの呼び出し元は staff のみ。
+      // 安全側に倒して staff 以上に制限する。
+      requireStaff(user)
+      return await handleGetByScheduleEvent(req, res, user.orgId)
+    case 'by-customer':
+      requireStaff(user)
+      return await handleGetByCustomer(req, res, user.orgId)
+    case 'summary':
+      requireStaff(user)
+      return await handleGetSummary(req, res, user.orgId)
+    case 'availability':
+      // 公開的な情報なのでスタッフ縛りなし。ただし JWT は必須（requireAuth で確認済み）。
+      return await handleGetAvailability(req, res, user.orgId)
+    default:
+      return res.status(400).json({ error: `未対応の type: ${type}` })
+  }
+}
+
+// 既存の getAll / getByDateRange
+async function handleGetAllOrRange(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const start = req.query.start as string | undefined
+  const end = req.query.end as string | undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let query: any = (db as any)
+    .from('reservations')
+    .select(RESERVATION_SELECT_FIELDS)
+    .eq('organization_id', orgId)
+
+  if (start && end) {
+    query = query
+      .gte('requested_datetime', start)
+      .lte('requested_datetime', end)
+      .order('requested_datetime', { ascending: true })
+  } else {
+    query = query.order('requested_datetime', { ascending: false })
+  }
+
+  const { data, error } = await query
+  if (error) {
+    console.error('[reservations] handleGetAllOrRange error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// getByScheduleEvent: 特定イベントの予約 + customers JOIN
+async function handleGetByScheduleEvent(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const scheduleEventId = req.query.schedule_event_id as string | undefined
+  if (!scheduleEventId) {
+    return res.status(400).json({ error: 'schedule_event_id が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('reservations')
+    .select(RESERVATION_WITH_CUSTOMER_SELECT_FIELDS)
+    .eq('schedule_event_id', scheduleEventId)
+    .eq('organization_id', orgId)
+    .in('status', ACTIVE_STATUSES)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    console.error('[reservations:by-schedule-event] error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// getByCustomer
+async function handleGetByCustomer(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const customerId = req.query.customer_id as string | undefined
+  if (!customerId) {
+    return res.status(400).json({ error: 'customer_id が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('reservations')
+    .select(RESERVATION_SELECT_FIELDS)
+    .eq('customer_id', customerId)
+    .eq('organization_id', orgId)
+    .order('requested_datetime', { ascending: false })
+
+  if (error) {
+    console.error('[reservations:by-customer] error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// getSummary: reservation_summary ビュー（自組織のスケジュールに限定するため schedule_events で絞る）
+async function handleGetSummary(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const scheduleEventId = req.query.schedule_event_id as string | undefined
+
+  // schedule_event_id 指定 → その 1 件のみ。ただし当該 schedule_event が自組織のものであることを確認。
+  if (scheduleEventId) {
+    const { data: ev, error: evError } = await db
+      .from('schedule_events')
+      .select('id')
+      .eq('id', scheduleEventId)
+      .eq('organization_id', orgId)
+      .maybeSingle()
+    if (evError) {
+      console.error('[reservations:summary] schedule_events check error:', evError)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: evError.message })
+    }
+    if (!ev) {
+      return res.status(404).json({ error: 'schedule_event が見つかりません' })
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (db as any)
+      .from('reservation_summary')
+      .select(RESERVATION_SUMMARY_SELECT_FIELDS)
+      .eq('schedule_event_id', scheduleEventId)
+
+    if (error) {
+      console.error('[reservations:summary] error:', error)
+      return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? [])
+  }
+
+  // schedule_event_id 未指定 → 自組織のスケジュールに紐付くサマリだけを返す
+  const { data: events, error: evError } = await db
+    .from('schedule_events')
+    .select('id')
+    .eq('organization_id', orgId)
+  if (evError) {
+    console.error('[reservations:summary] schedule_events list error:', evError)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: evError.message })
+  }
+  const ids = (events ?? []).map((e: { id: string }) => e.id)
+  if (ids.length === 0) return res.status(200).json([])
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('reservation_summary')
+    .select(RESERVATION_SUMMARY_SELECT_FIELDS)
+    .in('schedule_event_id', ids)
+
+  if (error) {
+    console.error('[reservations:summary] in() error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// getAvailability: 空席状況。自組織の schedule_event のみ。
+async function handleGetAvailability(req: VercelRequest, res: VercelResponse, orgId: string) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const scheduleEventId = req.query.schedule_event_id as string | undefined
+  if (!scheduleEventId) {
+    return res.status(400).json({ error: 'schedule_event_id が必要です' })
+  }
+
+  // マルチテナント境界: schedule_event が自組織のものか
+  const { data: ev, error: evError } = await db
+    .from('schedule_events')
+    .select('id')
+    .eq('id', scheduleEventId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (evError) {
+    console.error('[reservations:availability] schedule_events check error:', evError)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: evError.message })
+  }
+  if (!ev) {
+    return res.status(404).json({ error: 'schedule_event が見つかりません' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('reservation_summary')
+    .select('schedule_event_id, max_participants, current_reservations, available_seats')
+    .eq('schedule_event_id', scheduleEventId)
+    .maybeSingle()
+
+  if (error && error.code !== 'PGRST116') {
+    console.error('[reservations:availability] error:', error)
+    return res.status(500).json({ error: 'データ取得に失敗しました', detail: error.message })
+  }
+
+  if (!data) {
+    return res.status(200).json({
+      maxParticipants: null,
+      currentReservations: 0,
+      availableSeats: 0,
+    })
+  }
+
+  return res.status(200).json({
+    maxParticipants: data.max_participants,
+    currentReservations: data.current_reservations,
+    availableSeats: data.available_seats,
+  })
+}
+
+// ─── POST ルーティング ────────────────────────────────────────────────────────
+async function routePost(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = (req.query.action as string | undefined) ?? 'create'
+
+  switch (action) {
+    case 'create':
+      // 顧客（ログイン済み）でも自分自身の予約は作成できる。
+      // 権限細分化は RPC 内の auth.uid() ベースの組織境界チェックに任せる。
+      return await handleCreate(req, res, user)
+    case 'create-staff-entry':
+      requireStaff(user)
+      return await handleCreateStaffEntry(req, res, user)
+    default:
+      return res.status(400).json({ error: `unknown action: ${action}` })
+  }
+}
+
+async function handleCreate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const reservation = (body.reservation ?? body) as Record<string, unknown>
+
+  const scheduleEventId = reservation.schedule_event_id as string | undefined
+  const customerId = reservation.customer_id as string | undefined
+  const participantCount = reservation.participant_count as number | undefined
+  if (!scheduleEventId || !customerId || participantCount == null) {
+    return res.status(400).json({
+      error: 'schedule_event_id / customer_id / participant_count が必要です',
+    })
+  }
+
+  // マルチテナント境界:
+  //  - schedule_event_id は自組織のものか
+  //  - customer_id は自組織のものか
+  // RPC 内部でも auth.uid() ベースのチェックがあるが、二重に明示検証する。
+  const { data: ev, error: evError } = await db
+    .from('schedule_events')
+    .select('id, organization_id')
+    .eq('id', scheduleEventId)
+    .maybeSingle()
+  if (evError || !ev) {
+    console.error('[reservations:create] schedule_events check error:', evError)
+    return res.status(404).json({ error: 'schedule_event が見つかりません' })
+  }
+  if (ev.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の schedule_event は指定できません' })
+  }
+
+  const { data: cust, error: custError } = await db
+    .from('customers')
+    .select('id, organization_id, user_id')
+    .eq('id', customerId)
+    .maybeSingle()
+  if (custError || !cust) {
+    console.error('[reservations:create] customers check error:', custError)
+    return res.status(404).json({ error: 'customer が見つかりません' })
+  }
+  if (cust.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の customer は指定できません' })
+  }
+  // 顧客ロールの場合は自分自身の customers 行のみ作成可
+  if (user.role === 'customer' && cust.user_id !== user.userId) {
+    return res.status(403).json({ error: '他人の customer に対しては作成できません' })
+  }
+
+  // 予約番号（冪等性: クライアント提供を優先）
+  const providedReservationNumber = reservation.reservation_number as string | undefined
+  const reservationNumber = providedReservationNumber || generateReservationNumber()
+
+  // RPC 呼び出し（auth.uid() を伝播する user-scoped client を使う）
+  const userClient = createUserScopedClient(user.jwt)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: createdId, error: rpcError } = await (userClient as any).rpc(
+    'create_reservation_with_lock_v2',
+    {
+      p_schedule_event_id: scheduleEventId,
+      p_participant_count: participantCount,
+      p_customer_id: customerId,
+      p_customer_name: (reservation.customer_name as string | null) ?? null,
+      p_customer_email: (reservation.customer_email as string | null) ?? null,
+      p_customer_phone: (reservation.customer_phone as string | null) ?? null,
+      p_notes: (reservation.customer_notes as string | null) ?? null,
+      p_how_found: (reservation as Record<string, unknown>).how_found as string | null ?? null,
+      p_reservation_number: reservationNumber,
+      p_customer_coupon_id:
+        (reservation as Record<string, unknown>).customer_coupon_id as string | null ?? null,
+    },
+  )
+
+  if (rpcError) {
+    console.error('[reservations:create] RPC error:', rpcError)
+    // 冪等性: UNIQUE 違反の場合、既存予約を返す
+    const code = String((rpcError as { code?: string }).code || '')
+    const msg = String((rpcError as { message?: string }).message || '')
+    const isUniqueViolation =
+      code === '23505' ||
+      msg.includes('reservation_number') ||
+      msg.includes('duplicate') ||
+      msg.includes('unique')
+    if (isUniqueViolation && reservationNumber) {
+      const { data: existing } = await db
+        .from('reservations')
+        .select(RESERVATION_SELECT_FIELDS)
+        .eq('reservation_number', reservationNumber)
+        .eq('organization_id', user.orgId)
+        .maybeSingle()
+      if (existing) return res.status(200).json(existing)
+    }
+    // 既知のエラーコードはメッセージを訳して返す
+    const known: Record<string, string> = {
+      P0001: '参加人数が不正です',
+      P0002: '公演が見つかりません',
+      P0003: 'この公演は満席です',
+      P0004: '選択した人数分の空席がありません',
+    }
+    if (known[code]) {
+      return res.status(400).json({ error: known[code], code, detail: msg })
+    }
+    return res.status(500).json({ error: '予約作成に失敗しました', detail: msg, code })
+  }
+
+  const reservationId = createdId as string | null
+  if (!reservationId) {
+    return res.status(500).json({ error: '予約 ID が取得できませんでした' })
+  }
+
+  const { data: created, error: fetchError } = await db
+    .from('reservations')
+    .select(RESERVATION_SELECT_FIELDS)
+    .eq('id', reservationId)
+    .single()
+
+  if (fetchError || !created) {
+    console.error('[reservations:create] fetch after insert error:', fetchError)
+    return res.status(500).json({ error: '作成後の予約取得に失敗しました' })
+  }
+
+  return res.status(201).json(created)
+}
+
+// スタッフ参加枠の予約（syncStaffReservations から呼ばれる）
+// 通常の create_reservation_with_lock_v2 は payment_method='staff'/reservation_source=staff_entry を扱えないため、
+// staff 専用の直接 INSERT エンドポイントとして提供する。
+async function handleCreateStaffEntry(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const scheduleEventId = body.schedule_event_id as string | undefined
+  const staffName = body.staff_name as string | undefined
+  const eventDetails = (body.event_details ?? {}) as {
+    date?: string
+    start_time?: string
+    scenario_master_id?: string | null
+    scenario_title?: string | null
+    store_id?: string | null
+    duration?: number | null
+  }
+
+  if (!scheduleEventId || !staffName) {
+    return res.status(400).json({ error: 'schedule_event_id / staff_name が必要です' })
+  }
+
+  // マルチテナント境界: schedule_event が自組織のものか
+  const { data: ev, error: evError } = await db
+    .from('schedule_events')
+    .select('id, organization_id, date, start_time, scenario, scenario_master_id, store_id, duration')
+    .eq('id', scheduleEventId)
+    .maybeSingle()
+  if (evError || !ev) {
+    return res.status(404).json({ error: 'schedule_event が見つかりません' })
+  }
+  if (ev.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の schedule_event は指定できません' })
+  }
+
+  const reservationNumber = generateReservationNumber()
+  const date = eventDetails.date || ev.date
+  const startTime = eventDetails.start_time || ev.start_time
+
+  const payload = {
+    organization_id: user.orgId,
+    schedule_event_id: scheduleEventId,
+    reservation_number: reservationNumber,
+    title: eventDetails.scenario_title || ev.scenario || '',
+    scenario_master_id: eventDetails.scenario_master_id ?? ev.scenario_master_id ?? null,
+    store_id: eventDetails.store_id ?? ev.store_id ?? null,
+    customer_id: null,
+    customer_notes: staffName,
+    requested_datetime: `${date}T${startTime}+09:00`,
+    duration: eventDetails.duration ?? ev.duration ?? 120,
+    participant_count: 1,
+    participant_names: [staffName],
+    assigned_staff: [],
+    base_price: 0,
+    options_price: 0,
+    total_price: 0,
+    discount_amount: 0,
+    final_price: 0,
+    payment_method: 'staff',
+    payment_status: 'paid',
+    status: 'confirmed',
+    reservation_source: RESERVATION_SOURCE_STAFF_ENTRY,
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: inserted, error: insertError } = await (db as any)
+    .from('reservations')
+    .insert([payload])
+    .select(RESERVATION_SELECT_FIELDS)
+    .single()
+
+  if (insertError) {
+    console.error('[reservations:create-staff-entry] insert error:', insertError)
+    return res.status(500).json({ error: 'スタッフ予約の作成に失敗しました', detail: insertError.message })
+  }
+
+  return res.status(201).json(inserted)
+}
+
+// ─── PATCH ルーティング ───────────────────────────────────────────────────────
+async function routePatch(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = (req.query.action as string | undefined) ?? 'update'
+
+  switch (action) {
+    case 'update':
+      requireStaff(user)
+      return await handleUpdate(req, res, user)
+    case 'cancel-with-lock':
+      // 顧客自身の予約 or staff
+      return await handleCancelWithLock(req, res, user)
+    case 'cancel-with-group-lock':
+      return await handleCancelWithGroupLock(req, res, user)
+    case 'cancel':
+      // 複合フロー: 予約 + グループ + システムメッセージ送信
+      return await handleCancelOrchestrated(req, res, user)
+    case 'update-participants-with-lock':
+      return await handleUpdateParticipantsWithLock(req, res, user)
+    case 'recalculate-prices':
+      requireStaff(user)
+      return await handleRecalculatePrices(req, res, user)
+    case 'sync-staff-reservation-statuses':
+      requireStaff(user)
+      return await handleSyncStaffReservationStatuses(req, res, user)
+    default:
+      return res.status(400).json({ error: `unknown action: ${action}` })
+  }
+}
+
+// 自組織が所有する予約か確認するヘルパ
+async function ensureReservationOwnedByOrg(
+  reservationId: string,
+  orgId: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<{ ok: true; reservation: any } | { ok: false; status: number; error: string }> {
+  if (!db) return { ok: false, status: 500, error: 'db unavailable' }
+  const { data, error } = await db
+    .from('reservations')
+    .select('id, organization_id, customer_id, private_group_id, schedule_event_id')
+    .eq('id', reservationId)
+    .maybeSingle()
+  if (error) {
+    return { ok: false, status: 500, error: error.message }
+  }
+  if (!data) {
+    return { ok: false, status: 404, error: '予約が見つかりません' }
+  }
+  if (data.organization_id !== orgId) {
+    return { ok: false, status: 403, error: '他組織の予約は操作できません' }
+  }
+  return { ok: true, reservation: data }
+}
+
+async function handleUpdate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updates = (body.updates ?? body) as Record<string, unknown>
+  if (!updates || typeof updates !== 'object') {
+    return res.status(400).json({ error: 'updates が必要です' })
+  }
+
+  // 1) 自組織所有チェック
+  const own = await ensureReservationOwnedByOrg(id, user.orgId)
+  if (!own.ok) return res.status(own.status).json({ error: own.error })
+
+  // 2) RPC (admin_update_reservation_fields) は SECURITY DEFINER で auth.uid() ベースの追加チェックを行う。
+  //    user-scoped client で呼ぶ。
+  const userClient = createUserScopedClient(user.jwt)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: ok, error: updateError } = await (userClient as any).rpc(
+    'admin_update_reservation_fields',
+    { p_reservation_id: id, p_updates: updates },
+  )
+
+  if (updateError) {
+    console.error('[reservations:update] RPC error:', updateError)
+    return res.status(500).json({ error: '予約の更新に失敗しました', detail: updateError.message })
+  }
+  if (!ok) {
+    return res.status(500).json({ error: '予約の更新に失敗しました（DB 側で 0 行更新）' })
+  }
+
+  // 3) 更新後のレコードを customers/schedule_events と一緒に返す（メール送信側で必要）
+  const { data, error } = await db
+    .from('reservations')
+    .select(RESERVATION_FOR_UPDATE_EMAIL_SELECT_FIELDS)
+    .eq('id', id)
+    .single()
+
+  if (error || !data) {
+    console.error('[reservations:update] fetch error:', error)
+    return res.status(500).json({ error: '更新後の予約取得に失敗しました' })
+  }
+
+  return res.status(200).json(data)
+}
+
+async function handleCancelWithLock(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const customerId = body.customer_id as string | null | undefined
+  const reason = (body.cancellation_reason as string | null | undefined) ?? null
+
+  // 自組織所有チェック
+  const own = await ensureReservationOwnedByOrg(id, user.orgId)
+  if (!own.ok) return res.status(own.status).json({ error: own.error })
+
+  // user-scoped で RPC を呼ぶ（RPC 側で auth.uid() による顧客/スタッフ判定）
+  const userClient = createUserScopedClient(user.jwt)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (userClient as any).rpc('cancel_reservation_with_lock', {
+    p_reservation_id: id,
+    p_customer_id: customerId ?? null,
+    p_cancellation_reason: reason,
+  })
+
+  if (error) {
+    console.error('[reservations:cancel-with-lock] RPC error:', error)
+    return res.status(500).json({ error: '予約のキャンセルに失敗しました', detail: error.message })
+  }
+  if (data !== true) {
+    return res.status(500).json({ error: '予約のキャンセルに失敗しました（DB 側で処理できませんでした）' })
+  }
+  return res.status(200).json({ success: true })
+}
+
+async function handleCancelWithGroupLock(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const customerId = body.customer_id as string | null | undefined
+  const reason = (body.cancellation_reason as string | null | undefined) ?? null
+
+  const own = await ensureReservationOwnedByOrg(id, user.orgId)
+  if (!own.ok) return res.status(own.status).json({ error: own.error })
+
+  const userClient = createUserScopedClient(user.jwt)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (userClient as any).rpc('cancel_reservation_and_group_with_lock', {
+    p_reservation_id: id,
+    p_customer_id: customerId ?? null,
+    p_cancellation_reason: reason,
+  })
+
+  if (error) {
+    console.error('[reservations:cancel-with-group-lock] RPC error:', error)
+    return res.status(500).json({ error: '予約+グループのキャンセルに失敗しました', detail: error.message })
+  }
+  if (data !== true) {
+    return res.status(500).json({ error: '予約+グループのキャンセルに失敗しました（DB 側）' })
+  }
+  return res.status(200).json({ success: true })
+}
+
+// cancel() の DB パートを一括で実行する複合エンドポイント。
+//
+// ⚠ クライアント側の cancel() は以下を実施していた:
+//   1. 予約取得（customer/schedule_events JOIN）
+//   2. RPC: cancel_reservation_and_group_with_lock or cancel_reservation_with_lock
+//   3. グループキャンセル時はシステムメッセージを private_group_messages に INSERT
+//   4. キャンセル確認メール送信（Edge Function）
+//   5. キャンセル待ち通知（Edge Function、失敗時はキューに INSERT）
+//   6. 貸切予約なら GM への Discord 通知（Edge Function）
+//
+// ここで DB 部分（1〜3 + 失敗時の waitlist キュー INSERT）をサーバー側に寄せ、
+// メール・Discord 通知系（Edge Function 呼び出し）はクライアント側に残す。
+// 戻り値で「次にクライアントが呼ぶべき Edge Function 呼び出しに必要な情報」を返す。
+async function handleCancelOrchestrated(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const reason = (body.cancellation_reason as string | null | undefined) ?? null
+  const skipGroupCancel = Boolean(body.skip_group_cancel)
+
+  // 1) 予約 + customers + schedule_events を取得（マルチテナント境界チェックも兼ねる）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: reservation, error: fetchError } = await (db as any)
+    .from('reservations')
+    .select(RESERVATION_WITH_CUSTOMER_AND_EVENT_SELECT_FIELDS)
+    .eq('id', id)
+    .maybeSingle()
+
+  if (fetchError) {
+    console.error('[reservations:cancel] fetch error:', fetchError)
+    return res.status(500).json({ error: '予約取得に失敗しました', detail: fetchError.message })
+  }
+  if (!reservation) {
+    return res.status(404).json({ error: '予約が見つかりません' })
+  }
+  if (reservation.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の予約は操作できません' })
+  }
+
+  // 2) RPC でキャンセル
+  const userClient = createUserScopedClient(user.jwt)
+  if (skipGroupCancel) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (userClient as any).rpc('cancel_reservation_with_lock', {
+      p_reservation_id: id,
+      p_customer_id: reservation.customer_id ?? null,
+      p_cancellation_reason: reason,
+    })
+    if (error || data !== true) {
+      console.error('[reservations:cancel] cancel_reservation_with_lock error:', error, 'data:', data)
+      return res.status(500).json({
+        error: '予約のキャンセルに失敗しました',
+        detail: error?.message,
+      })
+    }
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (userClient as any).rpc('cancel_reservation_and_group_with_lock', {
+      p_reservation_id: id,
+      p_customer_id: reservation.customer_id ?? null,
+      p_cancellation_reason: reason,
+    })
+    if (error || data !== true) {
+      console.error('[reservations:cancel] cancel_reservation_and_group_with_lock error:', error, 'data:', data)
+      return res.status(500).json({
+        error: '予約+グループのキャンセルに失敗しました',
+        detail: error?.message,
+      })
+    }
+  }
+
+  // 3) グループキャンセルの場合のみ、システムメッセージを送信
+  if (reservation.private_group_id && !skipGroupCancel) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: settings } = await (db as any)
+      .from('global_settings')
+      .select('system_msg_booking_cancelled_title, system_msg_booking_cancelled_body')
+      .eq('organization_id', reservation.organization_id)
+      .maybeSingle()
+
+    const title = settings?.system_msg_booking_cancelled_title || 'ご予約がキャンセルされました'
+    const messageBody =
+      settings?.system_msg_booking_cancelled_body ||
+      reason ||
+      '誠に申し訳ございませんが、やむを得ない事情によりご予約がキャンセルとなりました。'
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (db as any).from('private_group_messages').insert({
+      group_id: reservation.private_group_id,
+      sender_type: 'system',
+      message: JSON.stringify({
+        type: 'system',
+        action: 'booking_cancelled',
+        title,
+        body: messageBody,
+      }),
+    })
+  }
+
+  // 4) キャンセル後の予約レコード（プレーン）と、後段の Edge Function 呼び出しに必要な情報を返す
+  const { data: cancelled, error: fetchAfterError } = await db
+    .from('reservations')
+    .select(RESERVATION_SELECT_FIELDS)
+    .eq('id', id)
+    .single()
+  if (fetchAfterError || !cancelled) {
+    console.error('[reservations:cancel] fetch after cancel error:', fetchAfterError)
+    return res.status(500).json({ error: 'キャンセル後の予約取得に失敗しました' })
+  }
+
+  // 組織 slug は通知メール本文の URL 生成用にサーバ側で取得（クライアントは表示用に保持してもよい）
+  let orgSlug: string | null = null
+  try {
+    const { data: org } = await db
+      .from('organizations')
+      .select('slug')
+      .eq('id', reservation.organization_id)
+      .maybeSingle()
+    orgSlug = (org as { slug?: string } | null)?.slug ?? null
+  } catch (orgErr) {
+    console.warn('[reservations:cancel] organizations slug fetch error:', orgErr)
+  }
+
+  return res.status(200).json({
+    reservation: cancelled,
+    // クライアントが Edge Function 呼び出しに使う付加情報
+    contextForNotifications: {
+      reservation, // customers, schedule_events JOIN 込みの完全な予約
+      organization_slug: orgSlug,
+      skip_group_cancel: skipGroupCancel,
+    },
+  })
+}
+
+async function handleUpdateParticipantsWithLock(
+  req: VercelRequest,
+  res: VercelResponse,
+  user: AuthUser,
+) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const newCount = body.new_count as number | undefined
+  const customerId = (body.customer_id as string | null | undefined) ?? null
+  if (newCount == null) {
+    return res.status(400).json({ error: 'new_count が必要です' })
+  }
+
+  const own = await ensureReservationOwnedByOrg(id, user.orgId)
+  if (!own.ok) return res.status(own.status).json({ error: own.error })
+
+  const userClient = createUserScopedClient(user.jwt)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (userClient as any).rpc('update_reservation_participants', {
+    p_reservation_id: id,
+    p_new_count: newCount,
+    p_customer_id: customerId,
+  })
+
+  if (error) {
+    console.error('[reservations:update-participants-with-lock] RPC error:', error)
+    const code = String((error as { code?: string }).code || '')
+    const known: Record<string, string> = {
+      P0006: '参加人数が不正です',
+      P0007: '予約が見つかりません',
+      P0008: '選択した人数分の空席がありません',
+      P0010: '権限がありません',
+      P0011: '権限がありません',
+    }
+    if (known[code]) {
+      return res.status(400).json({ error: known[code], code, detail: error.message })
+    }
+    return res.status(500).json({ error: '人数変更に失敗しました', detail: error.message, code })
+  }
+
+  return res.status(200).json({ success: Boolean(data) })
+}
+
+async function handleRecalculatePrices(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const participantNames = (body.participant_names as string[] | null | undefined) ?? null
+
+  const own = await ensureReservationOwnedByOrg(id, user.orgId)
+  if (!own.ok) return res.status(own.status).json({ error: own.error })
+
+  const userClient = createUserScopedClient(user.jwt)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (userClient as any).rpc('admin_recalculate_reservation_prices', {
+    p_reservation_id: id,
+    p_participant_names: participantNames,
+  })
+
+  if (error) {
+    console.error('[reservations:recalculate-prices] RPC error:', error)
+    return res.status(500).json({ error: '料金再計算に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: Boolean(data) })
+}
+
+// syncStaffReservations から呼ばれる、複数予約のステータスを一括 cancelled に変更するエンドポイント。
+// （旧 client の syncStaffReservations は this.update(id, { status: 'cancelled' }) を for ループで呼んでいた）
+async function handleSyncStaffReservationStatuses(
+  req: VercelRequest,
+  res: VercelResponse,
+  user: AuthUser,
+) {
+  if (!db) return res.status(500).json({ error: 'db unavailable' })
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const ids = body.reservation_ids as string[] | undefined
+  const newStatus = (body.status as string | undefined) ?? 'cancelled'
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return res.status(400).json({ error: 'reservation_ids（配列）が必要です' })
+  }
+
+  // 全 ID が自組織のものか確認
+  const { data: owned, error: ownedError } = await db
+    .from('reservations')
+    .select('id, organization_id')
+    .in('id', ids)
+  if (ownedError) {
+    console.error('[reservations:sync-staff] owned check error:', ownedError)
+    return res.status(500).json({ error: '所有確認に失敗しました', detail: ownedError.message })
+  }
+  const ownedIds = new Set((owned ?? []).filter(
+    (r: { organization_id: string }) => r.organization_id === user.orgId,
+  ).map((r: { id: string }) => r.id))
+  const safeIds = ids.filter(id => ownedIds.has(id))
+  if (safeIds.length === 0) {
+    return res.status(403).json({ error: '対象予約が見つからない、または他組織の予約です' })
+  }
+
+  // 直接 UPDATE（service_role で RLS バイパス + 上で組織検証済み）。
+  // RPC を使わない理由: admin_update_reservation_fields は 1 件ずつしか扱わないため、N+1 を避ける。
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: updateError } = await (db as any)
+    .from('reservations')
+    .update({ status: newStatus, updated_at: new Date().toISOString() })
+    .in('id', safeIds)
+    .eq('organization_id', user.orgId)
+
+  if (updateError) {
+    console.error('[reservations:sync-staff] update error:', updateError)
+    return res.status(500).json({ error: '一括ステータス更新に失敗しました', detail: updateError.message })
+  }
+  return res.status(200).json({ success: true, updatedCount: safeIds.length })
+}
+
+// ─── DELETE ───────────────────────────────────────────────────────────────────
+async function routeDelete(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  requireStaff(user)
+
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  const own = await ensureReservationOwnedByOrg(id, user.orgId)
+  if (!own.ok) return res.status(own.status).json({ error: own.error })
+
+  // RPC: admin_delete_reservations_by_ids は SECURITY DEFINER + 内部で auth.uid() による org/role チェック
+  const userClient = createUserScopedClient(user.jwt)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (userClient as any).rpc('admin_delete_reservations_by_ids', {
+    p_reservation_ids: [id],
+  })
+
+  if (error) {
+    console.error('[reservations:delete] RPC error:', error)
+    return res.status(500).json({ error: '予約の削除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ success: true })
+}
+
+// ─── ユーティリティ ───────────────────────────────────────────────────────────
+function generateReservationNumber(): string {
+  const now = new Date()
+  const dateStr = now.toISOString().slice(2, 10).replace(/-/g, '')
+  const randomStr = Math.random().toString(36).substring(2, 6).toUpperCase()
+  return `${dateStr}-${randomStr}`
 }

--- a/src/lib/reservationApi.ts
+++ b/src/lib/reservationApi.ts
@@ -3,18 +3,8 @@ import { getCurrentOrganizationId } from '@/lib/organization'
 import { apiClient } from '@/lib/apiClient'
 import { logger, generateCorrelationId, createCorrelatedLogger } from '@/utils/logger'
 import { recalculateCurrentParticipants } from '@/lib/participantUtils'
-import { RESERVATION_SOURCE, STAFF_RESERVATION_SOURCES, AUTO_MANAGED_STAFF_SOURCES, GLOBAL_SETTINGS_MSG_SELECT } from '@/lib/constants'
+import { STAFF_RESERVATION_SOURCES, AUTO_MANAGED_STAFF_SOURCES } from '@/lib/constants'
 import type { Reservation, Customer, ReservationSummary } from '@/types'
-import type {
-  RpcCreateReservationParams,
-  RpcCancelReservationParams,
-  RpcCancelReservationAndGroupParams,
-  RpcUpdateReservationParticipantsParams,
-  RpcRecalculateReservationPricesParams,
-  RpcAdminUpdateReservationFieldsParams,
-  RpcAdminDeleteReservationsByIdsParams,
-  RpcAdminDeleteReservationsBySourceParams,
-} from '@/lib/rpcTypes'
 
 // NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
 const CUSTOMER_SELECT_FIELDS =
@@ -97,13 +87,13 @@ export const customerApi = {
     if (!organizationId) {
       throw new Error('組織情報が取得できません。再ログインしてください。')
     }
-    
+
     const { data, error } = await supabase
       .from('customers')
       .insert([{ ...customer, organization_id: organizationId }])
       .select(CUSTOMER_SELECT_FIELDS)
       .single()
-    
+
     if (error) throw error
     return data
   },
@@ -129,7 +119,7 @@ export const customerApi = {
       .eq('id', id)
       .select(CUSTOMER_SELECT_FIELDS)
       .single()
-    
+
     if (error) throw error
     return data
   },
@@ -141,7 +131,7 @@ export const customerApi = {
       .select(CUSTOMER_SELECT_FIELDS)
       .eq('email', email)
       .single()
-    
+
     if (error) {
       if (error.code === 'PGRST116') return null // Not found
       throw error
@@ -156,7 +146,7 @@ export const customerApi = {
       .select(CUSTOMER_SELECT_FIELDS)
       .eq('phone', phone)
       .single()
-    
+
     if (error) {
       if (error.code === 'PGRST116') return null // Not found
       throw error
@@ -170,23 +160,26 @@ export const customerApi = {
       .from('customers')
       .delete()
       .eq('id', id)
-    
+
     if (error) throw error
   }
 }
 
+// =============================================================================
 // 予約関連のAPI
+//
+// すべて /api/reservations 経由でバックエンド API を呼び出す。
+// organization_id はサーバー側 JWT 由来で強制フィルタするため、
+// クライアントから渡す organization_id 引数は基本的に無視される
+// （後方互換のため引数シグネチャは維持）。
+// =============================================================================
 export const reservationApi = {
   // 全予約を取得
-  // バックエンド API (/api/reservations) 経由で org_id をサーバー側で強制フィルタ
-  // organizationId 引数は後方互換のため残すが未使用
   async getAll(_organizationId?: string): Promise<Reservation[]> {
     return apiClient.get<Reservation[]>('/api/reservations')
   },
 
   // 特定期間の予約を取得
-  // バックエンド API (/api/reservations?start=&end=) 経由で org_id をサーバー側で強制フィルタ
-  // organizationId 引数は後方互換のため残すが未使用
   async getByDateRange(startDate: string, endDate: string, _organizationId?: string): Promise<Reservation[]> {
     return apiClient.get<Reservation[]>(
       `/api/reservations?start=${encodeURIComponent(startDate)}&end=${encodeURIComponent(endDate)}`
@@ -194,255 +187,91 @@ export const reservationApi = {
   },
 
   // スケジュールイベントIDで予約を取得
-  // organizationId を渡せるようにする（管理画面で「閲覧中の組織」とログインユーザー組織が異なるケース対策）
-  async getByScheduleEvent(scheduleEventId: string, organizationId?: string | null): Promise<Reservation[]> {
-    // organization_idを自動取得（マルチテナント対応）
-    const orgId = organizationId ?? await getCurrentOrganizationId()
-
-    const run = async (select: string) => {
-      let query = supabase
-        .from('reservations')
-        .select(select)
-        .eq('schedule_event_id', scheduleEventId)
-        .in('status', ['pending', 'confirmed', 'gm_confirmed', 'checked_in', 'cancelled'])
-
-      if (orgId) {
-        query = query.eq('organization_id', orgId)
-      }
-
-      return await query.order('created_at', { ascending: true })
-    }
-
-    const explicit = await run(RESERVATION_WITH_CUSTOMER_SELECT_FIELDS)
-    if (!explicit.error) {
-      return (explicit.data as unknown as Reservation[]) || []
-    }
-
-    // migration 未適用などで列不足の環境では明示列が 400 になることがあるためフォールバック
-    logger.warn('getByScheduleEvent: explicit select failed, falling back to *', {
-      scheduleEventId,
-      orgId,
-      error: explicit.error,
-    })
-    const fallback = await run('*, customers(*)')
-    if (!fallback.error) {
-      return (fallback.data as unknown as Reservation[]) || []
-    }
-
-    logger.error('getByScheduleEvent: both selects failed', {
-      scheduleEventId,
-      orgId,
-      explicitError: explicit.error,
-      fallbackError: fallback.error,
-    })
-    throw fallback.error
+  // バックエンド API (/api/reservations?type=by-schedule-event) 経由で org_id を強制フィルタ。
+  // _organizationId 引数は後方互換のため残すが未使用。
+  async getByScheduleEvent(scheduleEventId: string, _organizationId?: string | null): Promise<Reservation[]> {
+    return apiClient.get<Reservation[]>(
+      `/api/reservations?type=by-schedule-event&schedule_event_id=${encodeURIComponent(scheduleEventId)}`
+    )
   },
 
   // 顧客IDで予約を取得
-  // organizationId: 指定した場合そのIDを使用、未指定の場合はログインユーザーの組織で自動フィルタ
-  async getByCustomer(customerId: string, organizationId?: string): Promise<Reservation[]> {
-    // 組織フィルタリング（マルチテナント対応: 他組織の予約が漏れないように）
-    const orgId = organizationId || await getCurrentOrganizationId()
-    
-    let query = supabase
-      .from('reservations')
-      .select(RESERVATION_SELECT_FIELDS)
-      .eq('customer_id', customerId)
-    
-    if (orgId) {
-      query = query.eq('organization_id', orgId)
-    }
-    
-    const { data, error } = await query.order('requested_datetime', { ascending: false })
-    
-    if (error) throw error
-    return data || []
+  // バックエンド API (/api/reservations?type=by-customer) 経由で org_id を強制フィルタ。
+  // _organizationId 引数は後方互換のため残すが未使用。
+  async getByCustomer(customerId: string, _organizationId?: string): Promise<Reservation[]> {
+    return apiClient.get<Reservation[]>(
+      `/api/reservations?type=by-customer&customer_id=${encodeURIComponent(customerId)}`
+    )
   },
 
-  // 予約を作成（RPC + FOR UPDATE）
+  // 予約を作成（RPC + FOR UPDATE をサーバー側で実施）
   async create(reservation: CreateReservationWithLockParams): Promise<Reservation> {
-    const organizationId = reservation.organization_id || await getCurrentOrganizationId()
-    if (!organizationId) {
-      throw new Error('組織情報が取得できません。再ログインしてください。')
-    }
-
-    // 予約番号を自動生成（YYMMDD-XXXX形式: 11桁）
-    // 冪等性: 呼び出し元が reservation_number を渡す場合はそれを優先して使用する
-    const reservationNumber = reservation.reservation_number || (() => {
-      const now = new Date()
-      const dateStr = now.toISOString().slice(2, 10).replace(/-/g, '')
-      const randomStr = Math.random().toString(36).substring(2, 6).toUpperCase()
-      return `${dateStr}-${randomStr}`
-    })()
-
-    // 🔒 SEC-P0-01対策: v2のみを使用（レガシーフォールバック削除）
-    // - v2はサーバー側で料金/日時を確定し、クライアント入力の改ざんを防止
-    // - 旧関数（料金検証なし）へのフォールバックは削除
-    let reservationId: string | null = null
-    let error: any = null
-
-    const createParams: RpcCreateReservationParams = {
-      p_schedule_event_id: reservation.schedule_event_id!,
-      p_participant_count: reservation.participant_count,
-      p_customer_id: reservation.customer_id!,
-      p_customer_name: reservation.customer_name ?? null,
-      p_customer_email: reservation.customer_email ?? null,
-      p_customer_phone: reservation.customer_phone ?? null,
-      p_notes: reservation.customer_notes ?? null,
-      p_how_found: (reservation as any).how_found ?? null,
-      p_reservation_number: reservationNumber,
-      p_customer_coupon_id: (reservation as any).customer_coupon_id ?? null,
-    }
-    const res = await supabase.rpc('create_reservation_with_lock_v2', createParams)
-
-    if (!res.error) {
-      reservationId = res.data as any
-    } else {
-      error = res.error
-    }
-
-    if (error) {
-      logger.error('予約作成RPCエラー:', error)
-      // 冪等性: reservation_number が UNIQUE の場合、二重作成は 23505 で落ちる。
-      // その場合は既存の予約を取得して成功扱いにする（UIのリトライ/二重送信対策）
-      const errorCode = String((error as any).code || '')
-      const errorMsg = String((error as any).message || '')
-      const isUniqueViolation =
-        errorCode === '23505' ||
-        errorMsg.includes('reservation_number') ||
-        errorMsg.includes('duplicate') ||
-        errorMsg.includes('unique')
-      if (isUniqueViolation && reservationNumber) {
-        try {
-          const { data: existing, error: existingError } = await supabase
-            .from('reservations')
-            .select(RESERVATION_SELECT_FIELDS)
-            .eq('reservation_number', reservationNumber)
-            .single()
-
-          if (!existingError && existing) {
-            return existing
-          }
-        } catch (fetchExistingError) {
-          logger.warn('既存予約の取得に失敗（冪等性フォールバック）:', fetchExistingError)
-        }
-      }
-      if (error.code === 'P0003') {
-        throw new Error('この公演は満席です')
-      }
-      if (error.code === 'P0004') {
-        throw new Error('選択した人数分の空席がありません')
-      }
-      if (error.code === 'P0002') {
-        throw new Error('公演が見つかりません')
-      }
-      if (error.code === 'P0001') {
-        throw new Error('参加人数が不正です')
-      }
-      throw error
-    }
-
-    const { data, error: fetchError } = await supabase
-      .from('reservations')
-      .select(RESERVATION_SELECT_FIELDS)
-      .eq('id', reservationId)
-      .single()
-
-    if (fetchError) throw fetchError
-    return data
+    // organization_id はサーバ側 JWT から取得されるため、フロントの値は送らない（送っても無視）。
+    // 後方互換のため、明示渡しがあれば残す。
+    return apiClient.post<Reservation>('/api/reservations?action=create', {
+      reservation: {
+        schedule_event_id: reservation.schedule_event_id,
+        participant_count: reservation.participant_count,
+        customer_id: reservation.customer_id,
+        customer_name: reservation.customer_name ?? null,
+        customer_email: reservation.customer_email ?? null,
+        customer_phone: reservation.customer_phone ?? null,
+        customer_notes: reservation.customer_notes ?? null,
+        how_found: (reservation as Record<string, unknown>).how_found ?? null,
+        reservation_number: reservation.reservation_number,
+        customer_coupon_id: (reservation as Record<string, unknown>).customer_coupon_id ?? null,
+      },
+    })
   },
 
-  // 予約をキャンセル（RPC + FOR UPDATE）
+  // 予約をキャンセル（RPC + FOR UPDATE をサーバー側で実施）
   async cancelWithLock(reservationId: string, customerId: string | null, reason?: string): Promise<boolean> {
-    const cancelParams: RpcCancelReservationParams = {
-      p_reservation_id: reservationId,
-      p_customer_id: customerId,
-      p_cancellation_reason: reason ?? null,
-    }
-    const { data, error } = await supabase.rpc('cancel_reservation_with_lock', cancelParams)
-
-    if (error) {
-      logger.error('予約キャンセルRPCエラー:', error)
-      throw error
-    }
-
-    // error が無くても false が返るケース（0行更新/権限/想定外）を失敗扱いにする
-    if (data !== true) {
-      logger.error('予約キャンセルRPCが成功扱いにならない:', {
-        reservationId,
-        customerId,
-        data,
-      })
-      throw new Error('予約のキャンセルに失敗しました（DB側で処理できませんでした）')
-    }
-
+    await apiClient.patch<{ success: boolean }>(
+      `/api/reservations?action=cancel-with-lock&id=${encodeURIComponent(reservationId)}`,
+      {
+        customer_id: customerId,
+        cancellation_reason: reason ?? null,
+      }
+    )
     return true
   },
 
   // 予約 + 貸切グループを同一トランザクションでキャンセル（通常キャンセル専用）
   // 却下フロー（skipGroupCancel: true）では使わず、cancelWithLock を使い続けること
   async cancelWithGroupLock(reservationId: string, customerId: string | null, reason?: string): Promise<boolean> {
-    const params: RpcCancelReservationAndGroupParams = {
-      p_reservation_id: reservationId,
-      p_customer_id: customerId,
-      p_cancellation_reason: reason ?? null,
-    }
-    const { data, error } = await supabase.rpc('cancel_reservation_and_group_with_lock', params)
-    if (error) {
-      logger.error('予約+グループキャンセルRPCエラー:', error)
-      throw error
-    }
-    if (data !== true) {
-      throw new Error('予約のキャンセルに失敗しました（DB側で処理できませんでした）')
-    }
+    await apiClient.patch<{ success: boolean }>(
+      `/api/reservations?action=cancel-with-group-lock&id=${encodeURIComponent(reservationId)}`,
+      {
+        customer_id: customerId,
+        cancellation_reason: reason ?? null,
+      }
+    )
     return true
   },
 
-  // 参加人数を変更（RPC + FOR UPDATE）
+  // 参加人数を変更（RPC + FOR UPDATE をサーバー側で実施）
   async updateParticipantsWithLock(
     reservationId: string,
     newCount: number,
     customerId: string | null
   ): Promise<boolean> {
-    const updateParticipantsParams: RpcUpdateReservationParticipantsParams = {
-      p_reservation_id: reservationId,
-      p_new_count: newCount,
-      p_customer_id: customerId,
-    }
-    const { data, error } = await supabase.rpc('update_reservation_participants', updateParticipantsParams)
-
-    if (error) {
-      logger.error('参加人数更新RPCエラー:', error)
-      if (error.code === 'P0008') {
-        throw new Error('選択した人数分の空席がありません')
+    const result = await apiClient.patch<{ success: boolean }>(
+      `/api/reservations?action=update-participants-with-lock&id=${encodeURIComponent(reservationId)}`,
+      {
+        new_count: newCount,
+        customer_id: customerId,
       }
-      if (error.code === 'P0007') {
-        throw new Error('予約が見つかりません')
-      }
-      if (error.code === 'P0006') {
-        throw new Error('参加人数が不正です')
-      }
-      if (error.code === 'P0010') {
-        throw new Error('権限がありません')
-      }
-      if (error.code === 'P0011') {
-        throw new Error('権限がありません')
-      }
-      throw error
-    }
-
-    return Boolean(data)
+    )
+    return Boolean(result?.success)
   },
 
   // 料金/参加者名の再計算（サーバー側で実施）
   async recalculatePrices(reservationId: string, participantNames?: string[] | null): Promise<boolean> {
-    const recalcParams: RpcRecalculateReservationPricesParams = {
-      p_reservation_id: reservationId,
-      p_participant_names: participantNames ?? null,
-    }
-    const { data, error } = await supabase.rpc('admin_recalculate_reservation_prices', recalcParams)
-    if (error) throw error
-    return !!data
+    const result = await apiClient.patch<{ success: boolean }>(
+      `/api/reservations?action=recalculate-prices&id=${encodeURIComponent(reservationId)}`,
+      { participant_names: participantNames ?? null }
+    )
+    return Boolean(result?.success)
   },
 
   // 参加人数を変更（顧客向けシンプルAPI）
@@ -496,7 +325,7 @@ export const reservationApi = {
     const unitPrice = reservation.unit_price || 0
     // 料金は常に unit_price × 人数 で計算
     const oldPrice = unitPrice * oldCount
-    
+
     logger.log('人数変更前の情報:', {
       oldCount,
       newCount,
@@ -513,7 +342,7 @@ export const reservationApi = {
     if (!result) {
       throw new Error('人数変更に失敗しました')
     }
-    
+
     logger.log('人数変更成功（RPC内で完了）')
 
     // schedule_eventsのcurrent_participantsを再計算
@@ -533,8 +362,9 @@ export const reservationApi = {
         // 新料金は unit_price × newCount で計算
         const newPrice = unitPrice * newCount
         const priceDifference = newPrice - oldPrice
-        const scheduleEvent = reservation.schedule_events as any
-        
+        const scheduleEventRaw = reservation.schedule_events as unknown
+        const scheduleEvent = (Array.isArray(scheduleEventRaw) ? scheduleEventRaw[0] : scheduleEventRaw) as Record<string, unknown> | null | undefined
+
         const { error: emailError } = await supabase.functions.invoke('send-booking-change-confirmation', {
           body: {
             organizationId: reservation.organization_id,
@@ -579,9 +409,15 @@ export const reservationApi = {
   },
 
   // 予約を更新
+  // バックエンド API (/api/reservations?action=update) 経由で org_id を強制フィルタ + 所有検証。
+  // sendEmail=true の場合は更新前後の差分を計算して送信用 Edge Function を呼ぶ（従来通り）。
   async update(id: string, updates: Partial<Reservation>, sendEmail: boolean = false): Promise<Reservation> {
     // 変更前のデータを取得（メール送信用）
-    let originalReservation: any = null
+    type OriginalReservationForEmail = {
+      participant_count?: number
+      total_price?: number
+    } & Record<string, unknown>
+    let originalReservation: OriginalReservationForEmail | null = null
     if (sendEmail) {
       const { data: original, error: fetchError } = await supabase
         .from('reservations')
@@ -593,24 +429,15 @@ export const reservationApi = {
       originalReservation = original
     }
 
-    // 🚨 lint/no-restricted-syntax 対応: reservations はRPC経由で更新
-    const updateFieldsParams: RpcAdminUpdateReservationFieldsParams = {
-      p_reservation_id: id,
-      p_updates: updates as unknown as Record<string, unknown>,
-    }
-    const { data: ok, error: updateError } = await supabase.rpc('admin_update_reservation_fields', updateFieldsParams)
-
-    if (updateError) throw updateError
-    if (!ok) throw new Error('予約の更新に失敗しました')
-
-    // 更新後のデータを取得
-    const { data, error } = await supabase
-      .from('reservations')
-      .select(RESERVATION_FOR_UPDATE_EMAIL_SELECT_FIELDS)
-      .eq('id', id)
-      .single()
-
-    if (error) throw error
+    // 更新（サーバー側で admin_update_reservation_fields RPC を呼ぶ）
+    // 戻り値は RESERVATION_FOR_UPDATE_EMAIL_SELECT_FIELDS 形式
+    const data = await apiClient.patch<Reservation & {
+      customers?: Customer | Customer[] | null
+      schedule_events?: Record<string, unknown> | Record<string, unknown>[] | null
+    }>(
+      `/api/reservations?action=update&id=${encodeURIComponent(id)}`,
+      { updates }
+    )
 
     // 変更確認メールを送信（sendEmail=trueの場合のみ）
     if (sendEmail && originalReservation && joinedCustomerFromReservation(data.customers)) {
@@ -632,15 +459,16 @@ export const reservationApi = {
           changes.push({
             field: 'total_price',
             label: '料金',
-            oldValue: `¥${originalReservation.total_price.toLocaleString()}`,
+            oldValue: `¥${(originalReservation.total_price ?? 0).toLocaleString()}`,
             newValue: `¥${updates.total_price.toLocaleString()}`
           })
         }
 
         // 変更がある場合のみメール送信
         if (changes.length > 0) {
-          const scheduleEvent = Array.isArray(data.schedule_events) ? data.schedule_events[0] : data.schedule_events
-          const priceDifference = updates.total_price 
+          const scheduleEventRaw = Array.isArray(data.schedule_events) ? data.schedule_events[0] : data.schedule_events
+          const scheduleEvent = scheduleEventRaw as Record<string, unknown> | null | undefined
+          const priceDifference = updates.total_price
             ? updates.total_price - (originalReservation.total_price || 0)
             : 0
           const cust = joinedCustomerFromReservation(data.customers)
@@ -676,74 +504,53 @@ export const reservationApi = {
   },
 
   // 予約をキャンセル
+  // バックエンド API (/api/reservations?action=cancel) で DB 部分を一括処理し、
+  // メール送信 / Discord 通知 / waitlist 通知などの Edge Function 呼び出しは
+  // 引き続きクライアント側で実行する（既存挙動の維持）。
   async cancel(id: string, cancellationReason?: string, options?: { skipGroupCancel?: boolean }): Promise<Reservation> {
     // ⚠️ P1-12: 相関ID — キャンセル→メール→通知を一つのフローとして追跡
     const clog = createCorrelatedLogger(generateCorrelationId(), 'cancel')
     clog.info('キャンセル開始', { reservationId: id })
 
-    // 予約情報を取得（メール送信用、GM通知用にis_private_bookingとgmsも取得）
-    const { data: reservation, error: fetchError } = await supabase
-      .from('reservations')
-      .select(RESERVATION_WITH_CUSTOMER_AND_EVENT_SELECT_FIELDS)
-      .eq('id', id)
-      .single()
-
-    if (fetchError) throw fetchError
-    if (!reservation) {
-      throw new Error('予約情報の取得に失敗しました')
+    // サーバー側で予約 fetch + RPC キャンセル + システムメッセージ送信まで実施
+    type ReservationCancelContext = Reservation & {
+      customers?: Customer | Customer[] | null
+      schedule_events?: Record<string, unknown> | Record<string, unknown>[] | null
+      customer_name?: string | null
+      customer_email?: string | null
+      private_group_id?: string | null
     }
+    const orchestrated = await apiClient.patch<{
+      reservation: Reservation
+      contextForNotifications: {
+        reservation: ReservationCancelContext
+        organization_slug: string | null
+        skip_group_cancel: boolean
+      }
+    }>(
+      `/api/reservations?action=cancel&id=${encodeURIComponent(id)}`,
+      {
+        cancellation_reason: cancellationReason ?? null,
+        skip_group_cancel: Boolean(options?.skipGroupCancel),
+      }
+    )
 
-    // 通常キャンセル: 予約 + グループを1トランザクションで処理
-    // 却下フロー（skipGroupCancel: true）は cancelWithLock のみ使い、グループは別RPC で date_adjusting へ
-    if (options?.skipGroupCancel) {
-      await reservationApi.cancelWithLock(id, reservation.customer_id ?? null, cancellationReason)
-    } else {
-      await reservationApi.cancelWithGroupLock(id, reservation.customer_id ?? null, cancellationReason)
-      clog.info('予約+グループをatomicにキャンセル', { reservationId: id, groupId: reservation.private_group_id })
+    const data = orchestrated.reservation
+    const ctx = orchestrated.contextForNotifications
+    const reservation = ctx.reservation
+
+    if (reservation?.private_group_id && !options?.skipGroupCancel) {
+      clog.info('予約+グループをatomicにキャンセル + システムメッセージ送信', {
+        reservationId: id,
+        groupId: reservation.private_group_id,
+      })
     }
-
-    // 貸切グループのシステムメッセージ送信（グループキャンセルの場合のみ）
-    if (reservation.private_group_id && !options?.skipGroupCancel) {
-      
-      // システムメッセージ設定を取得
-      const { data: settings } = await supabase
-        .from('global_settings')
-        .select(GLOBAL_SETTINGS_MSG_SELECT.BOOKING_CANCELLED)
-        .eq('organization_id', reservation.organization_id)
-        .maybeSingle()
-      
-      const title = settings?.system_msg_booking_cancelled_title || 'ご予約がキャンセルされました'
-      const body = settings?.system_msg_booking_cancelled_body || cancellationReason || '誠に申し訳ございませんが、やむを得ない事情によりご予約がキャンセルとなりました。'
-      
-      // グループチャットにシステムメッセージを送信
-      await supabase
-        .from('private_group_messages')
-        .insert({
-          group_id: reservation.private_group_id,
-          sender_type: 'system',
-          message: JSON.stringify({
-            type: 'system',
-            action: 'booking_cancelled',
-            title,
-            body
-          })
-        })
-      clog.info('キャンセル通知をグループに送信', { groupId: reservation.private_group_id })
-    }
-
-    const { data, error } = await supabase
-      .from('reservations')
-      .select(RESERVATION_SELECT_FIELDS)
-      .eq('id', id)
-      .single()
-
-    if (error) throw error
 
     // キャンセル確認メールを送信
-    const cancelMailCustomer = joinedCustomerFromReservation(reservation.customers)
+    const cancelMailCustomer = joinedCustomerFromReservation(reservation?.customers)
     // 貸切予約など customers.email が null の場合は reservation.customer_email をフォールバックとして使う
-    const cancelMailEmail = cancelMailCustomer?.email || (reservation as any).customer_email || null
-    const cancelMailName = cancelMailCustomer?.name || (reservation as any).customer_name || null
+    const cancelMailEmail = cancelMailCustomer?.email || reservation?.customer_email || null
+    const cancelMailName = cancelMailCustomer?.name || reservation?.customer_name || null
     if (reservation && cancelMailEmail) {
       try {
         const scheduleEvent = Array.isArray(reservation.schedule_events) ? reservation.schedule_events[0] : reservation.schedule_events
@@ -784,22 +591,7 @@ export const reservationApi = {
         // キャンセル待ち通知を送信
         const orgIdForWaitlist = reservation.organization_id || scheduleEvent?.organization_id
         if (reservation.schedule_event_id && orgIdForWaitlist) {
-          // 組織のslugを取得（bookingUrlはサーバー側で生成するため参照のみ）
-          let orgSlug = ''
-          try {
-            const { data: org } = await supabase
-              .from('organizations')
-              .select('slug')
-              .eq('id', orgIdForWaitlist)
-              .single()
-
-            orgSlug = org?.slug || ''
-          } catch (orgError) {
-            logger.warn('組織slug取得エラー:', orgError)
-          }
-          
-          // 🔒 SEC-P0-03対策: bookingUrl はサーバー側で生成（送信しない）
-          
+          // 組織のslugはサーバー側で取得済み（ctx.organization_slug）
           try {
             // ⚠️ P1-8: べき等性キー（同じキャンセルに対する重複待ちリスト通知を防止）
             const waitlistIdempotencyKey = `waitlist-notify-${reservation.id}-${reservation.schedule_event_id}`
@@ -815,14 +607,14 @@ export const reservationApi = {
               idempotencyKey: waitlistIdempotencyKey
               // bookingUrl を削除（サーバー側で生成）
             }
-            
+
             await supabase.functions.invoke('notify-waitlist', {
               body: notificationData
             })
             logger.log('キャンセル待ち通知送信成功')
           } catch (waitlistError) {
             logger.error('キャンセル待ち通知エラー:', waitlistError)
-            
+
             // 通知失敗をキューに記録（リトライ用）
             try {
               await supabase.from('waitlist_notification_queue').insert({
@@ -852,11 +644,26 @@ export const reservationApi = {
     }
 
     // 貸切予約のキャンセル時、担当GMにDiscord通知を送信
-    const scheduleEventForGM = Array.isArray(reservation.schedule_events) 
-      ? reservation.schedule_events[0] 
-      : reservation.schedule_events
-    
-    if (scheduleEventForGM?.is_private_booking && scheduleEventForGM?.gms?.length > 0) {
+    const scheduleEventForGMRaw = Array.isArray(reservation?.schedule_events)
+      ? reservation.schedule_events[0]
+      : reservation?.schedule_events
+    const scheduleEventForGM = scheduleEventForGMRaw as
+      | (Record<string, unknown> & {
+          is_private_booking?: boolean | null
+          gms?: string[] | null
+          organization_id?: string | null
+          id?: string | null
+          scenario?: string | null
+          date?: string | null
+          start_time?: string | null
+          end_time?: string | null
+          venue?: string | null
+          store_id?: string | null
+        })
+      | null
+      | undefined
+
+    if (scheduleEventForGM?.is_private_booking && (scheduleEventForGM.gms?.length ?? 0) > 0) {
       try {
         const orgId = reservation.organization_id || scheduleEventForGM.organization_id
         const gmNotifyCustomer = joinedCustomerFromReservation(reservation.customers)
@@ -888,27 +695,15 @@ export const reservationApi = {
 
   // 予約を削除
   async delete(id: string): Promise<void> {
-    const deleteByIdsParams: RpcAdminDeleteReservationsByIdsParams = {
-      p_reservation_ids: [id],
-    }
-    const { error } = await supabase.rpc('admin_delete_reservations_by_ids', deleteByIdsParams)
-    if (error) throw error
+    await apiClient.delete<{ success: boolean }>(`/api/reservations?id=${encodeURIComponent(id)}`)
   },
 
   // 予約サマリーを取得
   async getSummary(scheduleEventId?: string): Promise<ReservationSummary[]> {
-    let query = supabase
-      .from('reservation_summary')
-      .select('schedule_event_id, date, venue, scenario, start_time, end_time, max_participants, current_reservations, available_seats, reservation_count')
-    
-    if (scheduleEventId) {
-      query = query.eq('schedule_event_id', scheduleEventId)
-    }
-    
-    const { data, error } = await query
-    
-    if (error) throw error
-    return data || []
+    const url = scheduleEventId
+      ? `/api/reservations?type=summary&schedule_event_id=${encodeURIComponent(scheduleEventId)}`
+      : '/api/reservations?type=summary'
+    return apiClient.get<ReservationSummary[]>(url)
   },
 
   // スケジュールイベントの空席状況を取得
@@ -917,38 +712,20 @@ export const reservationApi = {
     currentReservations: number
     availableSeats: number
   }> {
-    const { data, error } = await supabase
-      .from('reservation_summary')
-      .select('schedule_event_id, max_participants, current_reservations, available_seats')
-      .eq('schedule_event_id', scheduleEventId)
-      .single()
-    
-    if (error) {
-      if (error.code === 'PGRST116') {
-        // データがない場合は0で返す
-        return {
-          maxParticipants: null,
-          currentReservations: 0,
-          availableSeats: 0
-        }
-      }
-      throw error
-    }
-    
-    return {
-      maxParticipants: data.max_participants,
-      currentReservations: data.current_reservations,
-      availableSeats: data.available_seats
-    }
+    return apiClient.get<{
+      maxParticipants: number | null
+      currentReservations: number
+      availableSeats: number
+    }>(`/api/reservations?type=availability&schedule_event_id=${encodeURIComponent(scheduleEventId)}`)
   },
 
   // スタッフ参加の予約を同期する関数
   // GM欄の「スタッフ参加」と予約データを同期
   // ※ 手動追加された予約（staff_participation, walk_in, web等）は削除しない
   async syncStaffReservations(
-    eventId: string, 
-    gms: string[], 
-    gmRoles: Record<string, string>, 
+    eventId: string,
+    gms: string[],
+    gmRoles: Record<string, string>,
     eventDetails?: {
       date: string,
       start_time: string,
@@ -962,7 +739,7 @@ export const reservationApi = {
       // 1. スタッフ参加のGMリストを作成
       const staffParticipants = gms.filter(gm => gmRoles[gm] === 'staff')
 
-      // 2. 現在の予約を取得
+      // 2. 現在の予約を取得（サーバー側で org_id 強制フィルタ）
       const currentReservations = await this.getByScheduleEvent(eventId)
 
       // 3. すべてのアクティブなスタッフ予約を抽出（重複チェック用）
@@ -986,7 +763,7 @@ export const reservationApi = {
       // ※ 名前の完全一致で比較（trimして比較）
       const toAdd = staffParticipants.filter(staffName => {
         const trimmedName = staffName.trim()
-        return !activeStaffReservations.some(r => 
+        return !activeStaffReservations.some(r =>
           r.participant_names?.some(name => name.trim() === trimmedName)
         )
       })
@@ -997,96 +774,78 @@ export const reservationApi = {
       // ※ web, walk_in 等は保護（一般顧客の予約を誤削除しない）
       // ※ 名前の完全一致で比較（trimして比較）
       const toRemove = managedStaffReservations.filter(r =>
-        !r.participant_names?.some(name => 
+        !r.participant_names?.some(name =>
           staffParticipants.some(sp => sp.trim() === name.trim())
         )
       )
 
       logger.log('🔄 スタッフ予約同期:', {
         staffParticipants,
-        activeStaffReservations: activeStaffReservations.map(r => ({ 
+        activeStaffReservations: activeStaffReservations.map(r => ({
           id: r.id,
-          name: r.participant_names, 
+          name: r.participant_names,
           source: r.reservation_source,
-          status: r.status 
+          status: r.status
         })),
         toAdd,
-        toRemove: toRemove.map(r => ({ 
+        toRemove: toRemove.map(r => ({
           id: r.id,
-          name: r.participant_names, 
+          name: r.participant_names,
           source: r.reservation_source,
-          status: r.status 
+          status: r.status
         }))
       })
 
       // 7. 実行
-      // 追加（スタッフ予約は通常のRPCではなく直接INSERTを使用）
-      // ※ create()はcreate_reservation_with_lock_v2 RPCを使用するが、
-      //    このRPCはpayment_method, reservation_source, participant_namesをサポートしていないため
+      // 追加: 専用エンドポイント /api/reservations?action=create-staff-entry を呼ぶ
+      // （通常の create_reservation_with_lock_v2 RPC は payment_method='staff' /
+      //   reservation_source='staff_entry' / participant_names をサポートしないため）
       if (eventDetails && toAdd.length > 0) {
-        // organization_idを取得
-        const organizationId = await getCurrentOrganizationId()
-        if (!organizationId) {
-          throw new Error('組織情報が取得できません')
-        }
-
         for (const staffName of toAdd) {
-          // 予約番号を生成
-          const now = new Date()
-          const dateStr = now.toISOString().slice(2, 10).replace(/-/g, '')
-          const randomStr = Math.random().toString(36).substring(2, 6).toUpperCase()
-          const reservationNumber = `${dateStr}-${randomStr}`
-
-          const staffReservation = {
-            organization_id: organizationId,
-            schedule_event_id: eventId,
-            reservation_number: reservationNumber,
-            title: eventDetails.scenario_title || '',
-            scenario_master_id: eventDetails.scenario_master_id || null,
-            store_id: eventDetails.store_id || null,
-            customer_id: null,
-            customer_notes: staffName,
-            requested_datetime: `${eventDetails.date}T${eventDetails.start_time}+09:00`,
-            duration: eventDetails.duration || 120,
-            participant_count: 1,
-            participant_names: [staffName],
-            assigned_staff: [], 
-            base_price: 0,
-            options_price: 0,
-            total_price: 0,
-            discount_amount: 0,
-            final_price: 0,
-            payment_method: 'staff',
-            payment_status: 'paid',
-            status: 'confirmed',
-            reservation_source: RESERVATION_SOURCE.STAFF_ENTRY
-          }
-
-          logger.log('📝 スタッフ予約を作成:', { staffName, reservationNumber })
-          
-          const { error: insertError } = await supabase
-            .from('reservations')
-            .insert([staffReservation])
-
-          if (insertError) {
+          logger.log('📝 スタッフ予約を作成:', { staffName })
+          try {
+            await apiClient.post('/api/reservations?action=create-staff-entry', {
+              schedule_event_id: eventId,
+              staff_name: staffName,
+              event_details: {
+                date: eventDetails.date,
+                start_time: eventDetails.start_time,
+                scenario_master_id: eventDetails.scenario_master_id ?? null,
+                scenario_title: eventDetails.scenario_title ?? null,
+                store_id: eventDetails.store_id ?? null,
+                duration: eventDetails.duration ?? 120,
+              },
+            })
+          } catch (insertError) {
             logger.error('スタッフ予約作成エラー:', insertError)
           }
         }
       }
 
-      // 削除（キャンセル）- staff_entry と staff_participation が対象
-      for (const res of toRemove) {
-        if (res.status !== 'cancelled') {
-          logger.log('🗑️ スタッフ予約を削除:', { name: res.participant_names, source: res.reservation_source })
-          await this.update(res.id, { status: 'cancelled' })
+      // 削除（キャンセル）- staff_entry が対象
+      // バックエンド経由で一括ステータス更新する（旧実装の for-await update よりも N+1 回避）
+      const activeToRemoveIds = toRemove
+        .filter(r => r.status !== 'cancelled')
+        .map(r => r.id)
+      if (activeToRemoveIds.length > 0) {
+        try {
+          await apiClient.patch('/api/reservations?action=sync-staff-reservation-statuses', {
+            reservation_ids: activeToRemoveIds,
+            status: 'cancelled',
+          })
+          for (const res of toRemove.filter(r => r.status !== 'cancelled')) {
+            logger.log('🗑️ スタッフ予約を削除:', { name: res.participant_names, source: res.reservation_source })
+          }
+        } catch (removeError) {
+          logger.error('スタッフ予約一括キャンセルエラー:', removeError)
         }
       }
 
       // 🚨 CRITICAL: 参加者数を予約テーブルから再計算して更新
       // 相対的な加減算ではなく、常に予約テーブルから集計して絶対値を設定
       const addedCount = toAdd.length
-      const removedCount = toRemove.filter(r => r.status !== 'cancelled').length
-      
+      const removedCount = activeToRemoveIds.length
+
       if (addedCount > 0 || removedCount > 0) {
         try {
           const newCount = await recalculateCurrentParticipants(eventId)


### PR DESCRIPTION
## Summary

reservationApi の write 系（create / update / cancel / cancelWithLock /
cancelWithGroupLock / updateParticipantsWithLock / recalculatePrices /
updateParticipantCount / delete / syncStaffReservations）と残り read 系
（getByScheduleEvent / getByCustomer / getSummary / getAvailability）を
`/api/reservations` 経由に切り替え、`organization_id` はサーバ側で JWT から
取得して強制適用するように変更。

複数組織が登録されたあとも安全なように、write 系では対象 `reservation` /
`schedule_event` / `customer` が自組織所有か明示検証してから書き込む
（service_role が RLS をバイパスする前提で、サーバコード側に org_id 検証を
寄せる）。

## 新規エンドポイント

`/api/reservations` を以下のように拡張:

- **GET**
  - 既存: `?` （一覧）, `?start=&end=` （期間内一覧）
  - 追加: `?type=by-schedule-event&schedule_event_id=...`
  - 追加: `?type=by-customer&customer_id=...`
  - 追加: `?type=summary[&schedule_event_id=...]`
  - 追加: `?type=availability&schedule_event_id=...`
- **POST**
  - `?action=create` — RPC `create_reservation_with_lock_v2` 経由
  - `?action=create-staff-entry` — GM 欄スタッフ参加用の直接 INSERT
- **PATCH**
  - `?action=update&id=...` — RPC `admin_update_reservation_fields` 経由
  - `?action=cancel&id=...` — 予約取得 + RPC キャンセル + システムメッセージ送信を一括（複合フロー）
  - `?action=cancel-with-lock&id=...` — RPC `cancel_reservation_with_lock` 経由
  - `?action=cancel-with-group-lock&id=...` — RPC `cancel_reservation_and_group_with_lock` 経由
  - `?action=update-participants-with-lock&id=...` — RPC `update_reservation_participants` 経由
  - `?action=recalculate-prices&id=...` — RPC `admin_recalculate_reservation_prices` 経由
  - `?action=sync-staff-reservation-statuses` — `syncStaffReservations` 用の一括ステータス更新
- **DELETE**
  - `?id=...` — RPC `admin_delete_reservations_by_ids` 経由

## セキュリティ強化点

- `organization_id` は **クライアント引数を一切受け付けず**、サーバが JWT から取得する。
- write 系全エンドポイントで `ensureReservationOwnedByOrg()` により「対象予約が自組織のものか」を先に検証してから RPC / UPDATE を呼ぶ。
- `create` では `schedule_event_id` / `customer_id` がそれぞれ自組織のものか検証。
- 顧客ロール（`role=customer`）が他人の `customer` 行に紐づく予約を作れないよう、`customers.user_id` と JWT の `userId` を突合。
- RPC（`create_reservation_with_lock_v2` / `cancel_reservation_with_lock` /
  `admin_update_reservation_fields` 等）は SECURITY DEFINER で内部的に
  `auth.uid()` / `get_user_organization_id()` / `is_org_admin()` を参照する。
  service_role クライアントでは `auth.uid()` が NULL になるため、
  **`createUserScopedClient(jwt)`**（`VITE_SUPABASE_PUBLISHABLE_KEY` か
  `VITE_SUPABASE_ANON_KEY` を使い JWT を Authorization にセットした
  Supabase クライアント）を新設し、RPC 呼び出しに使用。これにより
  RPC 側の権限判定を活かしつつ、サーバ側でも org_id を検証する二重防御。
- `cancel()` フロー: DB 部分（予約取得 + RPC + システムメッセージ INSERT）を
  サーバに寄せ、Edge Function（メール送信・Discord 通知・waitlist 通知）は
  クライアント側に残置（旧挙動と互換）。

## 互換性

- フロント側の API シグネチャ（`reservationApi.create(reservation)` 等）は
  変更なし。`organizationId` 引数は受け付けるが無視（後方互換）。
- `getAll` / `getByDateRange` は既存マイグレーション済みのため触っていない。

## TODO / 既知の制約

- `api/_lib/auth.ts` の `createUserScopedClient` は `SUPABASE_PUBLISHABLE_KEY` /
  `SUPABASE_ANON_KEY`（または `VITE_` プレフィックス版）のいずれかを必要とする。
  Vercel の Environment Variables に `VITE_SUPABASE_ANON_KEY` が既に設定済みなら
  そのまま動くはず（フロントビルド向けと共用）。未設定の場合は 500 を返す。

## Test plan

- [ ] `/api/reservations?type=by-schedule-event&schedule_event_id=...` でモーダルの予約一覧が表示される
- [ ] 予約作成（一般予約サイト）が成功し、満席ロジックが効く
- [ ] スタッフが予約を更新（人数変更・GM 変更）してメール送信が走る
- [ ] スタッフが予約を削除して `current_participants` が再計算される
- [ ] 顧客が自分の予約をキャンセル（waitlist 通知 / キャンセル確認メールが送られる）
- [ ] 貸切予約のキャンセル（GM への Discord 通知が走る）
- [ ] GM スタッフの追加・削除がスケジュール編集モーダル経由で同期される
- [ ] 他組織の予約 ID を直接叩いて 403 が返ることを確認
- [ ] `npx tsc -p tsconfig.json --noEmit` パス
- [ ] `node scripts/check-security-guardrails.mjs` exit 0
- [ ] `npm run lint` 致命的エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)