### PR TITLE
fix(booking): 電話番号検証クエリの organization_id フィルタを除去

### DIFF
--- a/src/pages/BookingConfirmation/hooks/useBookingSubmit.ts
+++ b/src/pages/BookingConfirmation/hooks/useBookingSubmit.ts
@@ -511,15 +511,12 @@ export function useBookingSubmit(props: UseBookingSubmitProps) {
         throw new Error('顧客情報の取得に失敗しました。もう一度お試しください。')
       }
 
-      let phoneVerifyQuery = supabase
+      const { data: phoneRow, error: phoneVerifyError } = await supabase
         .from('customers')
         .select('phone')
         .eq('id', customerId)
         .eq('user_id', props.userId)
-      if (organizationId) {
-        phoneVerifyQuery = phoneVerifyQuery.eq('organization_id', organizationId)
-      }
-      const { data: phoneRow, error: phoneVerifyError } = await phoneVerifyQuery.maybeSingle()
+        .maybeSingle()
       if (phoneVerifyError || !hasNonEmptyCustomerPhone(phoneRow?.phone)) {
         throw new Error(MSG_CUSTOMER_PHONE_REQUIRED_FOR_BOOKING)
       }


### PR DESCRIPTION
platform customer は organization_id = NULL のため、phoneVerifyQuery に organization_id フィルタが残っていると phoneRow が null になり「電話番号が登録されていません」エラーが発生していた。