### PR TITLE
feat(api): kitApi の kit_transfer_events / completions をバックエンド API 化

### DIFF
--- a/api/kit-transfer-completions.ts
+++ b/api/kit-transfer-completions.ts
@@ -1,0 +1,367 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError, type AuthUser } from './_lib/auth.js'
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+const SELECT = `
+  *,
+  picked_up_by_staff:staff!kit_transfer_completions_picked_up_by_fkey(id, name),
+  delivered_by_staff:staff!kit_transfer_completions_delivered_by_fkey(id, name)
+`
+
+// ─── ヘルパ ─────────────────────────────────────────────────────────────────
+async function getOrgScenarioMasterId(orgScenarioId: string, orgId: string): Promise<string | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_scenarios')
+    .select('id, scenario_master_id')
+    .eq('id', orgScenarioId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (error) throw new ApiError(500, `org_scenario 検証に失敗: ${error.message}`)
+  if (!data) throw new ApiError(403, '指定の org_scenario_id は自組織のものではありません')
+  return data.scenario_master_id ?? null
+}
+
+async function assertStoreOwnedByOrg(storeId: string, orgId: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('stores')
+    .select('id')
+    .eq('id', storeId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (error) throw new ApiError(500, `store 検証に失敗: ${error.message}`)
+  if (!data) throw new ApiError(403, '指定の store は自組織のものではありません')
+}
+
+async function assertStaffOwnedByOrg(staffId: string, orgId: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('staff')
+    .select('id')
+    .eq('id', staffId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (error) throw new ApiError(500, `staff 検証に失敗: ${error.message}`)
+  if (!data) throw new ApiError(403, '指定の staff は自組織のものではありません')
+}
+
+// ─── GET: getTransferCompletions ───────────────────────────────────────────
+async function handleGet(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const startDate = req.query.start_date as string | undefined
+  const endDate = req.query.end_date as string | undefined
+
+  if (!startDate || !endDate) {
+    return res.status(400).json({ error: 'start_date / end_date が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('kit_transfer_completions')
+    .select(SELECT)
+    .eq('organization_id', user.orgId)
+    .gte('performance_date', startDate)
+    .lte('performance_date', endDate)
+
+  if (error) {
+    console.error('[kit-transfer-completions] GET error:', error)
+    return res.status(500).json({ error: '完了状態の取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// ─── POST: action 別の upsert/update ───────────────────────────────────────
+async function handlePost(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = (req.query.action ?? req.body?.action) as string | undefined
+  const body = req.body ?? {}
+
+  if (action === 'mark_picked_up') {
+    return handleMarkPickedUp(body, res, user)
+  }
+  if (action === 'unmark_picked_up') {
+    return handleUnmarkPickedUp(body, res, user)
+  }
+  if (action === 'mark_delivered') {
+    return handleMarkDelivered(body, res, user)
+  }
+  if (action === 'unmark_delivered') {
+    return handleUnmarkDelivered(body, res, user)
+  }
+
+  return res.status(400).json({ error: 'action が必要です (mark_picked_up|unmark_picked_up|mark_delivered|unmark_delivered)' })
+}
+
+async function handleMarkPickedUp(
+  body: Record<string, unknown>,
+  res: VercelResponse,
+  user: AuthUser
+) {
+  const {
+    scenario_id,
+    kit_number,
+    performance_date,
+    from_store_id,
+    to_store_id,
+    staff_id,
+  } = body as {
+    scenario_id?: string
+    kit_number?: number
+    performance_date?: string
+    from_store_id?: string
+    to_store_id?: string
+    staff_id?: string
+  }
+
+  if (!scenario_id || !Number.isInteger(kit_number) || !performance_date || !from_store_id || !to_store_id || !staff_id) {
+    return res.status(400).json({ error: 'scenario_id / kit_number / performance_date / from_store_id / to_store_id / staff_id が必要です' })
+  }
+
+  const scenarioMasterId = await getOrgScenarioMasterId(scenario_id, user.orgId)
+  await assertStoreOwnedByOrg(from_store_id, user.orgId)
+  await assertStoreOwnedByOrg(to_store_id, user.orgId)
+  await assertStaffOwnedByOrg(staff_id, user.orgId)
+
+  // 既存レコードを検索
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existing, error: findErr } = await (db as any)
+    .from('kit_transfer_completions')
+    .select('id')
+    .eq('organization_id', user.orgId)
+    .eq('org_scenario_id', scenario_id)
+    .eq('kit_number', kit_number)
+    .eq('performance_date', performance_date)
+    .eq('to_store_id', to_store_id)
+    .maybeSingle()
+  if (findErr) {
+    return res.status(500).json({ error: '既存レコード検索に失敗', detail: findErr.message })
+  }
+
+  let data, error
+  if (existing) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = await (db as any)
+      .from('kit_transfer_completions')
+      .update({
+        from_store_id,
+        picked_up_at: new Date().toISOString(),
+        picked_up_by: staff_id,
+      })
+      .eq('id', existing.id)
+      .eq('organization_id', user.orgId)
+      .select(SELECT)
+      .single()
+    data = r.data
+    error = r.error
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = await (db as any)
+      .from('kit_transfer_completions')
+      .insert({
+        organization_id: user.orgId,
+        org_scenario_id: scenario_id,
+        scenario_master_id: scenarioMasterId,
+        kit_number,
+        performance_date,
+        from_store_id,
+        to_store_id,
+        picked_up_at: new Date().toISOString(),
+        picked_up_by: staff_id,
+      })
+      .select(SELECT)
+      .single()
+    data = r.data
+    error = r.error
+  }
+
+  if (error) {
+    console.error('[kit-transfer-completions] mark_picked_up error:', error)
+    return res.status(500).json({ error: '回収完了のマークに失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handleUnmarkPickedUp(
+  body: Record<string, unknown>,
+  res: VercelResponse,
+  user: AuthUser
+) {
+  const { scenario_id, kit_number, performance_date, to_store_id } = body as {
+    scenario_id?: string
+    kit_number?: number
+    performance_date?: string
+    to_store_id?: string
+  }
+
+  if (!scenario_id || !Number.isInteger(kit_number) || !performance_date || !to_store_id) {
+    return res.status(400).json({ error: 'scenario_id / kit_number / performance_date / to_store_id が必要です' })
+  }
+
+  await getOrgScenarioMasterId(scenario_id, user.orgId)
+  await assertStoreOwnedByOrg(to_store_id, user.orgId)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (db as any)
+    .from('kit_transfer_completions')
+    .update({
+      picked_up_at: null,
+      picked_up_by: null,
+      delivered_at: null,
+      delivered_by: null,
+    })
+    .eq('organization_id', user.orgId)
+    .eq('org_scenario_id', scenario_id)
+    .eq('kit_number', kit_number)
+    .eq('performance_date', performance_date)
+    .eq('to_store_id', to_store_id)
+
+  if (error) {
+    console.error('[kit-transfer-completions] unmark_picked_up error:', error)
+    return res.status(500).json({ error: '回収完了の解除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ ok: true })
+}
+
+async function handleMarkDelivered(
+  body: Record<string, unknown>,
+  res: VercelResponse,
+  user: AuthUser
+) {
+  const { scenario_id, kit_number, performance_date, to_store_id, staff_id } = body as {
+    scenario_id?: string
+    kit_number?: number
+    performance_date?: string
+    to_store_id?: string
+    staff_id?: string
+  }
+
+  if (!scenario_id || !Number.isInteger(kit_number) || !performance_date || !to_store_id || !staff_id) {
+    return res.status(400).json({ error: 'scenario_id / kit_number / performance_date / to_store_id / staff_id が必要です' })
+  }
+
+  await getOrgScenarioMasterId(scenario_id, user.orgId)
+  await assertStoreOwnedByOrg(to_store_id, user.orgId)
+  await assertStaffOwnedByOrg(staff_id, user.orgId)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('kit_transfer_completions')
+    .update({
+      delivered_at: new Date().toISOString(),
+      delivered_by: staff_id,
+    })
+    .eq('organization_id', user.orgId)
+    .eq('org_scenario_id', scenario_id)
+    .eq('kit_number', kit_number)
+    .eq('performance_date', performance_date)
+    .eq('to_store_id', to_store_id)
+    .select(SELECT)
+    .single()
+
+  if (error) {
+    console.error('[kit-transfer-completions] mark_delivered error:', error)
+    return res.status(500).json({ error: '設置完了のマークに失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+async function handleUnmarkDelivered(
+  body: Record<string, unknown>,
+  res: VercelResponse,
+  user: AuthUser
+) {
+  const { scenario_id, kit_number, performance_date, to_store_id } = body as {
+    scenario_id?: string
+    kit_number?: number
+    performance_date?: string
+    to_store_id?: string
+  }
+
+  if (!scenario_id || !Number.isInteger(kit_number) || !performance_date || !to_store_id) {
+    return res.status(400).json({ error: 'scenario_id / kit_number / performance_date / to_store_id が必要です' })
+  }
+
+  await getOrgScenarioMasterId(scenario_id, user.orgId)
+  await assertStoreOwnedByOrg(to_store_id, user.orgId)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (db as any)
+    .from('kit_transfer_completions')
+    .update({
+      delivered_at: null,
+      delivered_by: null,
+    })
+    .eq('organization_id', user.orgId)
+    .eq('org_scenario_id', scenario_id)
+    .eq('kit_number', kit_number)
+    .eq('performance_date', performance_date)
+    .eq('to_store_id', to_store_id)
+
+  if (error) {
+    console.error('[kit-transfer-completions] unmark_delivered error:', error)
+    return res.status(500).json({ error: '設置完了の解除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ ok: true })
+}
+
+// ─── DELETE: clearAllCompletions (期間内一括削除) ──────────────────────────
+async function handleDelete(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const startDate = (req.query.start_date ?? req.body?.start_date) as string | undefined
+  const endDate = (req.query.end_date ?? req.body?.end_date) as string | undefined
+
+  if (!startDate || !endDate) {
+    return res.status(400).json({ error: 'start_date / end_date が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('kit_transfer_completions')
+    .delete()
+    .eq('organization_id', user.orgId)
+    .gte('performance_date', startDate)
+    .lte('performance_date', endDate)
+    .select('id')
+
+  if (error) {
+    console.error('[kit-transfer-completions] delete error:', error)
+    return res.status(500).json({ error: '完了状態のクリアに失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ cleared: data?.length ?? 0 })
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+    requireStaff(user)
+
+    if (req.method === 'GET') return await handleGet(req, res, user)
+    if (req.method === 'POST') return await handlePost(req, res, user)
+    if (req.method === 'DELETE') return await handleDelete(req, res, user)
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[kit-transfer-completions] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}

--- a/api/kit-transfer-events.ts
+++ b/api/kit-transfer-events.ts
@@ -1,0 +1,257 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db, getMissingEnvError } from './_lib/db.js'
+import { requireAuth, requireStaff, ApiError, type AuthUser } from './_lib/auth.js'
+
+const ALLOWED_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://localhost:5174',
+].filter(Boolean) as string[]
+
+function setCors(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : (ALLOWED_ORIGINS[0] ?? '*')
+  res.setHeader('Access-Control-Allow-Origin', allowed)
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+}
+
+const SELECT = `
+  *,
+  org_scenario:organization_scenarios!kit_transfer_events_org_scenario_id_fkey(
+    id,
+    scenario_master_id,
+    scenario_masters(id, title)
+  ),
+  from_store:stores!kit_transfer_events_from_store_id_fkey(id, name, short_name),
+  to_store:stores!kit_transfer_events_to_store_id_fkey(id, name, short_name)
+`
+
+type TransferEventInput = {
+  org_scenario_id?: string
+  kit_number?: number
+  transfer_date?: string
+  from_store_id?: string | null
+  to_store_id?: string | null
+  status?: 'pending' | 'completed' | 'cancelled'
+  notes?: string | null
+}
+
+// ─── ヘルパ ─────────────────────────────────────────────────────────────────
+async function assertOrgScenarioOwnedByOrg(orgScenarioId: string, orgId: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('organization_scenarios')
+    .select('id')
+    .eq('id', orgScenarioId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (error) throw new ApiError(500, `org_scenario 所有検証に失敗: ${error.message}`)
+  if (!data) throw new ApiError(403, '指定の org_scenario_id は自組織のものではありません')
+}
+
+async function assertStoreOwnedByOrg(storeId: string, orgId: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('stores')
+    .select('id')
+    .eq('id', storeId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (error) throw new ApiError(500, `store 所有検証に失敗: ${error.message}`)
+  if (!data) throw new ApiError(403, '指定の store は自組織のものではありません')
+}
+
+async function validateTransferInput(input: TransferEventInput, orgId: string): Promise<void> {
+  if (!input.org_scenario_id || !Number.isInteger(input.kit_number) || !input.transfer_date) {
+    throw new ApiError(400, 'org_scenario_id / kit_number / transfer_date が必要です')
+  }
+  await assertOrgScenarioOwnedByOrg(input.org_scenario_id, orgId)
+  if (input.from_store_id) await assertStoreOwnedByOrg(input.from_store_id, orgId)
+  if (input.to_store_id) await assertStoreOwnedByOrg(input.to_store_id, orgId)
+}
+
+async function assertEventOwnedByOrg(eventId: string, orgId: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('kit_transfer_events')
+    .select('id, organization_id')
+    .eq('id', eventId)
+    .maybeSingle()
+  if (error) throw new ApiError(500, `イベント検証に失敗: ${error.message}`)
+  if (!data) throw new ApiError(404, 'イベントが見つかりません')
+  if (data.organization_id !== orgId) throw new ApiError(403, '他組織のイベントは操作できません')
+}
+
+// ─── GET: getTransferEvents ────────────────────────────────────────────────
+async function handleGet(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const startDate = req.query.start_date as string | undefined
+  const endDate = req.query.end_date as string | undefined
+
+  if (!startDate || !endDate) {
+    return res.status(400).json({ error: 'start_date / end_date が必要です' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('kit_transfer_events')
+    .select(SELECT)
+    .eq('organization_id', user.orgId)
+    .gte('transfer_date', startDate)
+    .lte('transfer_date', endDate)
+    .order('transfer_date')
+    .order('org_scenario_id')
+
+  if (error) {
+    console.error('[kit-transfer-events] GET error:', error)
+    return res.status(500).json({ error: '移動イベントの取得に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data ?? [])
+}
+
+// ─── POST: createTransferEvent / createTransferEvents / cancelPendingTransfers ─
+async function handlePost(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const action = (req.query.action ?? req.body?.action) as string | undefined
+  const body = req.body ?? {}
+
+  // cancelPendingTransfers 相当
+  if (action === 'cancel_pending') {
+    const { start_date, end_date } = body as { start_date?: string; end_date?: string }
+    if (!start_date || !end_date) {
+      return res.status(400).json({ error: 'start_date / end_date が必要です' })
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (db as any)
+      .from('kit_transfer_events')
+      .update({ status: 'cancelled' })
+      .eq('organization_id', user.orgId)
+      .eq('status', 'pending')
+      .gte('transfer_date', start_date)
+      .lte('transfer_date', end_date)
+      .select('id')
+    if (error) {
+      console.error('[kit-transfer-events] cancel_pending error:', error)
+      return res.status(500).json({ error: 'pendingのキャンセルに失敗しました', detail: error.message })
+    }
+    return res.status(200).json({ cancelled: data?.length ?? 0 })
+  }
+
+  // バルク作成（events: []）
+  if (Array.isArray(body.events)) {
+    const events = body.events as TransferEventInput[]
+    if (events.length === 0) return res.status(200).json([])
+
+    for (const ev of events) {
+      await validateTransferInput(ev, user.orgId)
+    }
+
+    const records = events.map(ev => ({
+      ...ev,
+      organization_id: user.orgId,
+      created_by: user.userId,
+    }))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (db as any)
+      .from('kit_transfer_events')
+      .insert(records)
+      .select(SELECT)
+    if (error) {
+      console.error('[kit-transfer-events] bulk insert error:', error)
+      return res.status(500).json({ error: '移動イベントの一括作成に失敗しました', detail: error.message })
+    }
+    return res.status(200).json(data ?? [])
+  }
+
+  // 単発作成
+  const input = body as TransferEventInput
+  await validateTransferInput(input, user.orgId)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('kit_transfer_events')
+    .insert({
+      ...input,
+      organization_id: user.orgId,
+      created_by: user.userId,
+    })
+    .select(SELECT)
+    .single()
+  if (error) {
+    console.error('[kit-transfer-events] insert error:', error)
+    return res.status(500).json({ error: '移動イベントの作成に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// ─── PATCH: updateTransferStatus ───────────────────────────────────────────
+async function handlePatch(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = (req.query.id ?? req.body?.id) as string | undefined
+  const status = req.body?.status as 'pending' | 'completed' | 'cancelled' | undefined
+
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+  if (!status || !['pending', 'completed', 'cancelled'].includes(status)) {
+    return res.status(400).json({ error: 'status (pending|completed|cancelled) が必要です' })
+  }
+
+  await assertEventOwnedByOrg(id, user.orgId)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (db as any)
+    .from('kit_transfer_events')
+    .update({ status })
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+    .select(SELECT)
+    .single()
+  if (error) {
+    console.error('[kit-transfer-events] patch error:', error)
+    return res.status(500).json({ error: 'ステータス更新に失敗しました', detail: error.message })
+  }
+  return res.status(200).json(data)
+}
+
+// ─── DELETE: deleteTransferEvent ───────────────────────────────────────────
+async function handleDelete(req: VercelRequest, res: VercelResponse, user: AuthUser) {
+  const id = (req.query.id ?? req.body?.id) as string | undefined
+  if (!id) return res.status(400).json({ error: 'id が必要です' })
+
+  await assertEventOwnedByOrg(id, user.orgId)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (db as any)
+    .from('kit_transfer_events')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', user.orgId)
+  if (error) {
+    console.error('[kit-transfer-events] delete error:', error)
+    return res.status(500).json({ error: '削除に失敗しました', detail: error.message })
+  }
+  return res.status(200).json({ ok: true })
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+
+  const envError = getMissingEnvError()
+  if (envError || !db) return res.status(500).json({ error: `環境変数が未設定です: ${envError}` })
+
+  try {
+    const user = await requireAuth(req)
+    requireStaff(user)
+
+    if (req.method === 'GET') return await handleGet(req, res, user)
+    if (req.method === 'POST') return await handlePost(req, res, user)
+    if (req.method === 'PATCH') return await handlePatch(req, res, user)
+    if (req.method === 'DELETE') return await handleDelete(req, res, user)
+
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err) {
+    if (err instanceof ApiError) return res.status(err.status).json({ error: err.message })
+    console.error('[kit-transfer-events] unexpected error:', err)
+    return res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  }
+}

--- a/src/lib/api/kitApi.ts
+++ b/src/lib/api/kitApi.ts
@@ -3,14 +3,10 @@
  *
  * シナリオキットの配置管理と移動イベントを操作するAPI
  *
- * - キット位置 (scenario_kit_locations) はバックエンド API (/api/kit-locations) 経由で
- *   org_id をサーバー側で強制フィルタする
- * - キット移動イベント・完了状態 (kit_transfer_events / kit_transfer_completions) は
- *   引き続き Supabase 経由（別タスクで API 化予定）
+ * すべてバックエンド API (/api/kit-locations, /api/kit-transfer-events,
+ * /api/kit-transfer-completions) 経由で org_id をサーバー側で強制フィルタする
  */
 
-import { supabase } from '../supabase'
-import { getCurrentOrganizationId } from '../organization'
 import { apiClient } from '@/lib/apiClient'
 import type { KitLocation, KitTransferEvent, KitCondition, KitTransferCompletion } from '@/types'
 
@@ -47,6 +43,28 @@ function transformKitLocation(item: KitLocationRaw): KitLocation {
     } as unknown as KitLocation
   }
   return { ...item, scenario: null } as unknown as KitLocation
+}
+
+/** transfer_events / transfer_completions の生レスポンス（scenario 整形用） */
+type TransferEventRaw = {
+  org_scenario?: {
+    id: string
+    scenario_master_id?: string
+    scenario_masters?: { id?: string; title?: string | null } | null
+  } | null
+  [key: string]: unknown
+}
+
+function transformTransferEvent(item: TransferEventRaw): KitTransferEvent {
+  return {
+    ...item,
+    scenario: item.org_scenario
+      ? {
+          id: item.org_scenario.id,
+          title: item.org_scenario.scenario_masters?.title || '',
+        }
+      : null,
+  } as unknown as KitTransferEvent
 }
 
 export const kitApi = {
@@ -125,8 +143,7 @@ export const kitApi = {
   },
 
   // ============================================
-  // キット移動イベント関連
-  // TODO: バックエンド API 化（kit_transfer_events 用エンドポイント）
+  // キット移動イベント関連（バックエンド API 経由）
   // ============================================
 
   /**
@@ -136,41 +153,10 @@ export const kitApi = {
     startDate: string,
     endDate: string
   ): Promise<KitTransferEvent[]> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) return []
-
-    const { data, error } = await supabase
-      .from('kit_transfer_events')
-      .select(`
-        *,
-        org_scenario:organization_scenarios!kit_transfer_events_org_scenario_id_fkey(
-          id,
-          scenario_master_id,
-          scenario_masters(id, title)
-        ),
-        from_store:stores!kit_transfer_events_from_store_id_fkey(id, name, short_name),
-        to_store:stores!kit_transfer_events_to_store_id_fkey(id, name, short_name)
-      `)
-      .eq('organization_id', orgId)
-      .gte('transfer_date', startDate)
-      .lte('transfer_date', endDate)
-      .order('transfer_date')
-      .order('org_scenario_id')
-
-    if (error) {
-      console.error('Failed to fetch transfer events:', error)
-      throw error
-    }
-
-    const transformed = (data || []).map(item => ({
-      ...item,
-      scenario: item.org_scenario ? {
-        id: item.org_scenario.id,
-        title: item.org_scenario.scenario_masters?.title || ''
-      } : null
-    }))
-
-    return transformed as KitTransferEvent[]
+    const data = await apiClient.get<TransferEventRaw[]>(
+      `/api/kit-transfer-events?start_date=${encodeURIComponent(startDate)}&end_date=${encodeURIComponent(endDate)}`
+    )
+    return (data || []).map(transformTransferEvent)
   },
 
   /**
@@ -180,44 +166,8 @@ export const kitApi = {
   async createTransferEvent(
     event: Omit<KitTransferEvent, 'id' | 'organization_id' | 'created_at' | 'updated_at' | 'scenario' | 'from_store' | 'to_store'>
   ): Promise<KitTransferEvent> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('Organization ID not found')
-
-    const { data: userData } = await supabase.auth.getUser()
-
-    const { data, error } = await supabase
-      .from('kit_transfer_events')
-      .insert({
-        ...event,
-        organization_id: orgId,
-        created_by: userData?.user?.id
-      })
-      .select(`
-        *,
-        org_scenario:organization_scenarios!kit_transfer_events_org_scenario_id_fkey(
-          id,
-          scenario_master_id,
-          scenario_masters(id, title)
-        ),
-        from_store:stores!kit_transfer_events_from_store_id_fkey(id, name, short_name),
-        to_store:stores!kit_transfer_events_to_store_id_fkey(id, name, short_name)
-      `)
-      .single()
-
-    if (error) {
-      console.error('Failed to create transfer event:', error)
-      throw error
-    }
-
-    const transformed = {
-      ...data,
-      scenario: data.org_scenario ? {
-        id: data.org_scenario.id,
-        title: data.org_scenario.scenario_masters?.title || ''
-      } : null
-    }
-
-    return transformed as KitTransferEvent
+    const data = await apiClient.post<TransferEventRaw>('/api/kit-transfer-events', event)
+    return transformTransferEvent(data)
   },
 
   /**
@@ -227,45 +177,8 @@ export const kitApi = {
   async createTransferEvents(
     events: Array<Omit<KitTransferEvent, 'id' | 'organization_id' | 'created_at' | 'updated_at' | 'scenario' | 'from_store' | 'to_store'>>
   ): Promise<KitTransferEvent[]> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('Organization ID not found')
-
-    const { data: userData } = await supabase.auth.getUser()
-
-    const records = events.map(event => ({
-      ...event,
-      organization_id: orgId,
-      created_by: userData?.user?.id
-    }))
-
-    const { data, error } = await supabase
-      .from('kit_transfer_events')
-      .insert(records)
-      .select(`
-        *,
-        org_scenario:organization_scenarios!kit_transfer_events_org_scenario_id_fkey(
-          id,
-          scenario_master_id,
-          scenario_masters(id, title)
-        ),
-        from_store:stores!kit_transfer_events_from_store_id_fkey(id, name, short_name),
-        to_store:stores!kit_transfer_events_to_store_id_fkey(id, name, short_name)
-      `)
-
-    if (error) {
-      console.error('Failed to create transfer events:', error)
-      throw error
-    }
-
-    const transformed = (data || []).map(item => ({
-      ...item,
-      scenario: item.org_scenario ? {
-        id: item.org_scenario.id,
-        title: item.org_scenario.scenario_masters?.title || ''
-      } : null
-    }))
-
-    return transformed as KitTransferEvent[]
+    const data = await apiClient.post<TransferEventRaw[]>('/api/kit-transfer-events', { events })
+    return (data || []).map(transformTransferEvent)
   },
 
   /**
@@ -275,51 +188,18 @@ export const kitApi = {
     eventId: string,
     status: 'pending' | 'completed' | 'cancelled'
   ): Promise<KitTransferEvent> {
-    const { data, error } = await supabase
-      .from('kit_transfer_events')
-      .update({ status })
-      .eq('id', eventId)
-      .select(`
-        *,
-        org_scenario:organization_scenarios!kit_transfer_events_org_scenario_id_fkey(
-          id,
-          scenario_master_id,
-          scenario_masters(id, title)
-        ),
-        from_store:stores!kit_transfer_events_from_store_id_fkey(id, name, short_name),
-        to_store:stores!kit_transfer_events_to_store_id_fkey(id, name, short_name)
-      `)
-      .single()
-
-    if (error) {
-      console.error('Failed to update transfer status:', error)
-      throw error
-    }
-
-    const transformed = {
-      ...data,
-      scenario: data.org_scenario ? {
-        id: data.org_scenario.id,
-        title: data.org_scenario.scenario_masters?.title || ''
-      } : null
-    }
-
-    return transformed as KitTransferEvent
+    const data = await apiClient.patch<TransferEventRaw>(
+      `/api/kit-transfer-events?id=${encodeURIComponent(eventId)}`,
+      { status }
+    )
+    return transformTransferEvent(data)
   },
 
   /**
    * 移動イベントを削除
    */
   async deleteTransferEvent(eventId: string): Promise<void> {
-    const { error } = await supabase
-      .from('kit_transfer_events')
-      .delete()
-      .eq('id', eventId)
-
-    if (error) {
-      console.error('Failed to delete transfer event:', error)
-      throw error
-    }
+    await apiClient.delete(`/api/kit-transfer-events?id=${encodeURIComponent(eventId)}`)
   },
 
   /**
@@ -329,29 +209,15 @@ export const kitApi = {
     startDate: string,
     endDate: string
   ): Promise<number> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) return 0
-
-    const { data, error } = await supabase
-      .from('kit_transfer_events')
-      .update({ status: 'cancelled' })
-      .eq('organization_id', orgId)
-      .eq('status', 'pending')
-      .gte('transfer_date', startDate)
-      .lte('transfer_date', endDate)
-      .select('id')
-
-    if (error) {
-      console.error('Failed to cancel pending transfers:', error)
-      throw error
-    }
-
-    return data?.length || 0
+    const result = await apiClient.post<{ cancelled: number }>(
+      '/api/kit-transfer-events?action=cancel_pending',
+      { start_date: startDate, end_date: endDate }
+    )
+    return result.cancelled ?? 0
   },
 
   // ============================================
-  // キット移動完了状態関連
-  // TODO: バックエンド API 化（kit_transfer_completions 用エンドポイント）
+  // キット移動完了状態関連（バックエンド API 経由）
   // ============================================
 
   /**
@@ -361,25 +227,9 @@ export const kitApi = {
     startDate: string,
     endDate: string
   ): Promise<KitTransferCompletion[]> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) return []
-
-    const { data, error } = await supabase
-      .from('kit_transfer_completions')
-      .select(`
-        *,
-        picked_up_by_staff:staff!kit_transfer_completions_picked_up_by_fkey(id, name),
-        delivered_by_staff:staff!kit_transfer_completions_delivered_by_fkey(id, name)
-      `)
-      .eq('organization_id', orgId)
-      .gte('performance_date', startDate)
-      .lte('performance_date', endDate)
-
-    if (error) {
-      console.error('Failed to fetch transfer completions:', error)
-      throw error
-    }
-
+    const data = await apiClient.get<KitTransferCompletion[]>(
+      `/api/kit-transfer-completions?start_date=${encodeURIComponent(startDate)}&end_date=${encodeURIComponent(endDate)}`
+    )
     return data || []
   },
 
@@ -395,82 +245,17 @@ export const kitApi = {
     toStoreId: string,
     staffId: string
   ): Promise<KitTransferCompletion> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('Organization ID not found')
-
-    // まず既存レコードを検索
-    const { data: existing } = await supabase
-      .from('kit_transfer_completions')
-      .select('id')
-      .eq('organization_id', orgId)
-      .eq('org_scenario_id', scenarioId)
-      .eq('kit_number', kitNumber)
-      .eq('performance_date', performanceDate)
-      .eq('to_store_id', toStoreId)
-      .maybeSingle()
-
-    let data, error
-
-    if (existing) {
-      // 既存レコードがあれば更新
-      const result = await supabase
-        .from('kit_transfer_completions')
-        .update({
-          from_store_id: fromStoreId,
-          picked_up_at: new Date().toISOString(),
-          picked_up_by: staffId
-        })
-        .eq('id', existing.id)
-        .select(`
-          *,
-          picked_up_by_staff:staff!kit_transfer_completions_picked_up_by_fkey(id, name),
-          delivered_by_staff:staff!kit_transfer_completions_delivered_by_fkey(id, name)
-        `)
-        .single()
-      data = result.data
-      error = result.error
-    } else {
-      // org_scenario_id から scenario_master_id を取得
-      let scenarioMasterId: string | null = null
-      const { data: orgScenario } = await supabase
-        .from('organization_scenarios')
-        .select('scenario_master_id')
-        .eq('id', scenarioId)
-        .maybeSingle()
-      if (orgScenario) {
-        scenarioMasterId = orgScenario.scenario_master_id
+    return apiClient.post<KitTransferCompletion>(
+      '/api/kit-transfer-completions?action=mark_picked_up',
+      {
+        scenario_id: scenarioId,
+        kit_number: kitNumber,
+        performance_date: performanceDate,
+        from_store_id: fromStoreId,
+        to_store_id: toStoreId,
+        staff_id: staffId,
       }
-
-      // 新規レコードを挿入
-      const result = await supabase
-        .from('kit_transfer_completions')
-        .insert({
-          organization_id: orgId,
-          org_scenario_id: scenarioId,
-          scenario_master_id: scenarioMasterId,
-          kit_number: kitNumber,
-          performance_date: performanceDate,
-          from_store_id: fromStoreId,
-          to_store_id: toStoreId,
-          picked_up_at: new Date().toISOString(),
-          picked_up_by: staffId
-        })
-        .select(`
-          *,
-          picked_up_by_staff:staff!kit_transfer_completions_picked_up_by_fkey(id, name),
-          delivered_by_staff:staff!kit_transfer_completions_delivered_by_fkey(id, name)
-        `)
-        .single()
-      data = result.data
-      error = result.error
-    }
-
-    if (error) {
-      console.error('Failed to mark picked up:', error)
-      throw error
-    }
-
-    return data
+    )
   },
 
   /**
@@ -483,27 +268,12 @@ export const kitApi = {
     performanceDate: string,
     toStoreId: string
   ): Promise<void> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('Organization ID not found')
-
-    const { error } = await supabase
-      .from('kit_transfer_completions')
-      .update({
-        picked_up_at: null,
-        picked_up_by: null,
-        delivered_at: null,
-        delivered_by: null
-      })
-      .eq('organization_id', orgId)
-      .eq('org_scenario_id', scenarioId)
-      .eq('kit_number', kitNumber)
-      .eq('performance_date', performanceDate)
-      .eq('to_store_id', toStoreId)
-
-    if (error) {
-      console.error('Failed to unmark picked up:', error)
-      throw error
-    }
+    await apiClient.post('/api/kit-transfer-completions?action=unmark_picked_up', {
+      scenario_id: scenarioId,
+      kit_number: kitNumber,
+      performance_date: performanceDate,
+      to_store_id: toStoreId,
+    })
   },
 
   /**
@@ -518,34 +288,18 @@ export const kitApi = {
     toStoreId: string,
     staffId: string
   ): Promise<KitTransferCompletion> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('Organization ID not found')
+    const data = await apiClient.post<KitTransferCompletion>(
+      '/api/kit-transfer-completions?action=mark_delivered',
+      {
+        scenario_id: scenarioId,
+        kit_number: kitNumber,
+        performance_date: performanceDate,
+        to_store_id: toStoreId,
+        staff_id: staffId,
+      }
+    )
 
-    // 1. 完了状態を更新
-    const { data, error } = await supabase
-      .from('kit_transfer_completions')
-      .update({
-        delivered_at: new Date().toISOString(),
-        delivered_by: staffId
-      })
-      .eq('organization_id', orgId)
-      .eq('org_scenario_id', scenarioId)
-      .eq('kit_number', kitNumber)
-      .eq('performance_date', performanceDate)
-      .eq('to_store_id', toStoreId)
-      .select(`
-        *,
-        picked_up_by_staff:staff!kit_transfer_completions_picked_up_by_fkey(id, name),
-        delivered_by_staff:staff!kit_transfer_completions_delivered_by_fkey(id, name)
-      `)
-      .single()
-
-    if (error) {
-      console.error('Failed to mark delivered:', error)
-      throw error
-    }
-
-    // 2. キットの所在地を移動先店舗に更新（バックエンド API 経由）
+    // キットの所在地を移動先店舗に更新（バックエンド API 経由）
     try {
       await apiClient.post('/api/kit-locations', {
         scenario_id: scenarioId,
@@ -570,25 +324,12 @@ export const kitApi = {
     performanceDate: string,
     toStoreId: string
   ): Promise<void> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) throw new Error('Organization ID not found')
-
-    const { error } = await supabase
-      .from('kit_transfer_completions')
-      .update({
-        delivered_at: null,
-        delivered_by: null
-      })
-      .eq('organization_id', orgId)
-      .eq('org_scenario_id', scenarioId)
-      .eq('kit_number', kitNumber)
-      .eq('performance_date', performanceDate)
-      .eq('to_store_id', toStoreId)
-
-    if (error) {
-      console.error('Failed to unmark delivered:', error)
-      throw error
-    }
+    await apiClient.post('/api/kit-transfer-completions?action=unmark_delivered', {
+      scenario_id: scenarioId,
+      kit_number: kitNumber,
+      performance_date: performanceDate,
+      to_store_id: toStoreId,
+    })
   },
 
   /**
@@ -598,22 +339,9 @@ export const kitApi = {
     startDate: string,
     endDate: string
   ): Promise<number> {
-    const orgId = await getCurrentOrganizationId()
-    if (!orgId) return 0
-
-    const { data, error } = await supabase
-      .from('kit_transfer_completions')
-      .delete()
-      .eq('organization_id', orgId)
-      .gte('performance_date', startDate)
-      .lte('performance_date', endDate)
-      .select('id')
-
-    if (error) {
-      console.error('Failed to clear completions:', error)
-      throw error
-    }
-
-    return data?.length || 0
+    const result = await apiClient.delete<{ cleared: number }>(
+      `/api/kit-transfer-completions?start_date=${encodeURIComponent(startDate)}&end_date=${encodeURIComponent(endDate)}`
+    )
+    return result.cleared ?? 0
   }
 }


### PR DESCRIPTION
## Summary

- 残っていた `src/lib/api/kitApi.ts` の Supabase 直アクセス 12 メソッドをすべてバックエンド API 経由に切り替え
- 新規追加: `/api/kit-transfer-events`（イベント CRUD + 期間 pending 一括キャンセル）
- 新規追加: `/api/kit-transfer-completions`（pick/deliver の mark/unmark + 期間 clear_all）
- いずれも `org_scenario_id` / `store_id` / `staff_id` を毎回自組織所有か検証してから書き込むため、他組織のキット動線データに到達できない

## Org スコープ ロードマップ進捗
- ✅ scheduleApi (#166, #167, #168)
- ✅ sales/scenarios の `_staff_view` → 実テーブル (#170)
- ✅ CI guard (#171)
- ✅ 23505 → 409 (#172)
- ✅ **kitApi 残 8 箇所** ← 本 PR
- ⬜ scenarioMasterApi / scenarioApi / storeApi の数箇所
- ⬜ RLS ポリシー監査スクリプト

## Test plan
- [ ] ステージングで KitManagementDialog を開き、移動イベントの作成・ステータス変更・削除・一括 pending キャンセルが動くこと
- [ ] markPickedUp / markDelivered / unmark 系が動き、所在地が更新されること
- [ ] clearAllCompletions（週単位リセット）が動くこと
- [ ] 他組織の `org_scenario_id` を投げ込んだリクエストが 403 で弾かれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)