### PR TITLE
fix(platform-search): シナリオ重複・key重複・組織名削除

### DIFF
--- a/src/pages/PlatformScenarioSearch/index.tsx
+++ b/src/pages/PlatformScenarioSearch/index.tsx
@@ -139,7 +139,7 @@ async function fetchScenarioSearchData(): Promise<ScenarioSearchResult> {
   })
 
   // 組織の公開ステータスで絞り込み
-  const filteredScenarios = (scenariosResult.data || [])
+  const mapped = (scenariosResult.data || [])
     .filter(s => {
       if (!shouldFilterByOrgStatus) {
         return s.status === 'available'
@@ -150,7 +150,6 @@ async function fetchScenarioSearchData(): Promise<ScenarioSearchResult> {
     .map(s => {
       const org = s.organizations as { slug?: string; name?: string } | null
       const storeIds = s.available_stores || []
-      // available_storesのIDを店舗名に変換
       const storeNames = storeIds
         .map((storeId: string) => storeMap.get(storeId))
         .filter((name: string | undefined): name is string => !!name)
@@ -163,6 +162,30 @@ async function fetchScenarioSearchData(): Promise<ScenarioSearchResult> {
         available_store_ids: storeIds,
       }
     })
+
+  // scenario_master_id で重複排除（同シナリオが複数組織にある場合は1件に統合）
+  const seenMasterIds = new Map<string, typeof mapped[number]>()
+  const filteredScenarios = mapped.filter(s => {
+    const key = s.scenario_master_id || s.id
+    if (seenMasterIds.has(key)) {
+      // 既存エントリに店舗を追加・最安値価格に更新
+      const existing = seenMasterIds.get(key)!
+      const mergedStores = [...new Set([...existing.available_stores, ...s.available_stores])]
+      const minPrice = Math.min(
+        existing.participation_fee ?? Infinity,
+        s.participation_fee ?? Infinity
+      )
+      seenMasterIds.set(key, {
+        ...existing,
+        available_stores: mergedStores,
+        participation_fee: isFinite(minPrice) ? minPrice : existing.participation_fee,
+        // key_visual_urlは最初の非nullを優先（既存が既に入っている）
+      })
+      return false
+    }
+    seenMasterIds.set(key, s)
+    return true
+  }).map(s => seenMasterIds.get(s.scenario_master_id || s.id) ?? s)
   
   // 店舗データに組織名を補完（RPCから取得できない場合のフォールバック）
   const storesWithOrgName = (storesResult.data || []).map((store: any) => ({
@@ -656,11 +679,11 @@ export function PlatformScenarioSearch() {
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 md:gap-4">
-            {filteredScenarios.map((scenario, index) => (
+            {filteredScenarios.map((scenario) => (
               <div
-                key={scenario.id}
+                key={scenario.org_scenario_id || scenario.id}
                 className="group cursor-pointer"
-                onClick={() => handleCardClick(scenario.slug || scenario.id)}
+                onClick={() => handleCardClick(scenario.slug || scenario.org_scenario_id || scenario.id)}
               >
                 <div 
                   className="relative bg-white overflow-hidden border border-gray-200 group-hover:border-gray-300 group-hover:shadow-lg transition-all duration-200 flex md:flex-col hover:scale-[1.02]"
@@ -712,14 +735,8 @@ export function PlatformScenarioSearch() {
 
                   {/* コンテンツ */}
                   <div className="p-2 sm:p-3 flex-1 min-w-0">
-                    {/* 店舗名 + お気に入りボタン */}
-                    <div className="flex items-center justify-between mb-1">
-                      {scenario.organization_name && (
-                        <div className="flex items-center gap-1 text-xs text-gray-500">
-                          <Building2 className="w-3 h-3" />
-                          <span className="truncate">{scenario.organization_name}</span>
-                        </div>
-                      )}
+                    {/* お気に入りボタン（組織名は詳細の「遊べる店舗」に表示） */}
+                    <div className="flex items-center justify-end mb-1">
                       <button
                         onClick={(e) => handleToggleFavorite(scenario.id, e)}
                         className="flex-shrink-0 p-1 transition-colors hover:bg-red-50 rounded"


### PR DESCRIPTION
1. scenario_master_idで重複排除（複数組織の同シナリオを1件に統合）\n2. key={org_scenario_id}に変更（id=master_idで重複keyになりReactが6件表示するバグを修正）\n3. カードから組織名を削除（詳細の遊べる店舗に集約）