### PR TITLE
fix(edge-functions/invite-staff): listUsers のページネーション対応（auth.users 50件超で招待失敗するバグ）

### DIFF
--- a/supabase/functions/invite-staff/index.ts
+++ b/supabase/functions/invite-staff/index.ts
@@ -150,12 +150,24 @@ serve(async (req) => {
     console.log('📨 Staff invitation request:', { email: maskEmail(email), name: maskName(name) })
 
     const normalizedEmail = email.toLowerCase()
-    const { data: userList, error: listError } = await supabase.auth.admin.listUsers()
-    if (listError) {
-      throw new Error(`ユーザー一覧の取得に失敗しました: ${listError.message}`)
+    // listUsers はデフォルト 50 件のみ取得するので、対象 email がページ後方にいると
+    // 「未登録」と誤判定 → createUser → 「Email already registered」で 500 になる。
+    // ページネーションで全件走査して既存ユーザーを探す。
+    const PER_PAGE = 1000 // listUsers の上限
+    let existingUser: { id: string; email?: string | null } | undefined
+    for (let page = 1; ; page++) {
+      const { data: pageData, error: listError } = await supabase.auth.admin.listUsers({ page, perPage: PER_PAGE })
+      if (listError) {
+        throw new Error(`ユーザー一覧の取得に失敗しました: ${listError.message}`)
+      }
+      const users = pageData?.users ?? []
+      const found = users.find((user) => user.email?.toLowerCase() === normalizedEmail)
+      if (found) {
+        existingUser = found
+        break
+      }
+      if (users.length < PER_PAGE) break // 最終ページ
     }
-
-    const existingUser = userList?.users.find((user) => user.email?.toLowerCase() === normalizedEmail)
     let userId: string
     let isNewUser = false
 


### PR DESCRIPTION
## Summary
スタッフ招待 Edge Function (`supabase/functions/invite-staff/index.ts`) の `supabase.auth.admin.listUsers()` をページネーション対応。

## 再現条件 / 影響
- プロジェクトの `auth.users` が **50 件を超える** と発生
- 既存ユーザーがページ後方 (51 件目以降) にいると `listUsers()` の最初の 50 件には含まれない
- → Edge Function が「未登録」と判定 → `createUser` 呼び出し
- → Supabase Auth が「Email already registered」で 422 返却
- → Edge Function 全体が `エラーが発生しました` で 500 終了

staging (570 ユーザー) で再現確認済み。**本番でも 50 件超えた瞬間から起きる潜在バグ**。

## 修正内容
- `listUsers()` を `{ page, perPage: 1000 }` でループ呼び出し
- 各ページで対象 email を検索、見つかれば break
- 最終ページ（returned count < perPage）に到達したら break して未登録と判定

## Test plan
- [ ] staging デプロイ後、`auth.users` の 51 件目以降にいる既存 email でスタッフ招待を試行 → 既存ユーザーとして適切にハンドリングされる
- [ ] 未登録の新規 email でスタッフ招待 → 正常に作成・招待メール送信
- [ ] 既存ユーザー（admin）への role 上書きが起きていないか確認

## 補足
他の Edge Functions に同様の `admin.listUsers()` 利用箇所がないか調査済み → invite-staff のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)