### PR TITLE
fix(api): sales / scenarios もスタッフビューではなく schedule_events を直接参照

### DIFF
--- a/api/sales.ts
+++ b/api/sales.ts
@@ -2,6 +2,12 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { db, getMissingEnvError } from './_lib/db.js'
 import { requireAuth, requireStaff, ApiError } from './_lib/auth.js'
 
+// NOTE: schedule_events_staff_view ではなく schedule_events を直接参照する。
+// 理由: スタッフ向けビューは `WHERE is_staff_or_admin()` で auth.uid() を見るが、
+// この API ハンドラは service role で実行されるため auth.uid() が NULL になり
+// ビュー越しでは常に 0 件しか返らない。本ハンドラは requireStaff(user) で既に
+// スタッフ権限を確認しているので、ビューの追加チェックは不要。
+
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,
   'http://localhost:5173',
@@ -188,7 +194,7 @@ async function handleByPeriod(req: VercelRequest, res: VercelResponse, orgId: st
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: events, error } = await (db as any)
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select(SCHEDULE_EVENT_SALES_SELECT_FIELDS)
     .eq('organization_id', orgId)
     .gte('date', start)
@@ -369,7 +375,7 @@ async function handleByStore(req: VercelRequest, res: VercelResponse, orgId: str
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (db as any)
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select(STORE_AND_SCENARIO_NESTED_SELECT)
     .eq('organization_id', orgId)
     .gte('date', start)
@@ -391,7 +397,7 @@ async function handleByScenario(req: VercelRequest, res: VercelResponse, orgId: 
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (db as any)
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select(STORE_AND_SCENARIO_NESTED_SELECT)
     .eq('organization_id', orgId)
     .gte('date', start)
@@ -413,7 +419,7 @@ async function handleAuthorPerformanceCount(req: VercelRequest, res: VercelRespo
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (db as any)
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select(AUTHOR_PERFORMANCE_SELECT)
     .eq('organization_id', orgId)
     .gte('date', start)
@@ -452,7 +458,7 @@ async function handleScenarioPerformance(req: VercelRequest, res: VercelResponse
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let query: any = (db as any)
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select(SCHEDULE_EVENT_SALES_SELECT_FIELDS)
     .eq('organization_id', orgId)
     .gte('date', start)
@@ -561,7 +567,7 @@ async function handleOpenEventAnalysis(req: VercelRequest, res: VercelResponse, 
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let eventsQuery: any = (db as any)
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select('id, date, start_time, scenario, scenario_master_id, capacity, max_participants, current_participants, is_cancelled, created_at, store_id, category')
     .eq('organization_id', orgId)
     .in('category', categories)
@@ -612,7 +618,7 @@ async function handleScheduleExport(req: VercelRequest, res: VercelResponse, org
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: events, error } = await (db as any)
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select('id, date, start_time, end_time, store_id, venue, scenario, scenario_master_id, organization_scenario_id, category, gms, capacity, max_participants, venue_rental_fee, is_cancelled, organization_id')
     .eq('organization_id', orgId)
     .gte('date', start)

--- a/api/scenarios.ts
+++ b/api/scenarios.ts
@@ -8,6 +8,12 @@ const db = supabaseUrl && serviceRoleKey
   ? createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } })
   : null
 
+// NOTE: schedule_events_staff_view ではなく schedule_events を直接参照する。
+// 理由: スタッフ向けビューは `WHERE is_staff_or_admin()` で auth.uid() を見るが、
+// この API ハンドラは service role で実行されるため auth.uid() が NULL になり
+// ビュー越しでは常に 0 件しか返らない。requireStaff(user) で既にスタッフ権限を
+// 確認しているので、ビューの追加チェックは不要。
+
 // ─── CORS ────────────────────────────────────────────────────────────────────
 const ALLOWED_ORIGINS = [
   process.env.ALLOWED_ORIGIN,
@@ -482,7 +488,7 @@ async function handleGetScenarioStats(req: VercelRequest, res: VercelResponse, o
 
   // ── 公演イベント詳細 ────────────────────────────────────────────────────
   const { data: events, error: eventsError } = await db
-    .from('schedule_events_staff_view')
+    .from('schedule_events')
     .select(STATS_SCHEDULE_EVENT_DETAIL_FIELDS)
     .eq('scenario_master_id', scenarioId)
     .eq('organization_id', orgId)
@@ -675,7 +681,7 @@ async function handleGetAllScenarioStats(res: VercelResponse, orgId: string) {
     const from = page * pageSize
     const to = from + pageSize - 1
     const { data, error } = await db
-      .from('schedule_events_staff_view')
+      .from('schedule_events')
       .select(STATS_ALL_SCHEDULE_EVENT_FIELDS)
       .eq('organization_id', orgId)
       .lte('date', today)


### PR DESCRIPTION
## 経緯
PR #168 と同じバグが \`api/sales.ts\` (7 箇所) と \`api/scenarios.ts\` (2 箇所) にも存在。本番データ restore 後に売上画面・シナリオ詳細が空になっていた可能性が高い。

## 影響範囲
| 画面 | 症状 |
|---|---|
| 売上管理 | 全部 0 件で売上 0 円 |
| 公演別売上分析 | データなし |
| シナリオ詳細の公演履歴 | 空 |

## Root Cause
\`schedule_events_staff_view\` は \`WHERE is_staff_or_admin()\` でフィルタしているが、API ハンドラは service role で動くので \`auth.uid()\` が NULL → false → 常に 0 件。

## Fix
\`.from('schedule_events_staff_view')\` を \`.from('schedule_events')\` に置換。service role なら RLS バイパスで全カラム見えるため、ビューの追加チェックは冗長。

## なぜフロントは触らない
\`src/*\` の \`schedule_events_staff_view\` 参照は **authenticated ロール (ユーザー JWT)** で動作するためビューのフィルタが正しく効く。フロントは schedule_events の authenticated 用カラム制限を view 経由で回避する必要があるため、view を使い続ける必要がある。

| 場所 | クライアント | view 使用 |
|---|---|---|
| \`api/*\` (Vercel functions) | service role | ❌ 直接 \`schedule_events\` 必須 |
| \`src/*\` (フロント) | authenticated JWT | ✅ view 必須 |

## Test plan
- [ ] ステージングで売上管理画面に売上が表示される
- [ ] 公演別売上分析にデータが出る
- [ ] シナリオ詳細の公演履歴が表示される

## Follow-ups
- 再発防止: \`api/*\` で \`*_staff_view\` を grep して fail にする CI ガード追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)