### PR TITLE
feat(org-signup): admin 必須項目 + 代表店舗ステップ（PR #177 取りこぼし補完）

### DIFF
--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -35,6 +35,16 @@ import { resendSignupConfirmationEmail } from '@/lib/authResendSignup'
 
 type Step = 'organization' | 'admin' | 'confirm' | 'complete'
 
+const PREFECTURES = [
+  '北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県',
+  '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県',
+  '新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県', '岐阜県',
+  '静岡県', '愛知県', '三重県', '滋賀県', '京都府', '大阪府', '兵庫県',
+  '奈良県', '和歌山県', '鳥取県', '島根県', '岡山県', '広島県', '山口県',
+  '徳島県', '香川県', '愛媛県', '高知県', '福岡県', '佐賀県', '長崎県',
+  '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県',
+]
+
 const STEPS_NEW: { id: Exclude<Step, 'complete'>; label: string }[] = [
   { id: 'organization', label: '組織情報' },
   { id: 'admin', label: '管理者アカウント' },
@@ -93,6 +103,9 @@ export default function OrgSignup() {
     email: '',
     password: '',
     confirmPassword: '',
+    phone: '',
+    prefecture: '',
+    birthDate: '',
   })
 
   const [agreedToTerms, setAgreedToTerms] = useState(false)
@@ -156,6 +169,21 @@ export default function OrgSignup() {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(adminData.email)) { setError('有効なメールアドレスを入力してください'); return false }
     if (adminData.password.length < 8) { setError('パスワードは8文字以上で入力してください'); return false }
     if (adminData.password !== adminData.confirmPassword) { setError('パスワードが一致しません'); return false }
+
+    const phoneDigits = adminData.phone.replace(/[-\s]/g, '')
+    if (!phoneDigits) { setError('電話番号を入力してください'); return false }
+    if (!/^\d{10,11}$/.test(phoneDigits)) { setError('電話番号は10〜11桁で入力してください'); return false }
+    if (!adminData.prefecture) { setError('お住まいの都道府県を選択してください'); return false }
+    if (!adminData.birthDate) { setError('生年月日を入力してください'); return false }
+    const birthDateMatch = adminData.birthDate.match(/^(\d{4})\/(\d{2})\/(\d{2})$/)
+    if (!birthDateMatch) { setError('生年月日は YYYY/MM/DD 形式で入力してください'); return false }
+    const [, y, m, d] = birthDateMatch
+    const dt = new Date(parseInt(y), parseInt(m) - 1, parseInt(d))
+    if (dt.getFullYear() !== parseInt(y) || dt.getMonth() !== parseInt(m) - 1 || dt.getDate() !== parseInt(d)) {
+      setError('有効な日付を入力してください'); return false
+    }
+    if (dt >= new Date()) { setError('生年月日に未来の日付は設定できません'); return false }
+
     setError(null)
     return true
   }
@@ -251,15 +279,22 @@ export default function OrgSignup() {
         setTimeout(() => navigate(`/${newOrg.slug}/dashboard`), 1500)
       } else {
         // ── 新規アカウントパス: signUp に user_metadata を渡す ──
-        //    handle_new_user トリガーが users + staff レコードを自動作成する
+        //    handle_new_user トリガーが users + staff + customers レコードを自動作成する
+        const birthMatch = adminData.birthDate.match(/^(\d{4})\/(\d{2})\/(\d{2})$/)
+        const adminBirthDateIso = birthMatch
+          ? `${birthMatch[1]}-${birthMatch[2]}-${birthMatch[3]}`
+          : null
         const { error: authError } = await supabase.auth.signUp({
           email: adminData.email.trim(),
           password: adminData.password,
           options: {
             data: {
-              organization_id: newOrg.id,
-              invited_as:      'admin',
-              admin_name:      adminData.name.trim(),
+              organization_id:   newOrg.id,
+              invited_as:        'admin',
+              admin_name:        adminData.name.trim(),
+              admin_phone:       adminData.phone.trim(),
+              admin_prefecture:  adminData.prefecture,
+              admin_birth_date:  adminBirthDateIso,
             },
           },
         })
@@ -596,6 +631,67 @@ export default function OrgSignup() {
                 </div>
               )}
 
+              {/* ── 電話番号 ── */}
+              <div className="space-y-1.5">
+                <Label htmlFor="admin-phone" className="text-sm font-medium">
+                  電話番号 <span className="text-red-500">*</span>
+                  <span className="text-xs text-gray-500 ml-2">（当日連絡用）</span>
+                </Label>
+                <Input
+                  id="admin-phone"
+                  type="tel"
+                  value={adminData.phone}
+                  onChange={e => setAdminData(prev => ({ ...prev, phone: e.target.value }))}
+                  placeholder="例: 090-1234-5678"
+                  autoComplete="tel"
+                />
+              </div>
+
+              {/* ── 都道府県 ── */}
+              <div className="space-y-1.5">
+                <Label htmlFor="admin-prefecture" className="text-sm font-medium">
+                  お住まいの都道府県 <span className="text-red-500">*</span>
+                </Label>
+                <select
+                  id="admin-prefecture"
+                  value={adminData.prefecture}
+                  onChange={e => setAdminData(prev => ({ ...prev, prefecture: e.target.value }))}
+                  className="w-full h-10 px-3 border border-gray-300 rounded-md bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-[#E60012] focus:border-transparent"
+                >
+                  <option value="">選択してください</option>
+                  {PREFECTURES.map((pref) => (
+                    <option key={pref} value={pref}>{pref}</option>
+                  ))}
+                </select>
+              </div>
+
+              {/* ── 生年月日 ── */}
+              <div className="space-y-1.5">
+                <Label htmlFor="admin-birth-date" className="text-sm font-medium">
+                  生年月日 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="admin-birth-date"
+                  type="text"
+                  inputMode="numeric"
+                  value={adminData.birthDate}
+                  onChange={e => {
+                    let value = e.target.value.replace(/[^\d/]/g, '')
+                    const digits = value.replace(/\//g, '')
+                    if (digits.length <= 4) {
+                      value = digits
+                    } else if (digits.length <= 6) {
+                      value = `${digits.slice(0, 4)}/${digits.slice(4)}`
+                    } else {
+                      value = `${digits.slice(0, 4)}/${digits.slice(4, 6)}/${digits.slice(6, 8)}`
+                    }
+                    setAdminData(prev => ({ ...prev, birthDate: value }))
+                  }}
+                  placeholder="1990/01/15"
+                  maxLength={10}
+                />
+              </div>
+
               <div className="space-y-1.5">
                 <Label htmlFor="admin-password" className="text-sm font-medium">パスワード <span className="text-red-500">*</span></Label>
                 <div className="relative">
@@ -679,6 +775,18 @@ export default function OrgSignup() {
                     <div className="flex justify-between">
                       <span className="text-gray-500">メール</span>
                       <span className="text-gray-900">{adminData.email}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">電話番号</span>
+                      <span className="text-gray-900">{adminData.phone}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">都道府県</span>
+                      <span className="text-gray-900">{adminData.prefecture}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">生年月日</span>
+                      <span className="text-gray-900">{adminData.birthDate}</span>
                     </div>
                   </div>
                 </div>

--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -33,7 +33,7 @@ import { supabase } from '@/lib/supabase'
 import { toast } from 'sonner'
 import { resendSignupConfirmationEmail } from '@/lib/authResendSignup'
 
-type Step = 'organization' | 'admin' | 'confirm' | 'complete'
+type Step = 'organization' | 'admin' | 'store' | 'confirm' | 'complete'
 
 const PREFECTURES = [
   '北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県',
@@ -48,11 +48,13 @@ const PREFECTURES = [
 const STEPS_NEW: { id: Exclude<Step, 'complete'>; label: string }[] = [
   { id: 'organization', label: '組織情報' },
   { id: 'admin', label: '管理者アカウント' },
+  { id: 'store', label: '代表店舗' },
   { id: 'confirm', label: '確認' },
 ]
 
 const STEPS_EXISTING: { id: Exclude<Step, 'complete'>; label: string }[] = [
   { id: 'organization', label: '組織情報' },
+  { id: 'store', label: '代表店舗' },
   { id: 'confirm', label: '確認' },
 ]
 
@@ -107,6 +109,14 @@ export default function OrgSignup() {
     prefecture: '',
     birthDate: '',
   })
+
+  const [storeData, setStoreData] = useState({
+    name: '',
+    address: '',
+    phone: '',
+  })
+  // 店舗名が未入力なら組織名をデフォルトとして自動で同期
+  const [storeNameTouched, setStoreNameTouched] = useState(false)
 
   const [agreedToTerms, setAgreedToTerms] = useState(false)
 
@@ -163,6 +173,16 @@ export default function OrgSignup() {
     return true
   }
 
+  const validateStore = (): boolean => {
+    if (!storeData.name.trim()) { setError('店舗名を入力してください'); return false }
+    if (!storeData.address.trim()) { setError('住所を入力してください'); return false }
+    const phoneDigits = storeData.phone.replace(/[-\s]/g, '')
+    if (!phoneDigits) { setError('店舗の電話番号を入力してください'); return false }
+    if (!/^\d{9,11}$/.test(phoneDigits)) { setError('電話番号は9〜11桁で入力してください'); return false }
+    setError(null)
+    return true
+  }
+
   const validateAdmin = (): boolean => {
     if (!adminData.name.trim()) { setError('管理者名を入力してください'); return false }
     if (!adminData.email.trim()) { setError('メールアドレスを入力してください'); return false }
@@ -190,12 +210,20 @@ export default function OrgSignup() {
 
   const handleNext = async () => {
     if (currentStep === 'organization' && validateOrganization()) {
-      // ログイン済みの場合は admin ステップをスキップ
-      setCurrentStep(isLoggedIn ? 'confirm' : 'admin')
+      // 店舗名のデフォルトを組織名で初期化
+      if (!storeNameTouched && !storeData.name) {
+        setStoreData(prev => ({ ...prev, name: orgData.name }))
+      }
+      // ログイン済みの場合は admin ステップをスキップして store へ
+      setCurrentStep(isLoggedIn ? 'store' : 'admin')
+      return
+    }
+    if (currentStep === 'store' && validateStore()) {
+      setCurrentStep('confirm')
       return
     }
     if (currentStep === 'admin' && validateAdmin()) {
-      // ② 既存メアドチェック：既に MMQ アカウントがあれば確認ステップに進ませない
+      // ② 既存メアドチェック：既に MMQ アカウントがあれば店舗ステップに進ませない
       setIsCheckingEmail(true)
       try {
         const { data: status, error: checkErr } = await supabase.rpc(
@@ -205,7 +233,7 @@ export default function OrgSignup() {
         if (checkErr) {
           // チェック失敗時は安全側ではなく続行（既存ユーザーは signUp 側で弾かれる）
           logger.warn('check_email_registration_status エラー（続行）:', checkErr)
-          setCurrentStep('confirm')
+          setCurrentStep('store')
           return
         }
         if (status === 'confirmed') {
@@ -216,7 +244,7 @@ export default function OrgSignup() {
           setEmailCheckStatus('pending_confirmation')
           return
         }
-        setCurrentStep('confirm')
+        setCurrentStep('store')
       } finally {
         setIsCheckingEmail(false)
       }
@@ -226,7 +254,8 @@ export default function OrgSignup() {
   const handleBack = () => {
     setError(null)
     if (currentStep === 'admin') setCurrentStep('organization')
-    else if (currentStep === 'confirm') setCurrentStep(isLoggedIn ? 'organization' : 'admin')
+    else if (currentStep === 'store') setCurrentStep(isLoggedIn ? 'organization' : 'admin')
+    else if (currentStep === 'confirm') setCurrentStep('store')
   }
 
   // 組織をロールバック（RPC経由で作成した場合）
@@ -248,13 +277,16 @@ export default function OrgSignup() {
     let createdOrgId: string | null = null
 
     try {
-      // 1. SECURITY DEFINER RPC で組織を作成（anon 可、RLSをバイパス）
+      // 1. SECURITY DEFINER RPC で組織+代表店舗を作成（anon 可、RLSをバイパス）
       const { data: newOrg, error: orgError } = await supabase.rpc(
         'register_organization_for_signup',
         {
           p_name:          orgData.name.trim(),
           p_slug:          orgData.slug.trim(),
           p_contact_email: orgData.contact_email.trim() || (isLoggedIn ? user?.email ?? '' : adminData.email.trim()),
+          p_store_name:    storeData.name.trim(),
+          p_store_address: storeData.address.trim(),
+          p_store_phone:   storeData.phone.trim(),
         }
       )
 
@@ -742,6 +774,71 @@ export default function OrgSignup() {
             </div>
           )}
 
+          {/* ── ステップ：代表店舗 ── */}
+          {currentStep === 'store' && (
+            <div className="space-y-4">
+              <p className="text-xs text-gray-500 -mt-2">
+                代表となる店舗を 1 件登録してください。後で追加・編集できます。
+              </p>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="store-name" className="text-sm font-medium">
+                  店舗名 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="store-name"
+                  value={storeData.name}
+                  onChange={e => {
+                    setStoreNameTouched(true)
+                    setStoreData(prev => ({ ...prev, name: e.target.value }))
+                  }}
+                  placeholder={`例: ${orgData.name || '〇〇店'}`}
+                />
+                <p className="text-xs text-gray-400">
+                  デフォルトは組織名です。実店舗の名前があれば変更してください。
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="store-address" className="text-sm font-medium">
+                  住所 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="store-address"
+                  value={storeData.address}
+                  onChange={e => setStoreData(prev => ({ ...prev, address: e.target.value }))}
+                  placeholder="例: 東京都渋谷区道玄坂 1-2-3 〇〇ビル 5F"
+                  autoComplete="street-address"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="store-phone" className="text-sm font-medium">
+                  電話番号 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="store-phone"
+                  type="tel"
+                  value={storeData.phone}
+                  onChange={e => setStoreData(prev => ({ ...prev, phone: e.target.value }))}
+                  placeholder="例: 03-1234-5678"
+                  autoComplete="tel"
+                />
+              </div>
+
+              <div className="flex gap-2">
+                <Button variant="outline" className="flex-1" onClick={handleBack}>
+                  <ArrowLeft className="w-4 h-4 mr-2" />
+                  戻る
+                </Button>
+                <Button className="flex-1" onClick={handleNext}>
+                  次へ：確認
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Button>
+              </div>
+            </div>
+          )}
+
           {/* ── ステップ3：確認 ── */}
           {currentStep === 'confirm' && (
             <div className="space-y-4">
@@ -765,28 +862,47 @@ export default function OrgSignup() {
                     )}
                   </div>
                 </div>
+                {!isLoggedIn && (
+                  <div className="border-t border-gray-200 pt-3">
+                    <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">管理者アカウント</p>
+                    <div className="space-y-1.5">
+                      <div className="flex justify-between">
+                        <span className="text-gray-500">名前</span>
+                        <span className="font-medium text-gray-900">{adminData.name}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-500">メール</span>
+                        <span className="text-gray-900">{adminData.email}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-500">電話番号</span>
+                        <span className="text-gray-900">{adminData.phone}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-500">都道府県</span>
+                        <span className="text-gray-900">{adminData.prefecture}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-500">生年月日</span>
+                        <span className="text-gray-900">{adminData.birthDate}</span>
+                      </div>
+                    </div>
+                  </div>
+                )}
                 <div className="border-t border-gray-200 pt-3">
-                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">管理者アカウント</p>
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">代表店舗</p>
                   <div className="space-y-1.5">
                     <div className="flex justify-between">
-                      <span className="text-gray-500">名前</span>
-                      <span className="font-medium text-gray-900">{adminData.name}</span>
+                      <span className="text-gray-500">店舗名</span>
+                      <span className="font-medium text-gray-900">{storeData.name}</span>
                     </div>
                     <div className="flex justify-between">
-                      <span className="text-gray-500">メール</span>
-                      <span className="text-gray-900">{adminData.email}</span>
+                      <span className="text-gray-500">住所</span>
+                      <span className="text-gray-900 text-right max-w-[60%]">{storeData.address}</span>
                     </div>
                     <div className="flex justify-between">
                       <span className="text-gray-500">電話番号</span>
-                      <span className="text-gray-900">{adminData.phone}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">都道府県</span>
-                      <span className="text-gray-900">{adminData.prefecture}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">生年月日</span>
-                      <span className="text-gray-900">{adminData.birthDate}</span>
+                      <span className="text-gray-900">{storeData.phone}</span>
                     </div>
                   </div>
                 </div>

--- a/supabase/migrations/20260518110000_extend_handle_new_user_for_admin_profile.sql
+++ b/supabase/migrations/20260518110000_extend_handle_new_user_for_admin_profile.sql
@@ -1,0 +1,121 @@
+-- =============================================================================
+-- handle_new_user トリガー拡張: admin 登録時に phone / prefecture / birth_date も保存
+-- =============================================================================
+-- 背景:
+--   OrgSignup (/start) は signUp 後に email 確認するまでフロントから authenticated
+--   ユーザーとして INSERT できないため、admin の連絡先情報（電話・都道府県・生年月日）
+--   をどこにも記録できなかった。
+--
+--   admin もスタッフ兼ユーザーとして連絡先・所在地・生年月日を保持すべきため、
+--   signUp 時の user_metadata に admin_phone / admin_prefecture / admin_birth_date を
+--   含めて渡し、トリガー内で staff / customers の両テーブルに反映する。
+--
+-- 変更内容:
+--   1. user_metadata から admin_phone / admin_prefecture / admin_birth_date を読む
+--   2. staff INSERT に phone を追加
+--   3. customers INSERT を追加（admin も「自組織の顧客」になり得るため）
+--      - email UNIQUE index と衝突した場合は ON CONFLICT (email) DO NOTHING でスキップ
+--
+-- 既存フローへの影響:
+--   - 旧 OrgSignup 経由（phone/prefecture/birth_date を渡さない）は NULL のまま処理続行
+--   - スタッフ招待フロー（invited_as='staff'）は customers INSERT 分岐を通らず変化なし
+--   - 顧客登録フロー（invited_as 無し）も従来通り
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role       app_role := 'customer';
+  v_org_id     UUID;
+  v_name       TEXT;
+  v_phone      TEXT;
+  v_prefecture TEXT;
+  v_birth_date DATE;
+BEGIN
+  v_org_id     := (NEW.raw_user_meta_data->>'organization_id')::UUID;
+  v_name       := NULLIF(trim(COALESCE(NEW.raw_user_meta_data->>'admin_name', '')), '');
+  v_phone      := NULLIF(trim(COALESCE(NEW.raw_user_meta_data->>'admin_phone', '')), '');
+  v_prefecture := NULLIF(trim(COALESCE(NEW.raw_user_meta_data->>'admin_prefecture', '')), '');
+
+  BEGIN
+    v_birth_date := NULLIF(trim(COALESCE(NEW.raw_user_meta_data->>'admin_birth_date', '')), '')::DATE;
+  EXCEPTION WHEN OTHERS THEN
+    v_birth_date := NULL;
+  END;
+
+  IF (NEW.raw_user_meta_data->>'invited_as') IS NOT NULL THEN
+    CASE (NEW.raw_user_meta_data->>'invited_as')
+      WHEN 'staff'         THEN v_role := 'staff';
+      WHEN 'admin'         THEN v_role := 'admin';
+      WHEN 'license_admin' THEN v_role := 'license_admin';
+      ELSE                      v_role := 'customer';
+    END CASE;
+  END IF;
+
+  INSERT INTO public.users (id, email, role, organization_id, created_at, updated_at)
+  VALUES (NEW.id, NEW.email, v_role, v_org_id, NOW(), NOW())
+  ON CONFLICT (id) DO UPDATE SET
+    role            = EXCLUDED.role,
+    organization_id = COALESCE(EXCLUDED.organization_id, users.organization_id),
+    updated_at      = NOW();
+
+  IF v_role = 'admin' AND v_org_id IS NOT NULL THEN
+    -- staff: admin を組織所属スタッフとして登録（phone も入れる）
+    INSERT INTO public.staff (
+      name, email, phone, user_id, organization_id, role, status,
+      stores, ng_days, want_to_learn, available_scenarios,
+      availability, experience, special_scenarios
+    ) VALUES (
+      COALESCE(v_name, split_part(NEW.email, '@', 1)),
+      NEW.email,
+      v_phone,
+      NEW.id,
+      v_org_id,
+      ARRAY['管理者']::TEXT[],
+      'active',
+      '{}'::TEXT[], '{}'::TEXT[], '{}'::TEXT[], '{}'::TEXT[],
+      '{}'::TEXT[], 0, '{}'::TEXT[]
+    )
+    ON CONFLICT (user_id) DO NOTHING;
+
+    -- customers: admin も自組織の顧客として予約等を行える前提でレコードを作る
+    -- email UNIQUE と衝突した場合（顧客として既に登録済み）はスキップ
+    INSERT INTO public.customers (
+      user_id, organization_id, name, email, phone,
+      prefecture, birth_date,
+      visit_count, total_spent,
+      notification_settings,
+      created_at, updated_at
+    ) VALUES (
+      NEW.id, v_org_id,
+      COALESCE(v_name, split_part(NEW.email, '@', 1)),
+      NEW.email,
+      v_phone,
+      v_prefecture,
+      v_birth_date,
+      0, 0,
+      jsonb_build_object(
+        'email_notifications',    true,
+        'reminder_notifications', true,
+        'campaign_notifications', false
+      ),
+      NOW(), NOW()
+    )
+    ON CONFLICT (email) DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'handle_new_user: エラーが発生しました (user_id=%, error=%)', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ handle_new_user 拡張: admin 登録時に phone / prefecture / birth_date を staff + customers に保存';
+END $$;

--- a/supabase/migrations/20260518120000_extend_register_organization_rpc_with_store.sql
+++ b/supabase/migrations/20260518120000_extend_register_organization_rpc_with_store.sql
@@ -1,0 +1,109 @@
+-- =============================================================================
+-- register_organization_for_signup RPC 拡張: 代表店舗の情報も同時に登録
+-- =============================================================================
+-- 背景:
+--   OrgSignup (/start) では initialize_organization_data() トリガーが
+--   「臨時会場 1〜5」を自動生成するが、ユーザーが運営する実店舗は
+--   登録されない。手動で /stores から追加する必要があり UX が悪い。
+--
+--   代表店舗 1 件を組織登録と同時に必須項目として作成できるよう RPC を拡張する。
+--   臨時会場 5 件はそのまま残す（既存挙動）。
+--
+-- 変更内容:
+--   - register_organization_for_signup に p_store_name / p_store_address /
+--     p_store_phone の 3 パラメータを追加（すべて optional）
+--   - p_store_name が指定されていれば、組織作成直後に stores へ 1 件 INSERT
+--   - 旧シグネチャ（3 引数版）の関数は DROP（呼び出し側は新シグネチャに統一）
+-- =============================================================================
+
+-- 旧シグネチャ（3 引数）を削除
+DROP FUNCTION IF EXISTS public.register_organization_for_signup(TEXT, TEXT, TEXT);
+
+CREATE OR REPLACE FUNCTION public.register_organization_for_signup(
+  p_name          TEXT,
+  p_slug          TEXT,
+  p_contact_email TEXT,
+  p_store_name    TEXT DEFAULT NULL,
+  p_store_address TEXT DEFAULT NULL,
+  p_store_phone   TEXT DEFAULT NULL
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id        UUID;
+  v_store_name    TEXT;
+  v_short_name    TEXT;
+BEGIN
+  IF p_name IS NULL OR trim(p_name) = '' THEN
+    RAISE EXCEPTION 'invalid_name: 組織名は必須です';
+  END IF;
+
+  IF p_slug IS NULL OR trim(p_slug) = '' THEN
+    RAISE EXCEPTION 'invalid_slug: 識別子は必須です';
+  END IF;
+
+  IF p_slug !~ '^[a-z0-9][a-z0-9\-]{0,29}$' THEN
+    RAISE EXCEPTION 'invalid_slug_format: 識別子は半角英数字とハイフンのみ使用できます';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.organizations WHERE slug = p_slug) THEN
+    RAISE EXCEPTION 'slug_already_exists: この識別子は既に使用されています';
+  END IF;
+
+  INSERT INTO public.organizations (
+    name, slug, plan, contact_email, is_active, is_license_manager, settings
+  )
+  VALUES (
+    trim(p_name), p_slug, 'free',
+    COALESCE(nullif(trim(p_contact_email), ''), NULL),
+    true, false, '{}'::jsonb
+  )
+  RETURNING id INTO v_org_id;
+
+  -- 代表店舗を作成（指定されていれば）
+  -- ※ initialize_organization_data() トリガーが「臨時会場 1〜5」を別途作るのは継続
+  IF p_store_name IS NOT NULL AND trim(p_store_name) != '' THEN
+    v_store_name := trim(p_store_name);
+    -- short_name は NOT NULL なので名前から作る（先頭6文字、空なら名前そのもの）
+    v_short_name := COALESCE(NULLIF(left(v_store_name, 6), ''), v_store_name);
+
+    INSERT INTO public.stores (
+      name, short_name, address, phone_number,
+      organization_id, status, capacity, rooms, color,
+      opening_date, is_temporary,
+      created_at, updated_at
+    )
+    VALUES (
+      v_store_name,
+      v_short_name,
+      NULLIF(trim(COALESCE(p_store_address, '')), ''),
+      NULLIF(trim(COALESCE(p_store_phone, '')), ''),
+      v_org_id,
+      'active',
+      6,        -- capacity デフォルト
+      1,        -- rooms デフォルト
+      '#E60012', -- color デフォルト（テーマカラー）
+      CURRENT_DATE,
+      false,    -- is_temporary = false（代表店舗）
+      NOW(), NOW()
+    );
+  END IF;
+
+  RETURN json_build_object(
+    'id',   v_org_id,
+    'slug', p_slug,
+    'name', trim(p_name)
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.register_organization_for_signup(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT)
+  TO anon, authenticated;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ register_organization_for_signup 拡張: 代表店舗の同時登録に対応';
+END $$;


### PR DESCRIPTION
## 概要

PR #177 がマージされた時点で、後から push した ② と ③ の commit (96216d0d / 4fcd6359) が取り込まれていなかった。**staging DB は migration 適用済みなのに、staging frontend は旧 3 引数 RPC を呼び続けて壊れている**ため、急ぎ補完する。

## 取りこぼし内容

### ② 管理者プロフィール必須項目（電話/都道府県/生年月日）

admin ステップに 電話番号 / 都道府県 / 生年月日 の入力欄を追加し必須化。signUp の user_metadata に \`admin_phone\` / \`admin_prefecture\` / \`admin_birth_date\` を渡し、\`handle_new_user\` トリガー側で:

- **staff**: phone を含めた管理者レコード作成
- **customers**: 同じユーザーを自組織の顧客としても登録

### ③ 代表店舗 1 件の同時登録

\`/start\` フローに「代表店舗」ステップを追加（組織情報 → 管理者 → **代表店舗** → 確認）。\`register_organization_for_signup\` RPC に \`p_store_name\` / \`p_store_address\` / \`p_store_phone\` を追加し、組織作成直後に \`stores\` へ 1 件 INSERT。店舗名のデフォルトは組織名。

## 変更ファイル

- \`src/pages/OrgSignup/index.tsx\` — ステップ追加と入力欄拡張
- \`supabase/migrations/20260518110000_extend_handle_new_user_for_admin_profile.sql\` — トリガー拡張（staging DB に**適用済み**）
- \`supabase/migrations/20260518120000_extend_register_organization_rpc_with_store.sql\` — RPC 拡張（staging DB に**適用済み**）

## 緊急度

🔥 **High**: staging frontend で \`/start\` が壊れているため、マージ → デプロイ完了まで /start 利用不可。

## Test plan

- [ ] マージ後、Vercel staging デプロイ完了
- [ ] \`/start\` で 4 ステップ完了 → ダッシュボード遷移
- [ ] DB で users/staff/customers + 代表店舗が正しく作成されること

## 関連

- PR #177 の続き
- [[project-org-signup-bugs]] の機能強化完了分