### PR TITLE
fix(schedule): SlotMemo を月単位 1 クエリに統合（イベント表示不能の緊急対応）

### DIFF
--- a/src/components/schedule/SlotMemoInput.tsx
+++ b/src/components/schedule/SlotMemoInput.tsx
@@ -4,10 +4,57 @@
  * 公演追加時に備考として引き継がれる
  */
 import React, { useState, useEffect, useCallback, useRef } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Textarea } from '@/components/ui/textarea'
 import { supabase } from '@/lib/supabase'
 import { useOrganization } from '@/hooks/useOrganization'
 import { logger } from '@/utils/logger'
+
+// ---- 月単位一括取得（N+M+L のフェッチ枯渇を防ぐ） ----
+
+type SlotMemoMap = Map<string, string>
+
+function memoKey(date: string, storeId: string, timeSlot: string): string {
+  return `${date}|${storeId}|${timeSlot}`
+}
+
+function slotMemosQueryKey(year: number, month: number) {
+  return ['schedule-slot-memos', year, month] as const
+}
+
+async function fetchSlotMemosForMonth(year: number, month: number): Promise<SlotMemoMap> {
+  const startDate = `${year}-${String(month).padStart(2, '0')}-01`
+  const lastDay = new Date(year, month, 0).getDate()
+  const endDate = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+
+  const map: SlotMemoMap = new Map()
+  const { data, error } = await supabase
+    .from('schedule_slot_memos')
+    .select('date, store_id, time_slot, memo')
+    .gte('date', startDate)
+    .lte('date', endDate)
+  if (error) {
+    logger.error('スロットメモ一括取得エラー:', error)
+    return map
+  }
+  for (const row of (data as Array<{ date: string; store_id: string; time_slot: string; memo: string }> | null) ?? []) {
+    map.set(memoKey(row.date, row.store_id, row.time_slot), row.memo)
+  }
+  return map
+}
+
+/**
+ * 月単位で schedule_slot_memos を 1 クエリで取得する。
+ * React Query のキャッシュ共有により、同じ月を見ている SlotMemoInput が
+ * 何個マウントされても発火するフェッチは 1 回だけ。
+ */
+export function useScheduleSlotMemos(year: number, month: number) {
+  return useQuery({
+    queryKey: slotMemosQueryKey(year, month),
+    queryFn: () => fetchSlotMemosForMonth(year, month),
+    staleTime: 60_000,
+  })
+}
 
 // ---- localStorage → DB 一回限りの移行 ----
 
@@ -143,6 +190,14 @@ export function SlotMemoInput({ date, storeId, timeSlot }: SlotMemoInputProps) {
   const [memo, setMemo] = useState('')
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { organizationId } = useOrganization()
+  const queryClient = useQueryClient()
+
+  // 月単位で全メモを 1 クエリで取得（800+ セルが共有キャッシュを使うので fetch は月 1 回）
+  const [yearStr, monthStr] = date.split('-')
+  const year = Number(yearStr)
+  const month = Number(monthStr)
+  const { data: memosMap } = useScheduleSlotMemos(year, month)
+  const cachedMemo = memosMap?.get(memoKey(date, storeId, timeSlot)) ?? ''
 
   // 初回マウント時に localStorage → DB への一回限りの移行を実行
   useEffect(() => {
@@ -151,10 +206,10 @@ export function SlotMemoInput({ date, storeId, timeSlot }: SlotMemoInputProps) {
     }
   }, [organizationId])
 
-  // マウント時に DB からメモを取得
+  // キャッシュから取得したメモを表示用 state に同期
   useEffect(() => {
-    getEmptySlotMemo(date, storeId, timeSlot).then(setMemo)
-  }, [date, storeId, timeSlot])
+    setMemo(cachedMemo)
+  }, [cachedMemo])
 
   const adjustHeight = useCallback(() => {
     const textarea = textareaRef.current
@@ -167,12 +222,25 @@ export function SlotMemoInput({ date, storeId, timeSlot }: SlotMemoInputProps) {
     if (isEditing) adjustHeight()
   }, [isEditing, memo, adjustHeight])
 
+  const updateMemoCache = useCallback((value: string) => {
+    queryClient.setQueryData<SlotMemoMap>(slotMemosQueryKey(year, month), (prev) => {
+      const next: SlotMemoMap = new Map(prev ?? [])
+      if (value) {
+        next.set(memoKey(date, storeId, timeSlot), value)
+      } else {
+        next.delete(memoKey(date, storeId, timeSlot))
+      }
+      return next
+    })
+  }, [queryClient, year, month, date, storeId, timeSlot])
+
   const persistMemo = useCallback((value: string) => {
+    updateMemoCache(value)
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     saveTimerRef.current = setTimeout(() => {
       saveEmptySlotMemo(date, storeId, timeSlot, value, organizationId || undefined)
     }, 500)
-  }, [date, storeId, timeSlot, organizationId])
+  }, [date, storeId, timeSlot, organizationId, updateMemoCache])
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newMemo = e.target.value
@@ -184,6 +252,7 @@ export function SlotMemoInput({ date, storeId, timeSlot }: SlotMemoInputProps) {
   const handleBlur = () => {
     setIsEditing(false)
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    updateMemoCache(memo)
     saveEmptySlotMemo(date, storeId, timeSlot, memo, organizationId || undefined)
   }
 


### PR DESCRIPTION
## Background
スケジュール画面でイベントが表示されない事象が発生（複数 PR マージ後に顕在化）。

## Root Cause
\`SlotMemoInput\` がセル毎に個別の Supabase 直クエリで \`schedule_slot_memos\` を取得していた。月表示で **30 日 × 9 店舗 × 3 時間帯 = 810 並列リクエスト** → Chrome の接続プール枯渇 (\`ERR_INSUFFICIENT_RESOURCES\`) → 同じ Supabase ホストへの他クエリ（臨時会場 / 予約ニックネーム / 貸切リクエスト）を巻き添えに → \`fetchScheduleEventsForMonth\` が例外/空配列で resolve → イベント表示不能。

これは PR #166 とは独立した既存問題だが、staging への複数 PR マージで微妙にタイミングが変わり顕在化した。

## Fix
- \`useScheduleSlotMemos(year, month)\` を新設し、月の全メモを **1 クエリで取得**
- React Query のキャッシュ共有により、同じ月の \`SlotMemoInput\` が何個マウントされても発火する fetch は 1 回だけ
- 保存時は \`queryClient.setQueryData\` で楽観的にキャッシュ更新

## Test plan
- [ ] ステージングでスケジュール画面を開き、イベントが表示されること
- [ ] DevTools Network タブで \`schedule_slot_memos\` リクエストが**月あたり 1 回**だけ発火していること
- [ ] スロットメモを編集 → 保存 → 月を切り替えて戻ったときに反映されていること
- [ ] 臨時会場・貸切リクエストの読み込みエラーが消えていること

## Follow-ups (本 PR スコープ外)
- \`useEventOperations\` 内の \`saveEmptySlotMemo\` 呼び出しもキャッシュ更新するように改善
- \`PerformanceModal\` の \`getEmptySlotMemo\` も同キャッシュから lookup（現状は単発呼び出しなので影響軽微）

🤖 Generated with [Claude Code](https://claude.com/claude-code)