### PR TITLE
fix(CompleteProfile): 新規ユーザー登録時の organization_id 解決を強化

### DIFF
--- a/src/pages/CompleteProfile.tsx
+++ b/src/pages/CompleteProfile.tsx
@@ -18,7 +18,7 @@ import { grantRegistrationCoupon } from '@/lib/api/couponApi'
 import { MYPAGE_THEME as THEME } from '@/lib/theme'
 import { Link, useNavigate } from 'react-router-dom'
 import { resendSignupConfirmationEmail } from '@/lib/authResendSignup'
-import { getOrganizationBySlug } from '@/lib/organization'
+import { getOrganizationBySlug, QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
 import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
 
 // 都道府県リスト
@@ -375,14 +375,26 @@ export function CompleteProfile() {
 
       let organizationId = existingUser?.organization_id ?? null
       if (!organizationId) {
+        // 1. 現在のURLパスからスラッグを取得（/complete-profile は adminPaths なので null になる）
         const slug = getOrganizationSlugFromPath()
         if (slug) {
           const org = await getOrganizationBySlug(slug)
           organizationId = org?.id ?? null
         }
-        if (!organizationId) {
-          logger.warn('CompleteProfile: org_id が特定できません（URLにorgスラッグがありません）')
+      }
+      if (!organizationId) {
+        // 2. next クエリパラメータからスラッグを取得（例: ?next=/queens-waltz/booking/...）
+        const nextParam = new URLSearchParams(window.location.search).get('next')
+        const nextSlug = nextParam?.match(/^\/([^/?#]+)/)?.[1]
+        if (nextSlug) {
+          const org = await getOrganizationBySlug(nextSlug)
+          organizationId = org?.id ?? null
         }
+      }
+      if (!organizationId) {
+        // 3. どうしても特定できない場合はデフォルト組織（Queens Waltz）を使用
+        logger.warn('CompleteProfile: org_id が特定できません（URLにorgスラッグがありません）')
+        organizationId = QUEENS_WALTZ_ORG_ID
       }
       const { error: usersUpsertError } = await supabase
         .from('users')


### PR DESCRIPTION
## 問題

新規ユーザーが `/complete-profile` でプロフィール登録しようとすると `customers` INSERT が 400 エラーで失敗し、登録が完了できなかった。

## 原因

`/complete-profile` は `publicBookingPath.ts` の `adminPaths` リストに含まれているため、`getOrganizationSlugFromPath()` が常に null を返す。

マルチテナント対応で `|| DEFAULT_ORG_ID` フォールバックが削除されたため、`organizationId` が null のまま `customers.insert({ organization_id: null })` → `organization_id NOT NULL` 制約違反で 400 エラー。

## 修正

org_id の解決を3段階でフォールバックするよう変更:

1. **現在のURLパス** (`getOrganizationSlugFromPath()`) — 通常は null
2. **`next` クエリパラメータ** — `/complete-profile?next=/queens-waltz/...` のようにorg contextが含まれている場合に対応
3. **`QUEENS_WALTZ_ORG_ID`** — 最終フォールバック（マジックリンク経由の直接登録など、org contextが全くない場合）

## テスト

- マジックリンクから `/complete-profile` に遷移して新規登録が完了できることを確認
- 予約フローから `/complete-profile?next=/queens-waltz/...` 経由で登録した場合も正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)