### PR TITLE
fix(booking): シナリオカタログを組織固有のみに制限

### DIFF
--- a/src/pages/PublicBookingTop/hooks/useBookingData.ts
+++ b/src/pages/PublicBookingTop/hooks/useBookingData.ts
@@ -137,7 +137,7 @@ async function fetchBookingData(organizationSlug?: string): Promise<BookingDataR
           .neq('scenario_type', 'gm_test')
         
         if (orgId) {
-          query = query.or(`organization_id.eq.${orgId},is_shared.eq.true`)
+          query = query.eq('organization_id', orgId)
         }
         
         return await query.order('title', { ascending: true })


### PR DESCRIPTION
is_shared.eq.true が全プラットフォームシナリオをカタログに追加していた問題を修正。各組織は自分で登録したシナリオのみ表示。