### PR TITLE
refactor(ui): PageHeader 統一 & ローカル dev 環境を staging proxy 構成へ

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:vercel": "bash scripts/dev-local.sh",
+    "dev:stop": "lsof -ti:3000,5173 -sTCP:LISTEN 2>/dev/null | xargs -r kill || true",
     "build": "tsc --noEmit & vite build & wait",
     "build:fast": "vite build",
     "preview": "vite preview",

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ローカル開発サーバー起動スクリプト
+# - port 5173 が空いていれば npm run dev (vite) を起動
+# - /api/* は vite.config.ts の proxy 経由でステージングへ
+# - ブラウザは http://localhost:5173 を開く
+#
+# 注: 以前は vercel dev (port 3000) を起動して /api/* もローカルで動かす構成だったが、
+# macOS 上で vercel dev が spawn EBADF を起こし API 関数が実行できないため、
+# Vite proxy → staging deploy の構成に変更した。
+
+set -u
+
+cd "$(dirname "$0")/.."
+
+# 既存の vite を kill（5173 を解放）
+pid=$(lsof -ti:5173 -sTCP:LISTEN 2>/dev/null || true)
+if [[ -n "$pid" ]]; then
+  echo "🧹 port 5173 を使っている PID $pid を kill します"
+  kill "$pid" 2>/dev/null || true
+  sleep 1
+fi
+
+echo "🚀 vite を port 5173 で起動します（ブラウザは http://localhost:5173 を開いてください）"
+echo "   /api/* はステージング deploy に proxy されます"
+exec npm run dev

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
 
 interface PageHeaderProps {
   /**
@@ -7,9 +8,9 @@ interface PageHeaderProps {
    */
   title: ReactNode
   /**
-   * ページの説明文
+   * ページの説明文（省略可）
    */
-  description: string
+  description?: string
   /**
    * ヘッダー右側に配置する要素（ボタンなど）
    */
@@ -42,13 +43,15 @@ export function PageHeader({
   className = ''
 }: PageHeaderProps) {
   return (
-    <div className={`mb-6 ${className}`}>
+    <div className={cn('mb-6', className)}>
       <div className="flex flex-row items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
           <h1 className="text-xl font-bold tracking-tight break-words flex items-center gap-2">{title}</h1>
-          <p className="text-xs text-muted-foreground mt-1.5 break-words leading-normal">
-            {description}
-          </p>
+          {description && (
+            <p className="text-xs text-muted-foreground mt-1.5 break-words leading-normal">
+              {description}
+            </p>
+          )}
         </div>
         {children && (
           <div className="flex gap-2 flex-shrink-0 items-start">

--- a/src/pages/AccountManagement/index.tsx
+++ b/src/pages/AccountManagement/index.tsx
@@ -6,7 +6,9 @@
  * @organization 全組織
  */
 import { useSearchParams } from 'react-router-dom'
+import { Users } from 'lucide-react'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { UserManagementContent } from './pages/UserManagementContent'
 import { CustomerManagementContent } from './pages/CustomerManagementContent'
 
@@ -28,6 +30,10 @@ export function AccountManagement() {
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}
     >
+      <PageHeader
+        title={<><Users className="h-5 w-5" />アカウント管理</>}
+        description="スタッフ・顧客アカウントの統合管理"
+      />
       {renderContent()}
     </AppLayout>
   )

--- a/src/pages/AccountManagement/pages/CustomerManagementContent.tsx
+++ b/src/pages/AccountManagement/pages/CustomerManagementContent.tsx
@@ -42,12 +42,7 @@ export function CustomerManagementContent() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title={
-          <div className="flex items-center gap-2">
-            <Users className="h-5 w-5 text-primary" />
-            <span className="text-lg font-bold">顧客</span>
-          </div>
-        }
+        title={<><Users className="h-5 w-5 text-primary" />顧客</>}
         description={`全${customers.length}名の予約顧客を管理`}
       >
         <HelpButton topic="customer" label="顧客管理マニュアル" />

--- a/src/pages/AccountManagement/pages/UserManagementContent.tsx
+++ b/src/pages/AccountManagement/pages/UserManagementContent.tsx
@@ -230,12 +230,7 @@ export function UserManagementContent() {
     <>
       <div className="space-y-3 sm:space-y-4 md:space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <UserCog className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">ユーザー管理</span>
-            </div>
-          }
+          title={<><UserCog className="h-5 w-5 text-primary" />ユーザー管理</>}
           description="スタッフ・管理者のアカウントとロールを管理"
         >
           <HelpButton topic="user" label="ユーザー管理マニュアル" />

--- a/src/pages/BlogManagement.tsx
+++ b/src/pages/BlogManagement.tsx
@@ -2,7 +2,9 @@
  * ブログ管理ページ
  * @path /{org}/blog
  */
+import { Newspaper } from 'lucide-react'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { BlogSettings } from './Settings/pages/BlogSettings'
 
 export function BlogManagement() {
@@ -12,6 +14,10 @@ export function BlogManagement() {
       maxWidth="max-w-6xl"
       containerPadding="px-4 py-6"
     >
+      <PageHeader
+        title={<><Newspaper className="h-5 w-5" />ブログ管理</>}
+        description="記事の作成・編集・公開設定"
+      />
       <BlogSettings />
     </AppLayout>
   )

--- a/src/pages/CouponManagement/index.tsx
+++ b/src/pages/CouponManagement/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
 import { Header } from '@/components/layout/Header'
 import { AdminSidebar } from '@/components/layout/AdminSidebar'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { Button } from '@/components/ui/button'
 import { Plus, RefreshCw, Ticket } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
@@ -115,26 +116,23 @@ export function CouponManagement() {
       <div className="flex flex-1">
         {shouldShowNavigation && <AdminSidebar />}
         <main className="flex-1 max-w-[1440px] mx-auto px-[10px] py-3 sm:py-4 md:py-6">
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-3">
-            <Ticket className="h-6 w-6" />
-            <h1 className="text-2xl font-bold">クーポン管理</h1>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={loadCampaigns}
-              disabled={isLoading}
-            >
-              <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
-            </Button>
-            <Button onClick={handleCreateNew}>
-              <Plus className="h-4 w-4 mr-2" />
-              新規キャンペーン
-            </Button>
-          </div>
-        </div>
+        <PageHeader
+          title={<><Ticket className="h-5 w-5" />クーポン管理</>}
+          description="クーポンキャンペーンの作成・配布・利用状況を管理"
+        >
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={loadCampaigns}
+            disabled={isLoading}
+          >
+            <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+          </Button>
+          <Button onClick={handleCreateNew}>
+            <Plus className="h-4 w-4 mr-2" />
+            新規キャンペーン
+          </Button>
+        </PageHeader>
 
         <CampaignList
           campaigns={campaigns}

--- a/src/pages/CustomerManagement/index.tsx
+++ b/src/pages/CustomerManagement/index.tsx
@@ -52,12 +52,7 @@ export default function CustomerManagement() {
     >
       <div className="space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <Users className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">顧客管理</span>
-            </div>
-          }
+          title={<><Users className="h-5 w-5 text-primary" />顧客管理</>}
           description={`全${customers.length}名の顧客を管理`}
         >
           <HelpButton topic="customer" label="顧客管理マニュアル" />

--- a/src/pages/ExternalReports/index.tsx
+++ b/src/pages/ExternalReports/index.tsx
@@ -74,12 +74,7 @@ export default function ExternalReports() {
     >
     <div className="space-y-6">
       <PageHeader
-        title={
-          <div className="flex items-center gap-2">
-            <FileText className="h-5 w-5 text-primary" />
-            <span className="text-lg font-bold">公演報告</span>
-        </div>
-        }
+        title={<><FileText className="h-5 w-5 text-primary" />公演報告</>}
         description="管理シナリオの公演実績を報告"
       >
         <Button onClick={() => setIsCreateDialogOpen(true)}>

--- a/src/pages/GMAvailabilityCheck/index.tsx
+++ b/src/pages/GMAvailabilityCheck/index.tsx
@@ -108,12 +108,7 @@ export function GMAvailabilityCheck() {
     >
       <div className="space-y-4">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <UserCheck className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">GM可否確認</span>
-            </div>
-          }
+          title={<><UserCheck className="h-5 w-5 text-primary" />GM可否確認</>}
           description="貸切予約のGM可否を確認・回答します"
         />
 

--- a/src/pages/LicenseManagement/index.tsx
+++ b/src/pages/LicenseManagement/index.tsx
@@ -6,8 +6,9 @@
  */
 import { useSearchParams } from 'react-router-dom'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, AlertCircle } from 'lucide-react'
+import { Loader2, AlertCircle, FileCheck } from 'lucide-react'
 import { useOrganization } from '@/hooks/useOrganization'
 import { ReportsReceived } from './tabs/ReportsReceived'
 import { SendReports } from './tabs/SendReports'
@@ -54,6 +55,10 @@ export default function LicenseManagement() {
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}
     >
+      <PageHeader
+        title={<><FileCheck className="h-5 w-5" />ライセンス管理</>}
+        description="公演報告の送信・受信・ライセンス料の集計"
+      />
       {renderContent()}
     </AppLayout>
   )

--- a/src/pages/LicenseReportManagement/index.tsx
+++ b/src/pages/LicenseReportManagement/index.tsx
@@ -37,6 +37,7 @@ import { format } from '@/lib/dateFns'
 import { ja } from 'date-fns/locale'
 import type { ExternalPerformanceReport } from '@/types'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 
 export default function LicenseReportManagement() {
   const { organization, staff, isLicenseManager, isLoading: orgLoading } = useOrganization()
@@ -98,16 +99,10 @@ export default function LicenseReportManagement() {
       stickyLayout={true}
     >
     <div className="space-y-6">
-      {/* ヘッダー */}
-      <div>
-        <h1 className="text-2xl font-bold flex items-center gap-2">
-          <FileCheck className="w-6 h-6" />
-          ライセンス報告管理
-        </h1>
-        <p className="text-muted-foreground mt-1">
-          外部からの公演報告の確認と承認
-        </p>
-      </div>
+      <PageHeader
+        title={<><FileCheck className="w-5 h-5" />ライセンス報告管理</>}
+        description="外部からの公演報告の確認と承認"
+      />
 
       <Tabs defaultValue="reports" className="space-y-6">
         <TabsList>

--- a/src/pages/Manual/index.tsx
+++ b/src/pages/Manual/index.tsx
@@ -486,12 +486,7 @@ export function ManualPage() {
     >
       <div className="space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <BookOpen className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">操作マニュアル</span>
-            </div>
-          }
+          title={<><BookOpen className="h-5 w-5 text-primary" />操作マニュアル</>}
           description="システムの操作方法と使用シーンについてのガイド"
         />
         {renderContent()}

--- a/src/pages/OrganizationManagement/index.tsx
+++ b/src/pages/OrganizationManagement/index.tsx
@@ -141,12 +141,7 @@ export default function OrganizationManagement() {
     <AppLayout currentPage="organizations" maxWidth="max-w-[1440px]" containerPadding="px-[10px] py-3 sm:py-4 md:py-6">
       <div className="space-y-6">
       <PageHeader
-        title={
-          <div className="flex items-center gap-2">
-            <Building2 className="h-5 w-5 text-primary" />
-            <span className="text-lg font-bold">テナント管理</span>
-        </div>
-        }
+        title={<><Building2 className="h-5 w-5 text-primary" />テナント管理</>}
         description="MMQシステムを利用する加盟店（組織）の一覧管理"
       >
         <Button onClick={() => setIsCreateDialogOpen(true)}>

--- a/src/pages/OrganizationSettings/index.tsx
+++ b/src/pages/OrganizationSettings/index.tsx
@@ -180,12 +180,7 @@ export default function OrganizationSettings() {
     <AppLayout currentPage="organization-settings" maxWidth="max-w-[1440px]" containerPadding="px-[10px] py-3 sm:py-4 md:py-6">
       <div className="space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <Building2 className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">会社情報</span>
-            </div>
-          }
+          title={<><Building2 className="h-5 w-5 text-primary" />会社情報</>}
           description={`${organization.name} の基本情報と管理者の招待`}
         />
 

--- a/src/pages/PrivateBookingManagement/PrivateGroupListPage.tsx
+++ b/src/pages/PrivateBookingManagement/PrivateGroupListPage.tsx
@@ -1,4 +1,6 @@
+import { Users } from 'lucide-react'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { PrivateGroupList } from './components/PrivateGroupList'
 
 export default function PrivateGroupListPage() {
@@ -7,6 +9,10 @@ export default function PrivateGroupListPage() {
       currentPage="private-booking-groups"
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
     >
+      <PageHeader
+        title={<><Users className="h-5 w-5" />グループ一覧</>}
+        description="貸切公演グループの管理（招待状況・確定日・アンケート通知など）"
+      />
       <PrivateGroupList />
     </AppLayout>
   )

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -487,12 +487,7 @@ export function PrivateBookingManagement() {
     >
       <div className="space-y-4">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <Calendar className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">貸切予約管理</span>
-            </div>
-          }
+          title={<><Calendar className="h-5 w-5 text-primary" />貸切予約管理</>}
           description="貸切予約リクエストの承認・却下・店舗調整を行います"
         />
 

--- a/src/pages/ReservationManagement.tsx
+++ b/src/pages/ReservationManagement.tsx
@@ -245,12 +245,7 @@ export function ReservationManagement() {
     <AppLayout currentPage="reservations" maxWidth="max-w-[1440px]" containerPadding="px-[10px] py-3 sm:py-4 md:py-6" className="mx-auto">
       <div className="space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <Ticket className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">予約一覧</span>
-            </div>
-          }
+          title={<><Ticket className="h-5 w-5 text-primary" />予約一覧</>}
           description="予約状況の確認と管理"
         >
           <HelpButton topic="reservation" label="予約管理マニュアル" />

--- a/src/pages/SalesManagement/components/ExternalSales.tsx
+++ b/src/pages/SalesManagement/components/ExternalSales.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Textarea } from '@/components/ui/textarea'
 import { Plus, Edit2, Trash2, ShoppingBag, Store, Calendar } from 'lucide-react'
 import { MonthSwitcher } from '@/components/patterns/calendar'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { supabase } from '@/lib/supabase'
 import { useOrganization } from '@/hooks/useOrganization'
 import { showToast } from '@/utils/toast'
@@ -248,23 +249,16 @@ export const ExternalSales: React.FC = () => {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      {/* ヘッダー */}
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <div>
-          <div className="flex items-center gap-2">
-            <ShoppingBag className="h-5 w-5 text-primary" />
-            <span className="text-lg font-bold">外部売上管理</span>
-          </div>
-          <p className="text-sm text-muted-foreground mt-1">BOOTH売上・他店公演を管理</p>
-        </div>
-        <div className="flex items-center gap-4">
-          <MonthSwitcher value={currentDate} onChange={setCurrentDate} />
-          <Button onClick={handleOpenAdd} className="flex items-center gap-2">
-            <Plus className="h-4 w-4" />
-            新規登録
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title={<><ShoppingBag className="h-5 w-5 text-primary" />外部売上管理</>}
+        description="BOOTH売上・他店公演を管理"
+      >
+        <MonthSwitcher value={currentDate} onChange={setCurrentDate} />
+        <Button onClick={handleOpenAdd} className="flex items-center gap-2">
+          <Plus className="h-4 w-4" />
+          新規登録
+        </Button>
+      </PageHeader>
 
       {/* サマリーカード */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/pages/SalesManagement/components/OpenEventAnalysis.tsx
+++ b/src/pages/SalesManagement/components/OpenEventAnalysis.tsx
@@ -216,12 +216,7 @@ export const OpenEventAnalysis: React.FC<OpenEventAnalysisProps> = ({
     <div className="space-y-4 md:space-y-6">
       {/* ヘッダー */}
       <PageHeader
-        title={
-          <div className="flex items-center gap-2">
-            <CalendarCheck className="h-5 w-5 text-primary" />
-            <span className="text-lg font-bold">公演分析</span>
-          </div>
-        }
+        title={<><CalendarCheck className="h-5 w-5 text-primary" />公演分析</>}
         description="オープン公演の満席率・満席日数を分析します"
       />
 

--- a/src/pages/SalesManagement/components/SalesOverview.tsx
+++ b/src/pages/SalesManagement/components/SalesOverview.tsx
@@ -280,12 +280,7 @@ export const SalesOverview: React.FC<SalesOverviewProps> = ({
     <div id="sales-report-container" className="space-y-3 sm:space-y-4 md:space-y-6">
       {/* ヘッダー：タイトルとエクスポートボタン */}
       <PageHeader
-        title={
-          <div className="flex items-center gap-2">
-            <TrendingUp className="h-5 w-5 text-primary" />
-            <span className="text-lg font-bold">{isFranchiseOnly ? 'フランチャイズ売上管理' : '売上管理'}</span>
-          </div>
-        }
+        title={<><TrendingUp className="h-5 w-5 text-primary" />{isFranchiseOnly ? 'フランチャイズ売上管理' : '売上管理'}</>}
         description="期間別の売上・予約実績と分析"
       >
         <ExportButtons salesData={salesData} dateRange={dateRange} />

--- a/src/pages/SalesManagement/components/ScenarioPerformanceHeader.tsx
+++ b/src/pages/SalesManagement/components/ScenarioPerformanceHeader.tsx
@@ -34,12 +34,7 @@ export const ScenarioPerformanceHeader: React.FC<ScenarioPerformanceHeaderProps>
   return (
     <div className="space-y-6">
       <PageHeader
-        title={
-          <div className="flex items-center gap-2">
-            <BarChart3 className="h-5 w-5 text-primary" />
-            <span className="text-lg font-bold">シナリオ分析</span>
-          </div>
-        }
+        title={<><BarChart3 className="h-5 w-5 text-primary" />シナリオ分析</>}
         description="シナリオ別の公演実績と収益分析"
       >
         <Select value={period} onValueChange={onPeriodChange}>

--- a/src/pages/SalesManagement/index.tsx
+++ b/src/pages/SalesManagement/index.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, lazy, Suspense } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { TrendingUp } from 'lucide-react'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { useLocalState } from '@/hooks/useLocalState'
 import { useSalesData } from './hooks/useSalesData'
 
@@ -181,6 +183,10 @@ const SalesManagement: React.FC = () => {
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}
     >
+      <PageHeader
+        title={<><TrendingUp className="h-5 w-5" />売上管理</>}
+        description="売上集計・年次分析・スタッフ給与レポート"
+      />
       <Suspense fallback={<div className="flex items-center justify-center h-40 text-muted-foreground text-sm">読み込み中...</div>}>
         {renderContent()}
       </Suspense>

--- a/src/pages/ScenarioEdit/index.tsx
+++ b/src/pages/ScenarioEdit/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { UnifiedSidebar, SidebarMenuItem } from '@/components/layout/UnifiedSidebar'
 import { useSessionState } from '@/hooks/useSessionState'
 import { Button } from '@/components/ui/button'
@@ -413,35 +414,20 @@ export function ScenarioEdit({ scenarioId: propScenarioId, onClose, isDialog = f
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}
     >
-      {/* ヘッダー */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-lg">
-            {scenarioId ? 'シナリオ編集' : '新規シナリオ作成'}
-          </h2>
-          {formData.title && (
-            <p className="text-xs text-muted-foreground mt-1">
-              {formData.title}
-            </p>
-          )}
-          {scenarioId && !formData.title && (
-            <p className="text-xs text-muted-foreground mt-1">
-              ID: {scenarioId}
-            </p>
-          )}
-        </div>
-        <div className="flex items-center gap-3">
-          {showSaveSuccess && (
-            <div className="text-sm text-green-600 animate-in fade-in slide-in-from-right-1">
-              ✓ 保存しました
-            </div>
-          )}
-          <Button onClick={handleSave} disabled={scenarioMutation.isPending}>
-            <Save className="h-4 w-4 mr-2" />
-            {scenarioMutation.isPending ? '保存中...' : '保存'}
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title={<><BookOpen className="h-5 w-5" />{scenarioId ? 'シナリオ編集' : '新規シナリオ作成'}</>}
+        description={formData.title || (scenarioId ? `ID: ${scenarioId}` : undefined)}
+      >
+        {showSaveSuccess && (
+          <div className="text-sm text-green-600 animate-in fade-in slide-in-from-right-1 self-center">
+            ✓ 保存しました
+          </div>
+        )}
+        <Button onClick={handleSave} disabled={scenarioMutation.isPending}>
+          <Save className="h-4 w-4 mr-2" />
+          {scenarioMutation.isPending ? '保存中...' : '保存'}
+        </Button>
+      </PageHeader>
 
       {/* コンテンツ */}
       {renderContent()}

--- a/src/pages/ScenarioManagement/index.tsx
+++ b/src/pages/ScenarioManagement/index.tsx
@@ -444,12 +444,10 @@ export function ScenarioManagement() {
         <div className="space-y-6">
           <PageHeader
             title={
-              <div className="flex items-center gap-2">
+              <>
                 <BookOpen className="h-5 w-5 text-primary" />
-                <span className="text-lg font-bold">
-                  {organization?.name ? `${organization.name}のシナリオ管理` : 'シナリオ管理'}
-                </span>
-              </div>
+                {organization?.name ? `${organization.name}のシナリオ管理` : 'シナリオ管理'}
+              </>
             }
             description={`全${allScenarios.length}本のシナリオを管理`}
           >

--- a/src/pages/ScenarioMasterAdmin/index.tsx
+++ b/src/pages/ScenarioMasterAdmin/index.tsx
@@ -245,12 +245,7 @@ export function ScenarioMasterAdmin() {
     >
       <div className="space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <Shield className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">シナリオマスタ管理</span>
-            </div>
-          }
+          title={<><Shield className="h-5 w-5 text-primary" />シナリオマスタ管理</>}
           description={`全${masters.length}本のマスタを管理`}
         >
           <Button onClick={handleNew} size="sm">

--- a/src/pages/ScheduleManager/index.tsx
+++ b/src/pages/ScheduleManager/index.tsx
@@ -997,14 +997,12 @@ export function ScheduleManager() {
     >
       {/* ツールバー（sticky） */}
       <div data-schedule-toolbar className="sticky top-0 z-40 bg-background border-b -mx-[10px] px-[10px]">
-        {/* 見出し行（sticky に含めて消えないようにする） */}
-        <div className="flex items-center gap-2 pt-2 pb-1">
-          <CalendarDays className="h-4 w-4 text-primary shrink-0" />
-          <h1 className="text-base font-bold leading-none">スケジュール管理</h1>
-          <span className="text-xs text-muted-foreground">
-            {currentDate.getFullYear()}年{currentDate.getMonth() + 1}月
-          </span>
-        </div>
+        {/* 見出し（sticky に含めて消えないようにする / mb-2 は sticky 高さを抑えるため） */}
+        <PageHeader
+          title={<><CalendarDays className="h-5 w-5 text-primary" />スケジュール管理</>}
+          description={`${currentDate.getFullYear()}年${currentDate.getMonth() + 1}月`}
+          className="mb-2 pt-2"
+        />
         <div className="flex items-center h-12 gap-2">
           {/* 月切り替え - 連結ボタングループ */}
           <div className="flex items-center shrink-0 border border-input rounded-lg overflow-hidden bg-background">

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,5 +1,7 @@
 import { useSearchParams } from 'react-router-dom'
+import { Settings as SettingsIcon } from 'lucide-react'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { PageHeader } from '@/components/layout/PageHeader'
 import { useSettingsStore } from '@/hooks/useSettingsStore'
 import { SettingsLayout } from '@/components/settings/SettingsLayout'
 
@@ -91,7 +93,11 @@ export function Settings() {
       containerPadding="px-[10px] py-3 sm:py-4 md:py-6"
       stickyLayout={true}
     >
-      <SettingsLayout 
+      <PageHeader
+        title={<><SettingsIcon className="h-5 w-5" />設定</>}
+        description="組織情報・店舗・通知・連携などの各種設定"
+      />
+      <SettingsLayout
         selectedStoreId={selectedStoreId}
         onStoreChange={handleStoreChange}
         showStoreSelector={showStoreSelector}

--- a/src/pages/ShiftSubmission/index.tsx
+++ b/src/pages/ShiftSubmission/index.tsx
@@ -151,12 +151,7 @@ export function ShiftSubmission() {
     >
       <div className="space-y-3 sm:space-y-4 md:space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <CalendarClock className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">シフト提出 - {formatMonthYear()}</span>
-            </div>
-          }
+          title={<><CalendarClock className="h-5 w-5 text-primary" />シフト提出 - {formatMonthYear()}</>}
           description="出勤可能な時間帯にチェックを入れてください"
         >
           {/* PC・タブレット用提出ボタン */}

--- a/src/pages/StaffManagement/index.tsx
+++ b/src/pages/StaffManagement/index.tsx
@@ -359,12 +359,10 @@ export function StaffManagement() {
         <div className="space-y-6">
             <PageHeader
               title={
-                <div className="flex items-center gap-2">
+                <>
                   <Users className="h-5 w-5 text-primary" />
-                  <span className="text-lg font-bold">
                   {organization?.name ? `${organization.name}のスタッフ管理` : 'スタッフ管理'}
-                </span>
-                </div>
+                </>
               }
               description={`全${staff.length}名のスタッフを管理`}
             >

--- a/src/pages/StaffProfile/index.tsx
+++ b/src/pages/StaffProfile/index.tsx
@@ -336,12 +336,7 @@ export function StaffProfile() {
     <AppLayout currentPage="staff-profile" maxWidth="max-w-[1440px]" containerPadding="px-[10px] py-3 sm:py-4 md:py-6">
       <div className="space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <UserCircle className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">担当作品</span>
-            </div>
-          }
+          title={<><UserCircle className="h-5 w-5 text-primary" />担当作品</>}
           description={`${staffName}さんの体験リストとGM可否を管理。シナリオ編集の「GM」タブで必要GM数が2人以上の作品だけ、ここでメイン／サブを分けて設定できます`}
         >
           <Button onClick={handleSave} disabled={saving}>

--- a/src/pages/StoreManagement/index.tsx
+++ b/src/pages/StoreManagement/index.tsx
@@ -189,12 +189,10 @@ export function StoreManagement() {
       <div className="space-y-6">
         <PageHeader
           title={
-            <div className="flex items-center gap-2">
+            <>
               <StoreIcon className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">
-                {organization?.name ? `${organization.name}の店舗管理` : '店舗管理'}
-              </span>
-            </div>
+              {organization?.name ? `${organization.name}の店舗管理` : '店舗管理'}
+            </>
           }
           description={`全${stores.length}店舗の管理`}
         >

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -243,12 +243,7 @@ export function UserManagement() {
     >
       <div className="space-y-3 sm:space-y-4 md:space-y-6">
         <PageHeader
-          title={
-            <div className="flex items-center gap-2">
-              <UserCog className="h-5 w-5 text-primary" />
-              <span className="text-lg font-bold">ユーザー管理</span>
-            </div>
-          }
+          title={<><UserCog className="h-5 w-5 text-primary" />ユーザー管理</>}
           description="ユーザーの検索・ロール管理を行います"
         >
           <HelpButton topic="user" label="ユーザー管理マニュアル" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,16 +63,23 @@ export default defineConfig({
   server: {
     // 既定 127.0.0.1（起動安定）。スマホ等から繋ぐときは VITE_DEV_HOST=all npm run dev
     host: devHost,
-    port: 5173,
-    strictPort: true, // 5173固定（別ポートに逃がさない）
+    // vercel dev はランダムな PORT を渡してきて、その port を vite が掴むのを待つ。
+    // PORT があれば従い、なければ 5173 固定（通常の npm run dev）。
+    port: process.env.PORT ? Number(process.env.PORT) : 5173,
+    strictPort: !process.env.PORT, // 通常時のみ strict
     // CORS設定（ネットワーク経由アクセス対応）
     cors: true,
-    // /api/* を Vercel dev サーバー（port 3000）に転送する
-    // 開発時は `vercel dev` を port 3000 で起動すること
+    // /api/* をステージング Vercel deploy に転送する
+    // 理由: macOS 上で vercel dev が spawn EBADF で関数を実行できないため、
+    // ローカルからは staging deploy の /api を叩く方式に切り替えた。
+    // ローカルで API 自体を編集したい場合は staging へ push して反映を待つ
+    // （UI のみのローカル開発であれば npm run dev のみで完結する）。
+    // 環境変数 VITE_API_TARGET で別 URL を指定可能（例: 本番確認、preview deploy 確認）
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: process.env.VITE_API_TARGET || 'https://mmq-yoyaq-git-staging-nagayoshi0923s-projects.vercel.app',
         changeOrigin: true,
+        secure: true,
       },
     },
     hmr: {


### PR DESCRIPTION
## Summary
- 管理画面ヘッダーを `PageHeader` コンポーネントに統一（11 ページを新規移行）
- 既存 `PageHeader` 利用箇所の `title` を `<div className="flex items-center gap-2"><span text-lg font-bold>` ラッパから直接 Fragment に統一（21 ファイル / -97 行）
- ローカル開発を Vite + staging proxy 構成に変更（vercel dev が macOS 15.6 で spawn EBADF を起こすため）。`npm run dev:vercel` / `npm run dev:stop` を追加。`/api/*` は `VITE_API_TARGET` で staging deploy にプロキシ。

## Test plan
- [ ] `npm run dev:vercel` で http://localhost:5173 が起動し、ログイン後に各管理画面のヘッダー（Pageheader 統一済み 32 ページ）の見た目が崩れていないことを目視確認
- [ ] `/api/*` リクエストが staging deploy にプロキシされて 200 を返すこと（例: シナリオ一覧）
- [ ] `npm run build` が成功すること
- [ ] `tsc --noEmit` が pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)