### PR TITLE
fix(db): OrgSignup (/start) フロー復旧 — トリガー再作成 + staff.user_id UNIQUE

### DIFF
--- a/supabase/migrations/20260518100000_restore_user_creation_trigger_and_staff_unique.sql
+++ b/supabase/migrations/20260518100000_restore_user_creation_trigger_and_staff_unique.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- OrgSignup (/start) フロー復旧: handle_new_user トリガー再作成 + staff.user_id UNIQUE
+-- =============================================================================
+-- 背景:
+--   2026-05-18 セッションで /start からの組織自己登録が CompleteProfile に詰む
+--   バグが判明。原因は 2 段重ね:
+--
+--   ① staging DB では `on_auth_user_created` トリガーが何らかの理由で消失しており、
+--      auth.users INSERT 時に public.users / public.staff が一切作られない。
+--      （関数 handle_new_user は存在するが、トリガー登録のみ消えている状態）
+--      本番では現時点でトリガー登録は生きているが、誰も /start を試していないだけ。
+--
+--   ② handle_new_user 内の staff INSERT が `ON CONFLICT (user_id) DO NOTHING` を
+--      使っているが、staff テーブルに user_id の UNIQUE 制約が無く
+--      "no unique or exclusion constraint matching the ON CONFLICT specification"
+--      で必ず失敗する。トリガーの EXCEPTION WHEN OTHERS に飲まれ silent fail し、
+--      public.users INSERT までロールバックされる。
+--
+-- 修正内容:
+--   1. staff.user_id に UNIQUE インデックスを追加（NULL 多重登録は許容）
+--   2. on_auth_user_created トリガーを再作成（既に存在していても安全）
+--
+-- 既存データへの影響:
+--   - staging / 本番ともに staff.user_id の非 NULL 重複は 0 件確認済み（適用可能）
+--   - NULL user_id の staff 行（unregistered staff）は UNIQUE 配下でも複数可
+-- =============================================================================
+
+-- 1. staff.user_id に UNIQUE インデックスを追加
+--    ON CONFLICT (user_id) のターゲットとして機能させるため。
+--    UNIQUE INDEX は ON CONFLICT 推論で UNIQUE CONSTRAINT と同じく利用可能。
+CREATE UNIQUE INDEX IF NOT EXISTS staff_user_id_unique
+  ON public.staff(user_id);
+
+-- 2. on_auth_user_created トリガーを再作成（idempotent）
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_user();
+
+-- 完了通知
+DO $$
+BEGIN
+  RAISE NOTICE '✅ staff.user_id に UNIQUE INDEX を作成しました';
+  RAISE NOTICE '✅ on_auth_user_created トリガーを再作成しました';
+  RAISE NOTICE '   - /start 組織自己登録フローでの users / staff 自動作成が復旧';
+END $$;


### PR DESCRIPTION
## 背景

2026-05-18 セッションで `/start` からの組織自己登録が CompleteProfile に詰むバグが判明（[[project-org-signup-bugs]] バグ 2）。

## 根本原因（2 段重ね）

### ① staging DB から `on_auth_user_created` トリガーが消失

`handle_new_user` 関数は存在するが、auth.users への AFTER INSERT トリガー登録のみ消えていた。経緯は不明（過去のマイグレーションは適用済みだが、何らかの操作で消えた可能性）。

→ signUp しても public.users / public.staff が作られない → CompleteProfile の role 判定で「admin/staff でない」 → customer フォームへフォールバック → 結果 `org_id が特定できません` で詰む。

本番ではトリガー登録は生きているが、誰も /start を試していないため未発覚。

### ② `handle_new_user` 内の `ON CONFLICT (user_id) DO NOTHING` が失敗する

`staff.user_id` に UNIQUE 制約が無いため `there is no unique or exclusion constraint matching the ON CONFLICT specification` で必ず失敗。`EXCEPTION WHEN OTHERS` に飲まれ、public.users INSERT までロールバックされ silent fail。

本番のトリガーコードにも同じバグが存在するが、`/start` 試行者が居ないため顕在化していない。

## 修正

idempotent な 1 本の migration:

1. `staff.user_id` に UNIQUE インデックスを追加（`IF NOT EXISTS`、NULL 多重は許容）
2. `on_auth_user_created` トリガーを `DROP IF EXISTS → CREATE` で再作成

## 検証

staging DB のトランザクション内で本番フロー相当の `auth.users` INSERT を実行し、修正適用後に `public.users.role = 'admin'`, `public.staff.organization_id` が正しく作成されることを確認済み（ROLLBACK 済み、staging に痕跡なし）。

staff.user_id 非 NULL 重複は staging / 本番ともに 0 件確認済み。

## Test plan

- [ ] staging に migration 適用（`npm run db:push:staging`）
- [ ] staging DB で `SELECT tgname FROM pg_trigger WHERE tgname = 'on_auth_user_created';` が 1 行返ること
- [ ] staging で `/start` から新規組織登録 → 確認メール → `/{slug}/dashboard` に遷移できること
- [ ] 本番にも適用（ユーザー判断、`npm run db:push:prod`）

## 関連

- [[project-org-signup-bugs]] バグ 2 の修正
- バグ 3（同一ユーザーが 2 つ目の組織作成 → orphan）は別 PR で対応予定