### PR TITLE
fix: /group/create?org= の組織ID解決とパスワード422エラー処理を修正

### DIFF
--- a/src/hooks/usePrivateGroup.ts
+++ b/src/hooks/usePrivateGroup.ts
@@ -231,9 +231,20 @@ export function usePrivateGroup() {
 
       let organizationId = await getCurrentOrganizationId()
       if (!organizationId) {
+        // 1. パスの先頭セグメントからスラッグを解決（例: /queens-waltz/private-booking-request）
         const slug = getOrganizationSlugFromPath()
         if (slug) {
           const org = await getOrganizationBySlug(slug)
+          organizationId = org?.id ?? null
+        }
+      }
+      if (!organizationId) {
+        // 2. ?org= クエリパラメータから解決（例: /group/create?org=queens-waltz）
+        const orgParam = typeof window !== 'undefined'
+          ? new URLSearchParams(window.location.search).get('org')
+          : null
+        if (orgParam) {
+          const org = await getOrganizationBySlug(orgParam)
           organizationId = org?.id ?? null
         }
       }

--- a/src/pages/PrivateBookingRequest/hooks/usePrivateBookingSubmit.ts
+++ b/src/pages/PrivateBookingRequest/hooks/usePrivateBookingSubmit.ts
@@ -6,10 +6,21 @@ import { getOrganizationSlugFromPath } from '@/lib/publicBookingPath'
 async function resolveOrgId(): Promise<string | null> {
   const orgId = await getCurrentOrganizationId()
   if (orgId) return orgId
+  // 1. パスの先頭セグメント（例: /queens-waltz/private-booking-request）
   const slug = getOrganizationSlugFromPath()
-  if (!slug) return null
-  const org = await getOrganizationBySlug(slug)
-  return org?.id ?? null
+  if (slug) {
+    const org = await getOrganizationBySlug(slug)
+    if (org?.id) return org.id
+  }
+  // 2. ?org= クエリパラメータ（例: /group/create?org=queens-waltz）
+  const orgParam = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('org')
+    : null
+  if (orgParam) {
+    const org = await getOrganizationBySlug(orgParam)
+    if (org?.id) return org.id
+  }
+  return null
 }
 import { logger } from '@/utils/logger'
 import { hasNonEmptyCustomerPhone, MSG_CUSTOMER_PHONE_REQUIRED_FOR_BOOKING } from '@/lib/customerPhonePolicy'


### PR DESCRIPTION
## 修正内容

### 1. `/group/create?org=queens-waltz` でも組織IDを解決

**問題:** `/group/create` のURLはパスに組織スラッグがないため、
`getOrganizationSlugFromPath()` が `'group'` を誤返却 → `getOrganizationBySlug('group')` が null → 「組織情報が取得できません」

**修正:** `createGroup()` と `resolveOrgId()` に `?org=` クエリパラメータからの解決を追加
- パス解決失敗 → `?org=` クエリ解決 → throw の順

### 2. OTPセッションでのパスワード422エラーをスキップして登録続行

**問題:** マジックリンク（OTP）セッションで `updateUser({ password })` が 422 を返すと例外スロー → セッション状態が不安定になり後続の DB 操作が全て 42501 (RLS) で失敗 → 「登録に失敗しました」

**修正:** `updateError.status === 422` も「スキップして続行」に含める

### 変更ファイル
- `src/hooks/usePrivateGroup.ts` — createGroup() に ?org= 解決を追加
- `src/pages/PrivateBookingRequest/hooks/usePrivateBookingSubmit.ts` — resolveOrgId() に ?org= 解決を追加
- `src/pages/CompleteProfile.tsx` — 422 エラーもスキップして続行

🤖 Generated with [Claude Code](https://claude.com/claude-code)