### PR TITLE
feat(api): scheduleApi の write 系をバックエンド API に移行

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -12,7 +12,7 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined
   const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
   res.setHeader('Access-Control-Allow-Origin', allowed)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 }
@@ -181,37 +181,56 @@ function resolveMaxParticipants(event: ScheduleEventLike, orgScenarioMap: Map<st
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
 
   const envError = getMissingEnvError()
   if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
-
-  const type = req.query.type as string | undefined
-  if (!type) {
-    return res.status(400).json({ error: 'type クエリパラメータが必要です' })
-  }
 
   try {
     const user = await requireAuth(req)
     requireStaff(user)
 
-    switch (type) {
-      case 'my-schedule':
-        return await handleMySchedule(req, res, user)
-      case 'by-month':
-        return await handleByMonth(req, res, user)
-      case 'by-date-range':
-        return await handleByDateRange(req, res, user)
-      case 'by-scenario':
-        return await handleByScenario(req, res, user)
-      default:
-        return res.status(400).json({ error: `未対応の type: ${type}` })
-    }
+    if (req.method === 'GET') return await handleGet(req, res, user)
+    if (req.method === 'POST') return await handlePost(req, res, user)
+    if (req.method === 'PATCH') return await handlePatch(req, res, user)
+    if (req.method === 'DELETE') return await handleDelete(req, res, user)
+    return res.status(405).json({ error: 'Method not allowed' })
   } catch (err) {
     if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
     console.error('[schedule] unexpected error:', err)
     return res.status(500).json({ error: 'サーバーエラーが発生しました' })
   }
+}
+
+async function handleGet(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const type = req.query.type as string | undefined
+  if (!type) {
+    return res.status(400).json({ error: 'type クエリパラメータが必要です' })
+  }
+  switch (type) {
+    case 'my-schedule':
+      return await handleMySchedule(req, res, user)
+    case 'by-month':
+      return await handleByMonth(req, res, user)
+    case 'by-date-range':
+      return await handleByDateRange(req, res, user)
+    case 'by-scenario':
+      return await handleByScenario(req, res, user)
+    default:
+      return res.status(400).json({ error: `未対応の type: ${type}` })
+  }
+}
+
+async function handlePost(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = req.query.action as string | undefined
+  if (action === 'add-demo-participants') return await handleAddDemoParticipants(req, res, user)
+  if (action === 'remove-demo-reservations') return await handleRemoveDemoReservations(req, res, user)
+  return await handleCreate(req, res, user)
+}
+
+async function handlePatch(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = req.query.action as string | undefined
+  if (action === 'toggle-cancel') return await handleToggleCancel(req, res, user)
+  return await handleUpdate(req, res, user)
 }
 
 // ─── my-schedule (scheduleApi.getMySchedule) ─────────────────────────────
@@ -794,4 +813,587 @@ async function handleByScenario(req: VercelRequest, res: VercelResponse, user: A
   })
 
   return res.status(200).json(eventsWithActualParticipants)
+}
+
+// ─── write 系ヘルパ ────────────────────────────────────────────────────
+
+// DB で許可されているカテゴリ（チェック制約に合わせる）
+const DB_VALID_CATEGORIES = ['open', 'private', 'gmtest', 'testplay', 'offsite', 'venue_rental', 'venue_rental_free', 'package', 'mtg']
+
+// 作成可能フィールドのホワイトリスト（Mass Assignment 防止）
+const SCHEDULE_CREATABLE_FIELDS = [
+  'date', 'store_id', 'venue', 'scenario', 'scenario_master_id', 'organization_scenario_id',
+  'category', 'start_time', 'end_time', 'capacity', 'gms', 'gm_roles', 'notes',
+  'time_slot', 'is_reservation_enabled', 'is_tentative', 'venue_rental_fee',
+  'reservation_name', 'is_reservation_name_overwritten', 'is_private_request', 'reservation_id',
+] as const
+
+const SCHEDULE_UPDATABLE_FIELDS = [
+  ...SCHEDULE_CREATABLE_FIELDS,
+  'is_cancelled', 'cancellation_reason', 'cancelled_at',
+] as const
+
+function pickFields<T extends readonly string[]>(
+  src: Record<string, unknown>,
+  allowed: T,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(src)) {
+    if ((allowed as readonly string[]).includes(key)) {
+      out[key] = src[key]
+    }
+  }
+  return out
+}
+
+function normalizeScenarioName(name: string): string {
+  return name
+    .replace(/^["「『📗📕]/, '')
+    .replace(/["」』]$/, '')
+    .replace(/^貸・/, '')
+    .replace(/^募・/, '')
+    .replace(/^🈵・/, '')
+    .replace(/^GMテスト・/, '')
+    .replace(/^打診・/, '')
+    .replace(/^仮/, '')
+    .replace(/^（仮）/, '')
+    .replace(/^\(仮\)/, '')
+    .replace(/\(.*?\)$/, '')
+    .replace(/（.*?）$/, '')
+    .trim()
+}
+
+function removeMissingScheduleColumn(
+  payload: Record<string, unknown>,
+  error: { message?: string; details?: string; hint?: string } | null,
+): { nextPayload: Record<string, unknown>; removedColumn: string } | null {
+  if (!error) return null
+  const combined = `${error.message ?? ''} ${error.details ?? ''} ${error.hint ?? ''}`
+  const patterns = [
+    /column "([^"]+)" of relation "schedule_events" does not exist/i,
+    /Could not find the '([^']+)' column of 'schedule_events'/i,
+  ]
+  for (const pattern of patterns) {
+    const match = combined.match(pattern)
+    if (match?.[1]) {
+      const missingColumn = match[1]
+      if (missingColumn in payload) {
+        const nextPayload = { ...payload }
+        delete nextPayload[missingColumn]
+        return { nextPayload, removedColumn: missingColumn }
+      }
+    }
+  }
+  return null
+}
+
+async function findMatchingScenario(scenarioName: string | undefined): Promise<{ id: string; title: string } | null> {
+  if (!scenarioName || scenarioName.trim() === '') return null
+  if (!db) return null
+  const cleanName = normalizeScenarioName(scenarioName)
+  if (cleanName.length < 2) return null
+
+  // エイリアスマッピングを取得
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: aliasRows } = await (db as any)
+    .from('scenario_import_aliases')
+    .select('alias, canonical_name')
+  const aliasMap: Record<string, string> = {}
+  for (const row of (aliasRows as Array<{ alias: string; canonical_name: string }> | null) ?? []) {
+    aliasMap[row.alias] = row.canonical_name
+  }
+
+  let searchName = aliasMap[cleanName] ?? cleanName
+  if (searchName === cleanName) {
+    for (const [alias, formal] of Object.entries(aliasMap)) {
+      if (cleanName.includes(alias)) {
+        searchName = formal
+        break
+      }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: scenarios } = await (db as any)
+    .from('scenario_masters')
+    .select('id, title')
+  if (!scenarios || scenarios.length === 0) return null
+
+  type ScenarioMasterRow = { id: string; title: string }
+  const rows = scenarios as ScenarioMasterRow[]
+  let match: ScenarioMasterRow | undefined = rows.find(s => s.title === searchName)
+  if (!match) match = rows.find(s => s.title.startsWith(searchName))
+  if (!match) match = rows.find(s => searchName.includes(s.title))
+  if (!match && searchName.length >= 4) match = rows.find(s => s.title.includes(searchName))
+  return match || null
+}
+
+// INSERT/UPDATE 後にスタッフ専用ビューから完全レコードを取得する
+const SCHEDULE_EVENT_FULL_SELECT = `
+  *,
+  stores:store_id (
+    id,
+    name,
+    short_name
+  ),
+  scenario_masters:scenario_master_id (
+    id,
+    title,
+    player_count_max
+  )
+`
+
+// ─── handleCreate (POST) ─────────────────────────────────────────────────
+async function handleCreate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const body = (req.body ?? {}) as Record<string, unknown>
+
+  // ホワイトリスト + サーバ強制
+  const insertRow = pickFields(body, SCHEDULE_CREATABLE_FIELDS)
+  insertRow.organization_id = user.orgId // ← クライアント値は使わずサーバ強制
+
+  if (!insertRow.date || !insertRow.store_id || !insertRow.category || !insertRow.start_time || !insertRow.end_time) {
+    return res.status(400).json({ error: 'date / store_id / category / start_time / end_time は必須です' })
+  }
+
+  // 自組織の店舗かを確認
+  const { data: storeRow, error: storeErr } = await database
+    .from('stores')
+    .select('id, organization_id')
+    .eq('id', insertRow.store_id)
+    .maybeSingle()
+  if (storeErr) {
+    console.error('[schedule:create] store lookup error:', storeErr)
+    return res.status(500).json({ error: '店舗確認に失敗しました' })
+  }
+  if (!storeRow) return res.status(404).json({ error: '店舗が見つかりません' })
+  if (storeRow.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の店舗は使用できません' })
+  }
+
+  // シナリオ名から自動マッチング
+  const scenarioInput = typeof insertRow.scenario === 'string' ? insertRow.scenario : undefined
+  if (scenarioInput && !insertRow.scenario_master_id) {
+    const match = await findMatchingScenario(scenarioInput)
+    if (match) {
+      insertRow.scenario_master_id = match.id
+      insertRow.scenario = match.title
+    }
+  }
+
+  // organization_scenario_id を自動設定（scenario_master_id 経由）
+  if (insertRow.scenario_master_id && !insertRow.organization_scenario_id) {
+    const { data: orgScenario } = await database
+      .from('organization_scenarios')
+      .select('id')
+      .eq('scenario_master_id', insertRow.scenario_master_id as string)
+      .eq('organization_id', user.orgId)
+      .maybeSingle()
+    if (orgScenario?.id) {
+      insertRow.organization_scenario_id = orgScenario.id
+    }
+  }
+
+  // カテゴリのバリデーション
+  if (typeof insertRow.category === 'string' && !DB_VALID_CATEGORIES.includes(insertRow.category)) {
+    insertRow.category = 'open'
+  }
+
+  // INSERT（不明カラムをリトライ削除）
+  let insertPayload: Record<string, unknown> = { ...insertRow }
+  let lastError: { message?: string; details?: string; hint?: string; code?: string } | null = null
+  let insertedId: string | null = null
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const { data, error } = await database
+      .from('schedule_events')
+      .insert([insertPayload])
+      .select('id')
+      .single()
+    if (!error) {
+      insertedId = data.id as string
+      break
+    }
+    lastError = error
+    const removal = removeMissingScheduleColumn(insertPayload, error)
+    if (!removal) break
+    insertPayload = removal.nextPayload
+  }
+
+  if (!insertedId) {
+    console.error('[schedule:create] insert error:', lastError)
+    return res.status(500).json({ error: '公演の作成に失敗しました', detail: lastError?.message })
+  }
+
+  // スタッフ専用ビューから完全レコードを返す
+  const { data: fullEvent, error: fetchError } = await database
+    .from('schedule_events_staff_view')
+    .select(SCHEDULE_EVENT_FULL_SELECT)
+    .eq('id', insertedId)
+    .eq('organization_id', user.orgId)
+    .single()
+  if (fetchError) {
+    console.error('[schedule:create] fetch error:', fetchError)
+    return res.status(500).json({ error: '作成後の取得に失敗しました', detail: fetchError.message })
+  }
+  return res.status(201).json(fullEvent)
+}
+
+// ─── handleUpdate (PATCH) ────────────────────────────────────────────────
+async function handleUpdate(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  const expectedUpdatedAt = req.query.expected_updated_at as string | undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updateRow = pickFields(body, SCHEDULE_UPDATABLE_FIELDS)
+
+  if (Object.keys(updateRow).length === 0) {
+    return res.status(400).json({ error: '更新可能なフィールドがありません' })
+  }
+
+  // 対象イベントが自組織か確認
+  const { data: existing, error: existingErr } = await database
+    .from('schedule_events')
+    .select('id, organization_id, store_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (existingErr) {
+    console.error('[schedule:update] existing lookup error:', existingErr)
+    return res.status(500).json({ error: '公演情報の確認に失敗しました' })
+  }
+  if (!existing) return res.status(404).json({ error: '公演が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の公演は編集できません' })
+  }
+
+  // store_id を変える場合、移動先店舗も自組織か確認
+  if (typeof updateRow.store_id === 'string' && updateRow.store_id !== existing.store_id) {
+    const { data: newStore, error: newStoreErr } = await database
+      .from('stores')
+      .select('id, organization_id')
+      .eq('id', updateRow.store_id)
+      .maybeSingle()
+    if (newStoreErr) {
+      return res.status(500).json({ error: '店舗確認に失敗しました' })
+    }
+    if (!newStore) return res.status(404).json({ error: '店舗が見つかりません' })
+    if (newStore.organization_id !== user.orgId) {
+      return res.status(403).json({ error: '他組織の店舗は使用できません' })
+    }
+  }
+
+  // シナリオ名から自動マッチング
+  const scenarioInput = typeof updateRow.scenario === 'string' ? updateRow.scenario : undefined
+  if (scenarioInput && !updateRow.scenario_master_id) {
+    const match = await findMatchingScenario(scenarioInput)
+    if (match) {
+      updateRow.scenario_master_id = match.id
+      updateRow.scenario = match.title
+    }
+  }
+
+  // organization_scenario_id を自動設定（scenario_master_id 経由）
+  if (updateRow.scenario_master_id && !updateRow.organization_scenario_id) {
+    const { data: orgScenario } = await database
+      .from('organization_scenarios')
+      .select('id')
+      .eq('scenario_master_id', updateRow.scenario_master_id as string)
+      .eq('organization_id', user.orgId)
+      .maybeSingle()
+    if (orgScenario?.id) {
+      updateRow.organization_scenario_id = orgScenario.id
+    }
+  }
+
+  if (typeof updateRow.category === 'string' && !DB_VALID_CATEGORIES.includes(updateRow.category)) {
+    updateRow.category = 'open'
+  }
+
+  let updatePayload: Record<string, unknown> = { ...updateRow, updated_at: new Date().toISOString() }
+  let lastError: { message?: string; details?: string; hint?: string; code?: string } | null = null
+  let updateSucceeded = false
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let query = database
+      .from('schedule_events')
+      .update(updatePayload)
+      .eq('id', id)
+      .eq('organization_id', user.orgId)
+    if (expectedUpdatedAt) {
+      query = query.eq('updated_at', expectedUpdatedAt)
+    }
+    const { error } = await query.select('id').single()
+
+    if (!error) {
+      updateSucceeded = true
+      break
+    }
+    if (expectedUpdatedAt && error.code === 'PGRST116') {
+      return res.status(409).json({ error: '他のユーザーが先にこのイベントを更新しました。ページを再読み込みして最新データを確認してください。' })
+    }
+    lastError = error
+    const removal = removeMissingScheduleColumn(updatePayload, error)
+    if (!removal) break
+    updatePayload = removal.nextPayload
+  }
+
+  if (!updateSucceeded) {
+    console.error('[schedule:update] update error:', lastError)
+    return res.status(500).json({ error: '公演の更新に失敗しました', detail: lastError?.message })
+  }
+
+  const { data: fullEvent, error: fetchError } = await database
+    .from('schedule_events_staff_view')
+    .select(SCHEDULE_EVENT_FULL_SELECT)
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+    .single()
+  if (fetchError) {
+    console.error('[schedule:update] fetch error:', fetchError)
+    return res.status(500).json({ error: '更新後の取得に失敗しました', detail: fetchError.message })
+  }
+  return res.status(200).json(fullEvent)
+}
+
+// ─── handleToggleCancel (PATCH action=toggle-cancel) ─────────────────────
+async function handleToggleCancel(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const isCancelled = body.is_cancelled === true
+  const cancellationReason = typeof body.cancellation_reason === 'string' ? body.cancellation_reason : null
+
+  // 自組織のイベントか確認
+  const { data: existing, error: existingErr } = await database
+    .from('schedule_events')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (existingErr) return res.status(500).json({ error: '公演情報の確認に失敗しました' })
+  if (!existing) return res.status(404).json({ error: '公演が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の公演は変更できません' })
+  }
+
+  const updateData: Record<string, unknown> = {
+    is_cancelled: isCancelled,
+    cancellation_reason: isCancelled ? cancellationReason : null,
+    cancelled_at: isCancelled ? new Date().toISOString() : null,
+  }
+
+  const { error } = await database
+    .from('schedule_events')
+    .update(updateData)
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+  if (error) {
+    console.error('[schedule:toggle-cancel] update error:', error)
+    return res.status(500).json({ error: '公演の中止状態切り替えに失敗しました', detail: error.message })
+  }
+
+  const { data, error: fetchError } = await database
+    .from('schedule_events_staff_view')
+    .select()
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+    .single()
+  if (fetchError) {
+    return res.status(500).json({ error: '取得に失敗しました', detail: fetchError.message })
+  }
+  return res.status(200).json(data)
+}
+
+// ─── handleDelete (DELETE) ───────────────────────────────────────────────
+async function handleDelete(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = req.query.id as string | undefined
+  if (!id) return res.status(400).json({ error: 'id クエリパラメータが必要です' })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  const { data: existing, error: existingErr } = await database
+    .from('schedule_events')
+    .select('id, organization_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (existingErr) return res.status(500).json({ error: '公演情報の確認に失敗しました' })
+  if (!existing) return res.status(404).json({ error: '公演が見つかりません' })
+  if (existing.organization_id !== user.orgId) {
+    return res.status(403).json({ error: '他組織の公演は削除できません' })
+  }
+
+  const { error } = await database
+    .from('schedule_events')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+  if (error) {
+    console.error('[schedule:delete] DB error:', error)
+    return res.status(500).json({ error: '公演の削除に失敗しました', detail: error.message })
+  }
+  return res.status(204).end()
+}
+
+// ─── handleAddDemoParticipants (POST action=add-demo-participants) ───────
+async function handleAddDemoParticipants(_req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // 中止でない自組織の全公演を取得
+  const { data: events, error: eventsError } = await database
+    .from('schedule_events_staff_view')
+    .select('id, organization_id, scenario_master_id, scenario, store_id, date, start_time, category, gms, capacity, max_participants')
+    .eq('is_cancelled', false)
+    .eq('organization_id', user.orgId)
+    .order('date', { ascending: true })
+
+  if (eventsError) {
+    console.error('[schedule:add-demo] events fetch error:', eventsError)
+    return res.status(500).json({ error: '公演データの取得に失敗しました', detail: eventsError.message })
+  }
+  if (!events || events.length === 0) {
+    return res.status(200).json({ success: true, message: '中止でない公演が見つかりません', successCount: 0, errorCount: 0 })
+  }
+
+  const orgScenarioMap = await getOrgScenarioPlayerCounts(user.orgId)
+  let successCount = 0
+  let errorCount = 0
+
+  for (const event of events as Array<Record<string, unknown> & { id: string; scenario_master_id: string | null; organization_id: string; scenario: string | null; store_id: string | null; date: string; start_time: string; category: string; gms: string[] | null; capacity: number | null; max_participants: number | null }>) {
+    try {
+      const { data: reservations, error: reservationError } = await database
+        .from('reservations')
+        .select('participant_count, participant_names')
+        .eq('schedule_event_id', event.id)
+        .in('status', [...ACTIVE_RESERVATION_STATUSES])
+      if (reservationError && reservationError.code !== 'PGRST116') {
+        errorCount++
+        continue
+      }
+
+      const reservedParticipants = ((reservations as Array<{ participant_count: number | null; participant_names: string[] | null }> | null) ?? [])
+        .reduce((sum, r) => sum + (r.participant_count || 0), 0)
+
+      const capacity = resolveMaxParticipants(
+        { scenario_master_id: event.scenario_master_id, scenario: event.scenario, max_participants: event.max_participants, capacity: event.capacity },
+        orgScenarioMap,
+      )
+
+      const hasDemoParticipant = ((reservations as Array<{ participant_names: string[] | null }> | null) ?? []).some(r =>
+        r.participant_names?.some((name: string) => typeof name === 'string' && name.includes('デモ')),
+      )
+
+      const neededParticipants = capacity - reservedParticipants
+      if (neededParticipants <= 0 || hasDemoParticipant) continue
+      if (!event.scenario_master_id) continue
+
+      const { data: scenarioMaster, error: masterError } = await database
+        .from('scenario_masters')
+        .select('id, title, official_duration')
+        .eq('id', event.scenario_master_id)
+        .single()
+      if (masterError) { errorCount++; continue }
+
+      const { data: orgScenario } = await database
+        .from('organization_scenarios')
+        .select('participation_fee, gm_test_participation_fee')
+        .eq('scenario_master_id', event.scenario_master_id)
+        .eq('organization_id', user.orgId)
+        .maybeSingle()
+
+      const isGmTest = event.category === 'gmtest'
+      const participationFee = isGmTest
+        ? ((orgScenario as { gm_test_participation_fee?: number; participation_fee?: number } | null)?.gm_test_participation_fee
+          || (orgScenario as { participation_fee?: number } | null)?.participation_fee
+          || 0)
+        : ((orgScenario as { participation_fee?: number } | null)?.participation_fee || 0)
+
+      const demoReservation: Record<string, unknown> = {
+        schedule_event_id: event.id,
+        organization_id: user.orgId, // ← サーバ強制
+        title: event.scenario || (scenarioMaster as { title?: string } | null)?.title || '',
+        scenario_master_id: event.scenario_master_id,
+        store_id: event.store_id || null,
+        customer_id: null,
+        customer_notes: neededParticipants === 1 ? 'デモ参加者' : `デモ参加者${neededParticipants}名`,
+        requested_datetime: `${event.date}T${event.start_time}+09:00`,
+        duration: (scenarioMaster as { official_duration?: number } | null)?.official_duration || 120,
+        participant_count: neededParticipants,
+        participant_names: Array(neededParticipants).fill(null).map((_, i) =>
+          neededParticipants === 1 ? 'デモ参加者' : `デモ参加者${i + 1}`,
+        ),
+        assigned_staff: event.gms || [],
+        base_price: participationFee * neededParticipants,
+        options_price: 0,
+        total_price: participationFee * neededParticipants,
+        discount_amount: 0,
+        final_price: participationFee * neededParticipants,
+        payment_method: 'onsite',
+        payment_status: 'paid',
+        status: 'confirmed',
+        reservation_source: 'demo',
+      }
+
+      const { error: insertError } = await database
+        .from('reservations')
+        .insert(demoReservation)
+      if (insertError) { errorCount++; continue }
+
+      // 参加者数を予約テーブルから再計算して schedule_events を更新
+      const { data: allReservations, error: allResError } = await database
+        .from('reservations')
+        .select('participant_count')
+        .eq('schedule_event_id', event.id)
+        .in('status', [...ACTIVE_RESERVATION_STATUSES])
+      if (!allResError) {
+        const totalParticipants = ((allReservations as Array<{ participant_count: number | null }> | null) ?? [])
+          .reduce((sum, r) => sum + (r.participant_count || 0), 0)
+        await database
+          .from('schedule_events')
+          .update({ current_participants: totalParticipants })
+          .eq('id', event.id)
+          .eq('organization_id', user.orgId)
+      }
+
+      successCount++
+    } catch (err) {
+      console.error(`[schedule:add-demo] event ${event.id} error:`, err)
+      errorCount++
+    }
+  }
+
+  return res.status(200).json({
+    success: true,
+    message: `デモ参加者追加完了: 成功${successCount}件, エラー${errorCount}件`,
+    successCount,
+    errorCount,
+  })
+}
+
+// ─── handleRemoveDemoReservations (POST action=remove-demo-reservations) ─
+async function handleRemoveDemoReservations(_req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any
+
+  // RPC は SECURITY DEFINER だが、自組織のデモ予約のみを削除するため、
+  // ここでは手動で対象を絞ってから DELETE する（org スコープを強制）。
+  const { data, error } = await database
+    .from('reservations')
+    .delete()
+    .eq('reservation_source', 'demo')
+    .eq('organization_id', user.orgId)
+    .select('id')
+
+  if (error) {
+    console.error('[schedule:remove-demo] DB error:', error)
+    return res.status(500).json({ error: 'デモ予約の削除に失敗しました', detail: error.message })
+  }
+  const deletedCount = Array.isArray(data) ? data.length : 0
+  return res.status(200).json({ success: true, deletedCount })
 }

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -1,158 +1,17 @@
 /**
  * スケジュール関連API
- * 
- * 公演スケジュールの取得・作成・更新・削除を行う
+ *
+ * 公演スケジュールの取得・作成・更新・削除を行う。
+ * すべてバックエンド API (/api/schedule) 経由で、organization_id は
+ * サーバ側で JWT から強制される。
  */
-import { supabase } from '../supabase'
 import { apiClient } from '@/lib/apiClient'
-import { logger } from '@/utils/logger'
-import { getCurrentOrganizationId } from '@/lib/organization'
-import { recalculateCurrentParticipants } from '@/lib/participantUtils'
-import { ACTIVE_RESERVATION_STATUSES, RESERVATION_SOURCE } from '@/lib/constants'
-import type { RpcAdminDeleteReservationsBySourceParams } from '@/lib/rpcTypes'
-import { getScenarioAliases } from '@/lib/api/scenarioAliasApi'
+import type { ScheduleEvent } from '@/types/schedule'
 
-/**
- * organization_scenarios_with_master ビューから player_count_max を取得し、
- * scenario_master_id と title の両方でルックアップできる Map を返す。
- * scenario_masters の値ではなく、組織オーバーライドを反映した正しい値を取得する。
- */
-async function getOrgScenarioPlayerCounts(organizationId?: string | null): Promise<Map<string, number>> {
-  const orgId = organizationId || await getCurrentOrganizationId()
-  if (!orgId) return new Map()
-
-  const { data } = await supabase
-    .from('organization_scenarios_with_master')
-    .select('id, title, player_count_max')
-    .eq('organization_id', orgId)
-
-  const map = new Map<string, number>()
-  if (data) {
-    for (const row of data as { id: string; title: string; player_count_max: number }[]) {
-      if (row.player_count_max) {
-        map.set(row.id, row.player_count_max)
-        if (row.title) {
-          map.set(row.title, row.player_count_max)
-        }
-      }
-    }
-  }
-  return map
-}
-
-/**
- * イベントの正しい最大参加者数を解決する。
- * 優先順位: org override (by id) → org override (by title) → master JOIN → event fields → fallback
- */
-function resolveMaxParticipants(
-  event: { scenario_master_id?: string | null; scenario?: string; scenario_masters?: unknown; max_participants?: number; capacity?: number },
-  orgScenarioMap: Map<string, number>
-): number {
-  if (event.scenario_master_id && orgScenarioMap.has(event.scenario_master_id)) {
-    return orgScenarioMap.get(event.scenario_master_id)!
-  }
-  if (event.scenario && orgScenarioMap.has(event.scenario)) {
-    return orgScenarioMap.get(event.scenario)!
-  }
-  const scenarioData = event.scenario_masters as { player_count_max?: number } | null
-  if (scenarioData?.player_count_max) {
-    return scenarioData.player_count_max
-  }
-  return event.max_participants || event.capacity || 8
-}
-
-
-// シナリオ名を正規化（プレフィックス除去等）
-function normalizeScenarioName(name: string): string {
-  return name
-    .replace(/^["「『📗📕]/, '')
-    .replace(/["」』]$/, '')
-    .replace(/^貸・/, '')
-    .replace(/^募・/, '')
-    .replace(/^🈵・/, '')
-    .replace(/^GMテスト・/, '')
-    .replace(/^打診・/, '')
-    .replace(/^仮/, '')
-    .replace(/^（仮）/, '')
-    .replace(/^\(仮\)/, '')
-    .replace(/\(.*?\)$/, '')
-    .replace(/（.*?）$/, '')
-    .trim()
-}
-
-function removeMissingScheduleColumn(
-  payload: Record<string, unknown>,
-  error: { message?: string; details?: string; hint?: string } | null
-): { nextPayload: Record<string, unknown>; removedColumn?: string } | null {
-  if (!error) return null
-
-  const combined = `${error.message ?? ''} ${error.details ?? ''} ${error.hint ?? ''}`
-  const patterns = [
-    /column "([^"]+)" of relation "schedule_events" does not exist/i,
-    /Could not find the '([^']+)' column of 'schedule_events'/i
-  ]
-
-  for (const pattern of patterns) {
-    const match = combined.match(pattern)
-    if (match?.[1]) {
-      const missingColumn = match[1]
-      if (missingColumn in payload) {
-        const nextPayload = { ...payload }
-        delete nextPayload[missingColumn]
-        return { nextPayload, removedColumn: missingColumn }
-      }
-    }
-  }
-
-  return null
-}
-
-// シナリオ名から自動でマッチングして scenario_masters の id と正式名称を返す
-async function findMatchingScenario(scenarioName: string | undefined): Promise<{ id: string; title: string } | null> {
-  if (!scenarioName || scenarioName.trim() === '') return null
-  
-  const cleanName = normalizeScenarioName(scenarioName)
-  if (cleanName.length < 2) return null
-  
-  // エイリアスマッピングを適用（DBから取得）
-  const aliasMap = await getScenarioAliases()
-  let searchName = aliasMap[cleanName] ?? cleanName
-  if (searchName === cleanName) {
-    // 部分一致でエイリアスを探す
-    for (const [alias, formal] of Object.entries(aliasMap)) {
-      if (cleanName.includes(alias)) {
-        searchName = formal
-        break
-      }
-    }
-  }
-  
-  // シナリオマスタから検索
-  const { data: scenarios } = await supabase
-    .from('scenario_masters')
-    .select('id, title')
-  
-  if (!scenarios || scenarios.length === 0) return null
-  
-  // 1. 完全一致
-  let match = scenarios.find(s => s.title === searchName)
-  
-  // 2. 前方一致
-  if (!match) {
-    match = scenarios.find(s => s.title.startsWith(searchName))
-  }
-  
-  // 3. シナリオタイトルが入力に含まれている
-  if (!match) {
-    match = scenarios.find(s => searchName.includes(s.title))
-  }
-  
-  // 4. 入力がシナリオタイトルに含まれている（4文字以上）
-  if (!match && searchName.length >= 4) {
-    match = scenarios.find(s => s.title.includes(searchName))
-  }
-  
-  return match || null
+// API が返す schedule_events_staff_view 行（ScheduleEvent + DB のみの列）
+type ScheduleEventRow = ScheduleEvent & {
+  store_id: string
+  capacity?: number
 }
 
 // 公演スケジュール関連のAPI
@@ -170,10 +29,8 @@ export const scheduleApi = {
   },
 
   // 指定月の公演を取得（通常公演 + 確定した貸切公演）
-  // organizationId: 互換のため残すがバックエンド側で JWT から取得する（無視される）
-  // skipOrgFilter: 互換のため残すがバックエンド側では常に JWT の組織でフィルタする（無視される）
+  // organizationId / skipOrgFilter: 互換のため残すがバックエンド側で JWT から取得する（無視される）
   // skipPrivateBookings: trueの場合、確定貸切予約のクエリをスキップ
-  // バックエンド API (/api/schedule?type=by-month) 経由で取得
   async getByMonth(year: number, month: number, _organizationId?: string, _skipOrgFilter?: boolean, skipPrivateBookings?: boolean) {
     const params = new URLSearchParams({
       type: 'by-month',
@@ -187,8 +44,6 @@ export const scheduleApi = {
   },
 
   // 日付範囲でスケジュールを取得（キット管理用）
-  // organizationId: 互換のため残すがバックエンド側で JWT から取得する（無視される）
-  // バックエンド API (/api/schedule?type=by-date-range) 経由で取得
   async getByDateRange(startDate: string, endDate: string, _organizationId?: string, includeCancelled = false) {
     const params = new URLSearchParams({
       type: 'by-date-range',
@@ -217,8 +72,6 @@ export const scheduleApi = {
   },
 
   // シナリオIDで指定期間の公演を取得
-  // organizationId: 互換のため残すがバックエンド側で JWT から取得する（無視される）
-  // バックエンド API (/api/schedule?type=by-scenario) 経由で取得
   async getByScenarioId(scenarioId: string, startDate: string, endDate: string, _organizationId?: string) {
     const params = new URLSearchParams({
       type: 'by-scenario',
@@ -230,13 +83,14 @@ export const scheduleApi = {
   },
 
   // 公演を作成
+  // バックエンド API (POST /api/schedule) 経由。organization_id はサーバ側で JWT から強制。
   async create(eventData: {
     date: string
     store_id: string
     venue?: string
     scenario?: string
     scenario_master_id?: string | null
-    organization_scenario_id?: string | null  // 組織シナリオID（新UI対応）
+    organization_scenario_id?: string | null
     category: string
     start_time: string
     end_time: string
@@ -246,461 +100,85 @@ export const scheduleApi = {
     notes?: string
     time_slot?: string | null
     is_reservation_enabled?: boolean
-    is_tentative?: boolean  // 仮状態（非公開）
-    venue_rental_fee?: number  // 場所貸し公演料金
-    organization_id: string  // マルチテナント対応：必須
-    reservation_name?: string | null  // 貸切予約の予約者名
-    is_reservation_name_overwritten?: boolean  // 予約者名が手動上書きされたか
-    is_private_request?: boolean  // 貸切リクエストかどうか
-    reservation_id?: string | null  // 貸切リクエストID
+    is_tentative?: boolean
+    venue_rental_fee?: number
+    organization_id?: string  // 互換のため受けるがサーバ側で無視される
+    reservation_name?: string | null
+    is_reservation_name_overwritten?: boolean
+    is_private_request?: boolean
+    reservation_id?: string | null
   }) {
-    // シナリオ名から自動でマッチングして scenario_master_id と正式名称を設定
-    const finalData: Record<string, unknown> = { ...eventData }
-    if (eventData.scenario && !eventData.scenario_master_id && !finalData.scenario_master_id) {
-      const match = await findMatchingScenario(eventData.scenario)
-      if (match) {
-        // findMatchingScenario は scenario_masters から検索するので、scenario_master_id に設定
-        finalData.scenario_master_id = match.id
-        finalData.scenario = match.title // 正式名称に更新
-        logger.info(`シナリオ自動マッチング: ${eventData.scenario} -> ${match.title} (scenario_master_id: ${match.id})`)
-      }
-    }
-    
-    // organization_scenario_id を自動設定（scenario_master_id から逆引き）
-    if (finalData.scenario_master_id && eventData.organization_id && !finalData.organization_scenario_id) {
-      try {
-        // organization_scenarios から該当のレコードを取得
-        const { data: orgScenario } = await supabase
-          .from('organization_scenarios')
-          .select('id')
-          .eq('scenario_master_id', finalData.scenario_master_id as string)
-          .eq('organization_id', eventData.organization_id)
-          .single()
-        
-        if (orgScenario?.id) {
-          finalData.organization_scenario_id = orgScenario.id
-          logger.info(`organization_scenario_id 自動設定: ${orgScenario.id}`)
-        }
-      } catch (err) {
-        // エラーは無視（organization_scenario_id は任意）
-        logger.warn('organization_scenario_id の自動設定に失敗:', err)
-      }
-    }
-    
-    // DBで許可されていないカテゴリをopenにマッピング
-    const DB_VALID_CATEGORIES = ['open', 'private', 'gmtest', 'testplay', 'offsite', 'venue_rental', 'venue_rental_free', 'package', 'mtg']
-    
-    if (finalData.category && typeof finalData.category === 'string' && !DB_VALID_CATEGORIES.includes(finalData.category)) {
-      logger.info(`カテゴリマッピング: ${finalData.category} -> open`)
-      finalData.category = 'open'
-    }
-    
-    // INSERT: id のみ返す（authenticated のカラム制限を回避）
-    // 全カラムの取得はスタッフ専用ビューから別途行う
-    let insertPayload: Record<string, unknown> = { ...finalData }
-    let lastError: { message?: string; details?: string; hint?: string } | null = null
-    let insertedId: string | null = null
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      const { data, error } = await supabase
-        .from('schedule_events')
-        .insert([insertPayload])
-        .select('id')
-        .single()
-
-      if (!error) {
-        insertedId = data.id
-        break
-      }
-
-      lastError = error
-      const removal = removeMissingScheduleColumn(insertPayload, error)
-      if (!removal) break
-
-      insertPayload = removal.nextPayload
-      logger.warn(`schedule_events insert: missing column "${removal.removedColumn}", retrying without it`)
-    }
-
-    if (!insertedId) throw lastError
-
-    // スタッフ専用ビューから全カラム（JOIN含む）を取得して返す
-    const { data: fullEvent, error: fetchError } = await supabase
-      .from('schedule_events_staff_view')
-      .select(`
-        *,
-        stores:store_id (
-          id,
-          name,
-          short_name
-        ),
-        scenario_masters:scenario_master_id (
-          id,
-          title,
-          player_count_max
-        )
-      `)
-      .eq('id', insertedId)
-      .single()
-
-    if (fetchError) throw fetchError
-    return fullEvent
+    // organization_id はサーバ側で JWT から強制するので渡しても無視される
+    return await apiClient.post<ScheduleEventRow>('/api/schedule', eventData)
   },
 
   // 公演を更新
-  async update(id: string, updates: Partial<{
-    date: string
-    store_id: string
-    venue: string
-    scenario_master_id: string
-    organization_scenario_id: string  // 組織シナリオID（新UI対応）
-    scenario: string
-    category: string
-    start_time: string
-    end_time: string
-    capacity: number
-    gms: string[]
-    gm_roles: Record<string, string>
-    notes: string
-    is_cancelled: boolean
-    is_tentative: boolean // 仮状態（非公開）
-    is_reservation_enabled: boolean
-    time_slot: string | null
-    venue_rental_fee: number  // 場所貸し公演料金
-    reservation_name: string | null  // 貸切予約の予約者名
-    is_reservation_name_overwritten: boolean  // 予約者名が手動上書きされたか
-    is_private_request: boolean  // 貸切リクエストかどうか
-    reservation_id: string | null  // 貸切リクエストID
-  }>, organizationId?: string, expectedUpdatedAt?: string) {
-    // シナリオ名から自動でマッチングして scenario_master_id と正式名称を設定
-    const finalUpdates: Record<string, unknown> = { ...updates }
-    if (updates.scenario && !updates.scenario_master_id && !finalUpdates.scenario_master_id) {
-      const match = await findMatchingScenario(updates.scenario)
-      if (match) {
-        // findMatchingScenario は scenario_masters から検索するので、scenario_master_id に設定
-        finalUpdates.scenario_master_id = match.id
-        finalUpdates.scenario = match.title // 正式名称に更新
-        logger.info(`シナリオ自動マッチング: ${updates.scenario} -> ${match.title} (scenario_master_id: ${match.id})`)
-      }
+  // バックエンド API (PATCH /api/schedule?id=...) 経由。organizationId は無視される。
+  async update(
+    id: string,
+    updates: Partial<{
+      date: string
+      store_id: string
+      venue: string
+      scenario_master_id: string
+      organization_scenario_id: string
+      scenario: string
+      category: string
+      start_time: string
+      end_time: string
+      capacity: number
+      gms: string[]
+      gm_roles: Record<string, string>
+      notes: string
+      is_cancelled: boolean
+      is_tentative: boolean
+      is_reservation_enabled: boolean
+      time_slot: string | null
+      venue_rental_fee: number
+      reservation_name: string | null
+      is_reservation_name_overwritten: boolean
+      is_private_request: boolean
+      reservation_id: string | null
+    }>,
+    _organizationId?: string,
+    expectedUpdatedAt?: string,
+  ) {
+    const params = new URLSearchParams({ id })
+    if (expectedUpdatedAt) {
+      params.set('expected_updated_at', expectedUpdatedAt)
     }
-    
-    // organization_scenario_id を自動設定（scenario_master_id から逆引き）
-    const scenarioMasterIdToUse = (finalUpdates as Record<string, unknown>).scenario_master_id || (updates as Record<string, unknown>).scenario_master_id
-    const orgIdToUse = organizationId || await getCurrentOrganizationId()
-    if (scenarioMasterIdToUse && orgIdToUse && !finalUpdates.organization_scenario_id) {
-      try {
-        const { data: orgScenario } = await supabase
-          .from('organization_scenarios')
-          .select('id')
-          .eq('scenario_master_id', scenarioMasterIdToUse as string)
-          .eq('organization_id', orgIdToUse)
-          .single()
-        
-        if (orgScenario?.id) {
-          finalUpdates.organization_scenario_id = orgScenario.id
-          logger.info(`organization_scenario_id 自動設定（更新）: ${orgScenario.id}`)
-        }
-      } catch (err) {
-        logger.warn('organization_scenario_id の自動設定に失敗（更新）:', err)
-      }
-    }
-    
-    // DBで許可されていないカテゴリをopenにマッピング
-    const DB_VALID_CATEGORIES = ['open', 'private', 'gmtest', 'testplay', 'offsite', 'venue_rental', 'venue_rental_free', 'package', 'mtg']
-    
-    if (finalUpdates.category && typeof finalUpdates.category === 'string' && !DB_VALID_CATEGORIES.includes(finalUpdates.category)) {
-      logger.info(`カテゴリマッピング: ${finalUpdates.category} -> open`)
-      finalUpdates.category = 'open'
-    }
-    
-    let updatePayload: Record<string, unknown> = { ...finalUpdates, updated_at: new Date().toISOString() }
-    let lastError: { message?: string; details?: string; hint?: string } | null = null
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      let query = supabase
-        .from('schedule_events')
-        .update(updatePayload)
-        .eq('id', id)
-
-      // ⚠️ 楽観的ロック: updated_at が読み込み時と一致する場合のみ更新
-      if (expectedUpdatedAt) {
-        query = query.eq('updated_at', expectedUpdatedAt)
-      }
-
-      // id のみ返す（authenticated のカラム制限を回避、楽観的ロック失敗検出には十分）
-      const { data, error } = await query.select('id').single()
-
-      if (!error) break
-
-      // 楽観的ロック失敗（PGRST116 = 0 rows = 他の人が先に更新した）
-      if (expectedUpdatedAt && error.code === 'PGRST116') {
-        throw new Error('他のユーザーが先にこのイベントを更新しました。ページを再読み込みして最新データを確認してください。')
-      }
-
-      lastError = error
-      const removal = removeMissingScheduleColumn(updatePayload, error)
-      if (!removal) break
-
-      updatePayload = removal.nextPayload
-      logger.warn(`schedule_events update: missing column "${removal.removedColumn}", retrying without it`)
-    }
-
-    if (lastError) throw lastError
-
-    // スタッフ専用ビューから全カラム（JOIN含む）を取得して返す（INSERT と同パターン）
-    const { data: fullEvent, error: fetchError } = await supabase
-      .from('schedule_events_staff_view')
-      .select(`
-        *,
-        stores:store_id (
-          id,
-          name,
-          short_name
-        ),
-        scenario_masters:scenario_master_id (
-          id,
-          title
-        )
-      `)
-      .eq('id', id)
-      .single()
-
-    if (fetchError) throw fetchError
-    return fullEvent
+    return await apiClient.patch<ScheduleEventRow>(`/api/schedule?${params.toString()}`, updates)
   },
 
   // 公演を削除（関連する予約はCASCADEで自動削除）
   async delete(id: string) {
-    // 公演を削除（ON DELETE CASCADE により関連データも自動削除）
-    const { error } = await supabase
-      .from('schedule_events')
-      .delete()
-      .eq('id', id)
-    
-    if (error) throw error
+    await apiClient.delete<void>(`/api/schedule?id=${encodeURIComponent(id)}`)
   },
 
   // 公演をキャンセル/復活
   async toggleCancel(id: string, isCancelled: boolean, cancellationReason?: string) {
-    const updateData: Record<string, unknown> = { 
-      is_cancelled: isCancelled 
-    }
-    
-    // 中止の場合は理由と日時を設定
-    if (isCancelled) {
-      updateData.cancellation_reason = cancellationReason || null
-      updateData.cancelled_at = new Date().toISOString()
-    } else {
-      // 復活の場合はクリア
-      updateData.cancellation_reason = null
-      updateData.cancelled_at = null
-    }
-    
-    const { error } = await supabase
-      .from('schedule_events')
-      .update(updateData)
-      .eq('id', id)
-
-    if (error) throw error
-
-    // スタッフ専用ビューから更新後のデータを取得（カラム制限を回避）
-    const { data, error: fetchError } = await supabase
-      .from('schedule_events_staff_view')
-      .select()
-      .eq('id', id)
-      .single()
-
-    if (fetchError) throw fetchError
-    return data
+    const params = new URLSearchParams({ id, action: 'toggle-cancel' })
+    return await apiClient.patch<ScheduleEventRow>(`/api/schedule?${params.toString()}`, {
+      is_cancelled: isCancelled,
+      cancellation_reason: cancellationReason ?? null,
+    })
   },
 
   // 中止でない全公演にデモ参加者を満席まで追加（既存データの修復も含む）
   async addDemoParticipantsToAllActiveEvents() {
-    try {
-      // 組織フィルタ（マルチテナント対応）
-      const orgId = await getCurrentOrganizationId()
-      
-      let query = supabase
-        .from('schedule_events_staff_view')
-        .select('id, organization_id, scenario_master_id, scenario, store_id, date, start_time, category, gms, capacity, max_participants')
-        .eq('is_cancelled', false)
-        .order('date', { ascending: true })
-      
-      if (orgId) {
-        query = query.eq('organization_id', orgId)
-      }
-      
-      const { data: events, error: eventsError } = await query
-      
-      if (eventsError) {
-        logger.error('公演データの取得に失敗:', eventsError)
-        return { success: false, error: eventsError }
-      }
-      
-      if (!events || events.length === 0) {
-        logger.log('中止でない公演が見つかりません')
-        return { success: true, message: '中止でない公演が見つかりません' }
-      }
-      
-      logger.log(`${events.length}件の公演をチェックします`)
-      
-      const orgScenarioMapForDemo = await getOrgScenarioPlayerCounts(orgId)
-      let successCount = 0
-      let errorCount = 0
-      
-      for (const event of events) {
-        try {
-          const { data: reservations, error: reservationError } = await supabase
-            .from('reservations')
-            .select('participant_count, participant_names')
-            .eq('schedule_event_id', event.id)
-            .in('status', [...ACTIVE_RESERVATION_STATUSES])
-          
-          if (reservationError) {
-            if (reservationError.code !== 'PGRST116') {
-              logger.warn(`予約データの取得に失敗 (${event.id}):`, {
-                code: reservationError.code,
-                message: reservationError.message,
-                details: reservationError.details
-              })
-              errorCount++
-            }
-            continue
-          }
-          
-          // 予約レコードの合計参加者数
-          const reservedParticipants = reservations?.reduce((sum, reservation) => 
-            sum + (reservation.participant_count || 0), 0) || 0
-          
-          // 定員（organization_scenarios_with_master のオーバーライドを反映）
-          const capacity = resolveMaxParticipants(
-            { scenario_master_id: event.scenario_master_id, scenario: event.scenario, max_participants: event.max_participants, capacity: event.capacity },
-            orgScenarioMapForDemo
-          )
-          
-          // デモ参加者が既に存在するかチェック
-          const hasDemoParticipant = reservations?.some(r => 
-            r.participant_names?.includes('デモ参加者') || 
-            r.participant_names?.some((name: string) => name.includes('デモ'))
-          )
-          
-          // 足りない参加者数を計算（定員 - 実際の予約人数）
-          // ※ current_participantsの値は無視し、定員のみを基準とする
-          const neededParticipants = capacity - reservedParticipants
-          
-          if (neededParticipants > 0 && !hasDemoParticipant) {
-            // scenario_master_idがnullの場合はスキップ
-            if (!event.scenario_master_id) {
-              continue
-            }
-            
-            // scenario_masters から基本情報を取得
-            const { data: scenarioMaster, error: masterError } = await supabase
-              .from('scenario_masters')
-              .select('id, title, official_duration')
-              .eq('id', event.scenario_master_id)
-              .single()
-            
-            if (masterError) {
-              logger.error(`シナリオマスタ情報の取得に失敗 (${event.id}):`, masterError)
-              errorCount++
-              continue
-            }
-            
-            // organization_scenarios から料金情報を取得
-            const { data: orgScenario } = await supabase
-              .from('organization_scenarios')
-              .select('participation_fee, gm_test_participation_fee')
-              .eq('scenario_master_id', event.scenario_master_id)
-              .eq('organization_id', event.organization_id)
-              .single()
-            
-            const isGmTest = event.category === 'gmtest'
-            const participationFee = isGmTest 
-              ? (orgScenario?.gm_test_participation_fee || orgScenario?.participation_fee || 0)
-              : (orgScenario?.participation_fee || 0)
-            
-            const demoReservation = {
-              schedule_event_id: event.id,
-              organization_id: event.organization_id,
-              title: event.scenario || scenarioMaster?.title || '',
-              scenario_master_id: event.scenario_master_id,
-              store_id: event.store_id || null,
-              customer_id: null,
-              customer_notes: neededParticipants === 1 ? 'デモ参加者' : `デモ参加者${neededParticipants}名`,
-              requested_datetime: `${event.date}T${event.start_time}+09:00`,
-              duration: scenarioMaster?.official_duration || 120,
-              participant_count: neededParticipants,
-              participant_names: Array(neededParticipants).fill(null).map((_, i) => 
-                neededParticipants === 1 ? 'デモ参加者' : `デモ参加者${i + 1}`
-              ),
-              assigned_staff: event.gms || [],
-              base_price: participationFee * neededParticipants,
-              options_price: 0,
-              total_price: participationFee * neededParticipants,
-              discount_amount: 0,
-              final_price: participationFee * neededParticipants,
-              payment_method: 'onsite',
-              payment_status: 'paid',
-              status: 'confirmed',
-              reservation_source: RESERVATION_SOURCE.DEMO
-            }
-
-            const { error: insertError } = await supabase
-              .from('reservations')
-              .insert(demoReservation)
-            
-            if (insertError) {
-              logger.error(`デモ参加者の予約作成に失敗 (${event.id}):`, insertError)
-              errorCount++
-              continue
-            }
-            
-            // 🚨 CRITICAL: 参加者数を予約テーブルから再計算して更新
-            await recalculateCurrentParticipants(event.id)
-            
-            logger.log(`デモ参加者${neededParticipants}名を追加しました: ${event.scenario} (${event.date})`)
-            successCount++
-          }
-        } catch (err) {
-          logger.error(`デモ参加者の追加に失敗 (${event.id}):`, err)
-          errorCount++
-        }
-      }
-      
-      logger.log(`デモ参加者追加完了: 成功${successCount}件, エラー${errorCount}件`)
-      
-      return {
-        success: true,
-        message: `デモ参加者追加完了: 成功${successCount}件, エラー${errorCount}件`,
-        successCount,
-        errorCount
-      }
-    } catch (err) {
-      logger.error('デモ参加者追加処理でエラー:', err)
-      return { success: false, error: err }
-    }
+    return await apiClient.post<{
+      success: boolean
+      message?: string
+      successCount?: number
+      errorCount?: number
+    }>('/api/schedule?action=add-demo-participants', {})
   },
 
   // 誤って追加されたデモ予約を全削除
   async removeAllDemoReservations() {
-    try {
-      // reservation_source = 'demo' の予約をすべて削除
-      const deleteBySourceParams: RpcAdminDeleteReservationsBySourceParams = {
-        p_reservation_source: RESERVATION_SOURCE.DEMO,
-      }
-      const { data: deletedCount, error } = await supabase.rpc('admin_delete_reservations_by_source', deleteBySourceParams)
-      
-      if (error) {
-        logger.error('デモ予約の削除に失敗:', error)
-        return { success: false, error }
-      }
-      
-      const count = typeof deletedCount === 'number' ? deletedCount : 0
-      logger.log(`${count}件のデモ予約を削除しました`)
-      
-      return { success: true, deletedCount: count }
-    } catch (err) {
-      logger.error('デモ予約削除処理でエラー:', err)
-      return { success: false, error: err }
-    }
-  }
+    return await apiClient.post<{
+      success: boolean
+      deletedCount?: number
+    }>('/api/schedule?action=remove-demo-reservations', {})
+  },
 }
-


### PR DESCRIPTION
## Summary
- `scheduleApi.ts` の write 系メソッド (`create` / `update` / `delete` / `toggleCancel` / `addDemoParticipantsToAllActiveEvents` / `removeAllDemoReservations`) を `/api/schedule` 経由に移行
- フロント側の `.eq('organization_id')` を完全撤廃（5 → 0）
- `organization_id` は JWT 経由でサーバ側のみで取得し、クライアントが渡す値は一切信用しない
- write 系すべてで対象レコードの所有組織を検証（404/403 を適切に返す）
- ホワイトリスト（`SCHEDULE_CREATABLE_FIELDS` / `UPDATABLE_FIELDS`）で Mass Assignment 防止
- `updated_at` 楽観的ロックは `expected_updated_at` クエリパラメータで継承
- `removeAllDemoReservations` は SECURITY DEFINER RPC を使わず、`organization_id = user.orgId` スコープの DELETE に置き換え

## 既存 PR シリーズとの位置づけ
PR #155 (schedule-api-backend: read 系) の write 系版。`#155 → 本 PR` で scheduleApi が完全に API 化される。

## Test plan
- [ ] ステージングで公演の作成 / 編集 / 中止 / 復活 / 削除が動くこと
- [ ] 中止状態切り替えで `cancellation_reason` / `cancelled_at` が反映されること
- [ ] 楽観的ロック（`expected_updated_at` 不一致）で 409 が返ること
- [ ] AddDemoParticipants ページでデモ参加者追加 / 削除が動くこと
- [ ] 他組織のイベント ID を指定すると 403 が返ること
- [ ] ローカル `npm run dev:vercel` → http://localhost:5173 で UI 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)