### PR TITLE
fix(settings): 設定ページ 400 エラー修正 + booking_site_status を org select に追加

### DIFF
--- a/src/lib/organization.ts
+++ b/src/lib/organization.ts
@@ -8,7 +8,7 @@ import type { Organization, Staff } from '@/types'
 // NOTE: Supabase の型推論（select parser）の都合で、select 文字列は literal に寄せる
 /** 古いDBでも必ず存在する列のみ（マイグレーション未適用時のフォールバック用） */
 export const ORGANIZATION_SELECT_CORE =
-  'id, name, slug, plan, contact_email, contact_name, is_license_manager, is_active, settings, notes, created_at, updated_at' as const
+  'id, name, slug, plan, booking_site_status, contact_email, contact_name, is_license_manager, is_active, settings, notes, created_at, updated_at' as const
 
 /** 公開予約・ヘッダー等で使う標準セット */
 export const ORGANIZATION_SELECT_STANDARD =

--- a/supabase/migrations/20260519050000_add_reservation_settings_columns.sql
+++ b/supabase/migrations/20260519050000_add_reservation_settings_columns.sql
@@ -1,0 +1,4 @@
+-- CancellationSettings.tsx が SELECT している列が存在しないため 400 エラーになっていた問題を修正
+ALTER TABLE public.reservation_settings
+  ADD COLUMN IF NOT EXISTS auto_refund_enabled boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS refund_processing_days integer NOT NULL DEFAULT 7;


### PR DESCRIPTION
reservation_settings に不足していた auto_refund_enabled / refund_processing_days カラムを追加。組織 select に booking_site_status を追加。