### PR TITLE
fix(db): initialize_organization_data() の opening_date 型不一致を修正

### DIFF
--- a/supabase/migrations/20260518000000_fix_initialize_organization_opening_date.sql
+++ b/supabase/migrations/20260518000000_fix_initialize_organization_opening_date.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- initialize_organization_data() の opening_date 型不一致を修正
+-- =============================================================================
+-- 背景:
+--   organizations への INSERT 時に発火するトリガー initialize_organization_data() が
+--   臨時会場1-5 を stores に挿入する際、opening_date (DATE 型) に
+--   `CURRENT_DATE::text` を渡していたため、42804 (datatype_mismatch) で失敗する。
+--
+--   org セルフ登録 RPC (#register_organization_for_signup) が組織を INSERT する
+--   段階でこのトリガーが呼ばれ、新規組織登録フローが 400 エラーで完全に止まる。
+--
+-- 修正:
+--   `CURRENT_DATE::text` → `CURRENT_DATE` （DATE のまま渡す）
+--
+-- 影響範囲:
+--   関数の他のロジック（organization_settings / global_settings の初期化、
+--   SECURITY DEFINER + SET search_path = public）はそのまま維持。
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.initialize_organization_data()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.organization_settings (organization_id)
+  VALUES (NEW.id)
+  ON CONFLICT (organization_id) DO NOTHING;
+
+  INSERT INTO public.global_settings (organization_id)
+  VALUES (NEW.id)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.stores (name, short_name, status, capacity, rooms, color, is_temporary, temporary_dates, organization_id, address, phone_number, email, opening_date, manager_name)
+  VALUES
+    ('臨時会場1', '臨時1', 'active', 8, 1, '#9E9E9E', true, '[]', NEW.id, '', '', '', CURRENT_DATE, ''),
+    ('臨時会場2', '臨時2', 'active', 8, 1, '#9E9E9E', true, '[]', NEW.id, '', '', '', CURRENT_DATE, ''),
+    ('臨時会場3', '臨時3', 'active', 8, 1, '#9E9E9E', true, '[]', NEW.id, '', '', '', CURRENT_DATE, ''),
+    ('臨時会場4', '臨時4', 'active', 8, 1, '#9E9E9E', true, '[]', NEW.id, '', '', '', CURRENT_DATE, ''),
+    ('臨時会場5', '臨時5', 'active', 8, 1, '#9E9E9E', true, '[]', NEW.id, '', '', '', CURRENT_DATE, '')
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ initialize_organization_data() の opening_date 型不一致を修正しました';
+END $$;


### PR DESCRIPTION
## Summary

新規組織自己登録（\`register_organization_for_signup\` RPC）が 42804 \`column \"opening_date\" is of type date but expression is of type text\` で全件失敗していたバグを修正。

\`organizations\` テーブル INSERT で発火する \`initialize_organization_data()\` トリガーが \`stores.opening_date\` (DATE 型) に \`CURRENT_DATE::text\` を渡しており、PostgreSQL が暗黙キャストを拒否して失敗していた。\`CURRENT_DATE::text\` → \`CURRENT_DATE\` に修正。

旧定義は [20260210000003](supabase/migrations/20260210000003_auto_initialize_organization.sql) と [20260210000005](supabase/migrations/20260210000005_security_p0de_and_p1_fixes.sql) の双方に同じバグが存在していたが、本マイグレーションが CREATE OR REPLACE で上書きする。

## Test plan

- [x] staging DB に \`npm run db:push:staging\` で適用済み
- [ ] staging で \`/start\` 組織登録 RPC が 42804 を出さないこと（別 slug で確認）
- [ ] 本番 DB に適用前にユーザー判断（CLAUDE.md ルール）

## 関連バグ（別 PR / セッション）

OrgSignup フローには他にも判明したバグあり（signUp 後 CompleteProfile 誤遷移、orphan 残り問題等）。memory の \`project_org_signup_bugs.md\` に記録済みで本 PR スコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)