### PR TITLE
fix(schedule-cache): キャッシュバスタを v2 に上げ、空配列の永続化を防止

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -57,7 +57,9 @@ const queryClient = new QueryClient({
 
 // スケジュールデータを IndexedDB に永続化
 // buster を変えるとキャッシュが自動無効化される（スキーマ変更時に更新する）
-const SCHEDULE_CACHE_BUSTER = 'v1'
+// v2: PR #168 以前は API バグで空配列が永続化されていたため、全クライアントの
+//     キャッシュを強制無効化する
+const SCHEDULE_CACHE_BUSTER = 'v2'
 const SCHEDULE_CACHE_MAX_AGE = 14 * 24 * 60 * 60 * 1000 // 14日間
 
 const idbPersister = createAsyncStoragePersister({
@@ -538,8 +540,14 @@ function App() {
           buster: SCHEDULE_CACHE_BUSTER,
           dehydrateOptions: {
             // スケジュールイベントクエリのみ IndexedDB に保存（他は通常のメモリキャッシュ）
+            // 空配列・エラー結果は永続化しない: 一時的なエラー時のレスポンスが
+            // 「fresh」として残り続け、refetch されなくなる詰みを防ぐ
             shouldDehydrateQuery: (query) =>
-              Array.isArray(query.queryKey) && query.queryKey[0] === 'scheduleEvents',
+              Array.isArray(query.queryKey) &&
+              query.queryKey[0] === 'scheduleEvents' &&
+              query.state.status === 'success' &&
+              Array.isArray(query.state.data) &&
+              (query.state.data as unknown[]).length > 0,
           },
         }}
       >


### PR DESCRIPTION
## 経緯
PR #168 で API バグを修正したが、それ以前にユーザの IndexedDB に**空配列**が永続化済みのため、5月以外の月が表示されない症状が発生。

## Root Cause
\`useScheduleEventsQuery\` は \`staleTime: Infinity\` + \`gcTime: Infinity\` で、永続化された結果は実質永久に「fresh」扱い。\`queryClient.prefetchQuery\` も「キャッシュあり」と判断してスキップ → 再 fetch されない。

## Fix
1. **SCHEDULE_CACHE_BUSTER を v1 → v2** に変更 → 全クライアントの既存 IndexedDB キャッシュを自動無効化（次回アクセスで強制再 fetch）
2. **\`shouldDehydrateQuery\` に「success + 非空配列」ガード追加** → 一時的な失敗・空結果が永続化されないようにする（再発防止）

## Test plan
- [ ] staging deploy 後、各月のイベントが表示される
- [ ] 月切替でプリフェッチが効く（即時表示）
- [ ] DevTools Application → IndexedDB → \`keyval-store\` の中身が \`v2\` バスタで再構築されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)