### PR TITLE
🔥 hotfix: 貸切リクエスト送信不可・新規登録失敗を緊急修正

### DIFF
--- a/src/hooks/usePrivateGroup.ts
+++ b/src/hooks/usePrivateGroup.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '@/lib/supabase'
-import { getCurrentOrganizationId } from '@/lib/organization'
+import { getCurrentOrganizationId, getOrganizationBySlug } from '@/lib/organization'
+import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
 import { logger } from '@/utils/logger'
 import { privateGroupTimeSlotToDb } from '@/lib/privateGroupTimeSlot'
 import {
@@ -228,9 +229,15 @@ export function usePrivateGroup() {
       const { data: { user } } = await supabase.auth.getUser()
       if (!user) throw new Error('ログインが必要です')
 
-      const organizationId = await getCurrentOrganizationId()
+      let organizationId = await getCurrentOrganizationId()
+      if (!organizationId) {
+        const slug = getOrganizationSlugFromPath()
+        if (slug) {
+          const org = await getOrganizationBySlug(slug)
+          organizationId = org?.id ?? null
+        }
+      }
       if (!organizationId) throw new Error('組織情報が取得できません')
-
 
       let inviteCode = await generateInviteCode()
       let attempts = 0

--- a/src/pages/CompleteProfile.tsx
+++ b/src/pages/CompleteProfile.tsx
@@ -18,7 +18,7 @@ import { grantRegistrationCoupon } from '@/lib/api/couponApi'
 import { MYPAGE_THEME as THEME } from '@/lib/theme'
 import { Link, useNavigate } from 'react-router-dom'
 import { resendSignupConfirmationEmail } from '@/lib/authResendSignup'
-import { getOrganizationBySlug } from '@/lib/organization'
+import { getOrganizationBySlug, QUEENS_WALTZ_ORG_ID } from '@/lib/organization'
 import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
 
 // 都道府県リスト
@@ -380,9 +380,19 @@ export function CompleteProfile() {
           const org = await getOrganizationBySlug(slug)
           organizationId = org?.id ?? null
         }
-        if (!organizationId) {
-          logger.warn('CompleteProfile: org_id が特定できません（URLにorgスラッグがありません）')
+      }
+      if (!organizationId) {
+        // next クエリパラメータからスラッグを取得（例: ?next=/queens-waltz/booking/...）
+        const nextParam = new URLSearchParams(window.location.search).get('next')
+        const nextSlug = nextParam?.match(/^\/([^/?#]+)/)?.[1]
+        if (nextSlug) {
+          const org = await getOrganizationBySlug(nextSlug)
+          organizationId = org?.id ?? null
         }
+      }
+      if (!organizationId) {
+        logger.warn('CompleteProfile: org_id が特定できません（URLにorgスラッグがありません）')
+        organizationId = QUEENS_WALTZ_ORG_ID
       }
       const { error: usersUpsertError } = await supabase
         .from('users')


### PR DESCRIPTION
## 緊急修正（本番で多数のユーザーが影響）

### 問題1: 貸切リクエストが送信できない
**エラー:** 「組織情報が取得できません」
**原因:** `usePrivateGroup.createGroup()` で `getCurrentOrganizationId()` が null（一般顧客の `users.organization_id` は未設定）のまま例外をスロー
**修正:** URLパスのスラッグからも組織IDを解決するフォールバックを追加

### 問題2: 新規ユーザーがプロフィール登録できない
**エラー:** `null value in column "organization_id" of relation "customers" violates not-null constraint`（HTTP 400）
**原因:** `/complete-profile` は `adminPaths` に含まれるため `getOrganizationSlugFromPath()` が null → `organization_id=null` のまま INSERT
**修正:** `next` パラメータからスラッグ解決 → `QUEENS_WALTZ_ORG_ID` の3段階フォールバック

### 変更ファイル
- `src/hooks/usePrivateGroup.ts` — createGroup()にURLスラッグ解決を追加
- `src/pages/CompleteProfile.tsx` — 3段階フォールバックでorg_id解決を強化

🤖 Generated with [Claude Code](https://claude.com/claude-code)