### PR TITLE
fix: AdminSidebar React #310 / スタッフページ空組織ローディング無限ループを修正

### DIFF
--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -341,19 +341,18 @@ export const AdminSidebar = memo(function AdminSidebar() {
   // 管理ページかどうか
   const isAdminPage = ADMIN_PATH_SEGMENTS.some(seg => location.pathname.includes(`/${seg}`))
 
-  if (!user || user.role === 'customer' || !isAdminPage) return null
-
-  // カテゴリが開いているか（アクティブページが含まれる時のみ）
+  // フックは早期 return の前に宣言する（Rules of Hooks）
   const isGroupOpen = useCallback((group: typeof visibleGroups[0]) => {
-    if (!group.label) return true  // ラベルなし（トップ）は常に表示
+    if (!group.label) return true
     return group.items.some(item => isActive(item))
   }, [isActive])
 
-  // カテゴリヘッダーをクリック → そのカテゴリの最初のアイテムに遷移
   const handleGroupClick = useCallback((group: typeof visibleGroups[0]) => {
     const firstItem = group.items[0]
     if (firstItem) navigate(firstItem.path)
   }, [navigate])
+
+  if (!user || user.role === 'customer' || !isAdminPage) return null
 
   const bookingActive = isActive({ id: 'booking', label: '予約サイト', icon: Globe, path: `/${slug}`, roles: [] })
 

--- a/src/pages/StaffManagement/hooks/useStoresAndScenarios.ts
+++ b/src/pages/StaffManagement/hooks/useStoresAndScenarios.ts
@@ -9,13 +9,13 @@ export const storeScenarioKeys = {
 }
 
 export function useStoresAndScenarios() {
-  const { data: stores = [] } = useQuery<Store[]>({
+  const { data: stores = [], isLoading: storesLoading } = useQuery<Store[]>({
     queryKey: storeScenarioKeys.stores,
     queryFn: () => storeApi.getAll(),
     staleTime: 30 * 60 * 1000,
   })
 
-  const { data: scenarios = [] } = useQuery<Scenario[]>({
+  const { data: scenarios = [], isLoading: scenariosLoading } = useQuery<Scenario[]>({
     queryKey: storeScenarioKeys.scenarios,
     queryFn: () => scenarioApi.getAll(),
     staleTime: 30 * 60 * 1000,
@@ -56,6 +56,8 @@ export function useStoresAndScenarios() {
   return {
     stores,
     scenarios,
+    storesLoading,
+    scenariosLoading,
     loadStores,
     loadScenarios,
     getScenario,

--- a/src/pages/StaffManagement/index.tsx
+++ b/src/pages/StaffManagement/index.tsx
@@ -61,14 +61,16 @@ export function StaffManagement() {
   const {
     stores,
     scenarios,
+    storesLoading,
+    scenariosLoading,
     loadStores,
     loadScenarios,
     getScenario,
     getScenarioName
   } = useStoresAndScenarios()
 
-  // 店舗・シナリオが揃うまでローディング扱い（UUID/「不明なシナリオ」の一瞬表示を防ぐ）
-  const loading = staffLoading || stores.length === 0 || scenarios.length === 0
+  // フェッチ完了まではローディング扱い（シナリオ0件の組織でも正しく表示するため length ではなく isLoading で判定）
+  const loading = staffLoading || storesLoading || scenariosLoading
 
   // スタッフの認証状態を取得
   const staffUserIds = useMemo(() => staff.map(s => s.user_id ?? null), [staff])


### PR DESCRIPTION
## Summary
- **AdminSidebar**: `useCallback` 2 件が早期 `return null` の後に宣言されていた（Rules of Hooks 違反）。管理ページ ↔ 非管理ページ遷移時に intermittent で React error #310 が発生していた問題を修正
- **StaffManagement**: シナリオ0件の新規組織でスタッフページが永遠にローディングのままになるバグを修正。`scenarios.length === 0` をローディング判定に使っていたのを `isLoading` フラグに変更

## Test plan
- [ ] 管理ページ ↔ 予約サイトトップを行き来しても React error #310 が出ないことを確認
- [ ] シナリオ未登録の組織でスタッフページが正しくスタッフ一覧を表示することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)