### PR TITLE
fix(api/schedule): UNIQUE 違反 (23505) を 500 ではなく 409 + 友好的メッセージで返す

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1028,6 +1028,14 @@ async function handleCreate(req: VercelRequest, res: VercelResponse, user: AuthU
 
   if (!insertedId) {
     console.error('[schedule:create] insert error:', lastError)
+    // 23505: unique_violation
+    // idx_schedule_events_unique_slot: WHERE is_cancelled = false の partial unique
+    // (date, store_id, time_slot, organization_id) で重複が起きた場合
+    if (lastError?.code === '23505') {
+      return res.status(409).json({
+        error: 'この日時・店舗・時間帯にはすでに公演があります。既存の公演を確認するか、不要であれば中止してから再度作成してください。',
+      })
+    }
     return res.status(500).json({ error: '公演の作成に失敗しました', detail: lastError?.message })
   }
 
@@ -1148,6 +1156,11 @@ async function handleUpdate(req: VercelRequest, res: VercelResponse, user: AuthU
 
   if (!updateSucceeded) {
     console.error('[schedule:update] update error:', lastError)
+    if (lastError?.code === '23505') {
+      return res.status(409).json({
+        error: 'この日時・店舗・時間帯にはすでに別の公演があります。移動先を確認してください。',
+      })
+    }
     return res.status(500).json({ error: '公演の更新に失敗しました', detail: lastError?.message })
   }
 


### PR DESCRIPTION
## 背景
\`schedule_events\` には partial unique index があり、中止以外の公演で同じ \`(date, store_id, time_slot, organization_id)\` を作ろうとすると DB が \`23505\` を返す。これまではこれを補足せず、500 で「公演の作成に失敗しました」とだけ返していたため、ユーザーには原因が伝わらなかった。

## Fix
\`handleCreate\` / \`handleUpdate\` の insert/update エラーで PostgreSQL の \`23505\` を検出し、HTTP 409 + 日本語メッセージで返す:

| ケース | レスポンス |
|---|---|
| 重複追加 (create) | 409 「この日時・店舗・時間帯にはすでに公演があります。既存の公演を確認するか、不要であれば中止してから再度作成してください。」 |
| 移動先重複 (update) | 409 「この日時・店舗・時間帯にはすでに別の公演があります。移動先を確認してください。」 |
| その他 DB エラー | 500 (従来通り) |

## Test plan
- [ ] ステージングで埋まっているスロットに公演追加 → トーストに友好的メッセージが出る (500 ではなく 409)
- [ ] ドラッグで埋まっている枠に移動 → 同様

🤖 Generated with [Claude Code](https://claude.com/claude-code)