### PR TITLE
fix(security/api): organization_scenarios RLS・is_shared・performance_kits・scenarios write 権限を修正

### DIFF
--- a/api/scenarios.ts
+++ b/api/scenarios.ts
@@ -1090,14 +1090,12 @@ async function routeDelete(req: VercelRequest, res: VercelResponse, orgId: strin
     console.error('[scenarios:delete] staff_scenario_assignments delete error:', assignmentError)
   }
 
-  // 4. performance_kits を削除
-  // NOTE: performance_kits は organization_id を持たない（または別構造）ため
-  // scenario_master_id のみで削除する。旧実装と同じ挙動。
-  // TODO: performance_kits が org_id を持つようになったら orgId でも絞り込む。
+  // 4. performance_kits を削除（自組織分のみ）
   const { error: kitsError } = await db
     .from('performance_kits')
     .delete()
     .eq('scenario_master_id', id)
+    .eq('organization_id', orgId)
   if (kitsError) {
     console.error('[scenarios:delete] performance_kits delete error:', kitsError)
   }

--- a/api/scenarios.ts
+++ b/api/scenarios.ts
@@ -158,9 +158,9 @@ async function authenticate(
   const role = profile.role as string
 
   // GET リクエストは customer ロールも許可（シナリオ詳細は顧客も閲覧可）
-  // 書き込み操作（POST/PATCH/DELETE）は staff 以上が必要
-  if (req.method !== 'GET' && !['admin', 'staff', 'license_admin'].includes(role)) {
-    res.status(403).json({ error: 'スタッフ以上の権限が必要です' })
+  // 書き込み操作（POST/PATCH/DELETE）は admin 以上が必要（DB RLS と統一）
+  if (req.method !== 'GET' && !['admin', 'license_admin'].includes(role)) {
+    res.status(403).json({ error: '管理者権限が必要です' })
     return null
   }
 

--- a/src/components/modals/ScenarioEditDialogV2/sections/CharactersSectionV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2/sections/CharactersSectionV2.tsx
@@ -151,23 +151,18 @@ export function CharactersSectionV2({ formData, setFormData }: CharactersSection
 
       {/* キャラクター一覧 */}
       {characters.length === 0 ? (
-        <Card className="border-dashed">
-          <CardContent className="p-8 text-center">
-            <User className="w-8 h-8 mx-auto text-muted-foreground mb-2" />
-            <p className="text-sm text-muted-foreground">
-              キャラクターが登録されていません
-            </p>
-            <Button onClick={addCharacter} size="sm" variant="outline" className="mt-3">
-              <Plus className="w-4 h-4 mr-1" />
-              キャラクターを追加
-            </Button>
-          </CardContent>
-        </Card>
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <User className="w-8 h-8 mx-auto text-muted-foreground mb-2" />
+          <p className="text-sm text-muted-foreground">キャラクターが登録されていません</p>
+          <Button onClick={addCharacter} size="sm" variant="outline" className="mt-3">
+            <Plus className="w-4 h-4 mr-1" />キャラクターを追加
+          </Button>
+        </div>
       ) : (
         <div className="space-y-3">
           {characters.map((character, index) => (
-            <Card key={character.id}>
-              <CardContent className="p-3">
+            <div key={character.id} className="rounded-lg border bg-white p-3">
+              <div>
                 <div className="flex gap-2">
                   {/* 並び替えハンドル */}
                   <div className="flex flex-col justify-center gap-1">
@@ -547,8 +542,8 @@ export function CharactersSectionV2({ formData, setFormData }: CharactersSection
                     </Button>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+              </div>
+            </div>
           ))}
         </div>
       )}

--- a/src/components/modals/ScenarioEditDialogV2/sections/SurveySectionV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2/sections/SurveySectionV2.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -202,18 +201,13 @@ export function SurveySectionV2({ formData, setFormData }: SurveySectionV2Props)
   }, [setFormData])
 
   return (
-    <div className="space-y-4">
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base flex items-center gap-2">
-            <ClipboardList className="w-4 h-4" />
-            公演前アンケート
-          </CardTitle>
-          <CardDescription className="text-xs">
-            貸切リクエストのお客様へ公演前に回答いただくアンケートを設定します
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
+    <div className="space-y-3">
+      <div className="rounded-lg border bg-slate-50/70 p-3 space-y-3">
+        <p className="text-[11px] font-semibold text-slate-500 flex items-center gap-1.5 mb-1">
+          <ClipboardList className="h-3.5 w-3.5" />公演前アンケート
+        </p>
+        <p className="text-[11px] text-muted-foreground -mt-1">貸切リクエストのお客様へ公演前に回答いただくアンケートを設定します</p>
+        <div className="space-y-3">
           <div className="flex items-center gap-3">
             <Switch
               id="survey_enabled"
@@ -338,45 +332,31 @@ export function SurveySectionV2({ formData, setFormData }: SurveySectionV2Props)
               </div>
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </div>
 
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm flex items-center gap-2">
-            <MessageSquare className="w-4 h-4" />
-            個別お知らせ定型文
-          </CardTitle>
-          <CardDescription className="text-xs">
-            アンケート回答確認時に、メンバーへ個別お知らせを送る際に添付できる定型文です
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="pt-0 space-y-2">
-          <Textarea
-            value={formData.individual_notice_template || ''}
-            onChange={(e) => setFormData(prev => ({
-              ...prev,
-              individual_notice_template: e.target.value || null,
-            }))}
-            placeholder="例: アンケートの回答ありがとうございます。以下の資料を公演前にご確認ください。"
-            rows={3}
-            className="text-sm resize-none"
-          />
-          <p className={hintStyle}>
-            資料URLと一緒にこの定型文をメッセージに添付できます。メッセージ本文とは別に送信されます。
-          </p>
-        </CardContent>
-      </Card>
+      <div className="rounded-lg border bg-slate-50/70 p-3 space-y-2">
+        <p className="text-[11px] font-semibold text-slate-500 flex items-center gap-1.5 mb-1">
+          <MessageSquare className="h-3.5 w-3.5" />個別お知らせ定型文
+        </p>
+        <p className="text-[11px] text-muted-foreground -mt-1">アンケート回答確認時に、メンバーへ個別お知らせを送る際に添付できる定型文です</p>
+        <Textarea
+          value={formData.individual_notice_template || ''}
+          onChange={(e) => setFormData(prev => ({ ...prev, individual_notice_template: e.target.value || null }))}
+          placeholder="例: アンケートの回答ありがとうございます。以下の資料を公演前にご確認ください。"
+          rows={3}
+          className="text-sm resize-none"
+        />
+        <p className={hintStyle}>資料URLと一緒にこの定型文をメッセージに添付できます。メッセージ本文とは別に送信されます。</p>
+      </div>
 
-      <Card className="border-amber-200 bg-amber-50/50">
-        <CardContent className="p-4">
-          <p className="text-sm text-amber-800">
-            <span className="font-medium">💡 公演後アンケートについて</span>
-            <br />
-            公演後のアンケート（満足度調査など）は、設定 &gt; 組織情報 で組織全体に共通のURLを設定できます。
-          </p>
-        </CardContent>
-      </Card>
+      <div className="rounded-lg border border-amber-200 bg-amber-50/50 p-3">
+        <p className="text-sm text-amber-800">
+          <span className="font-medium">💡 公演後アンケートについて</span>
+          <br />
+          公演後のアンケート（満足度調査など）は、設定 &gt; 組織情報 で組織全体に共通のURLを設定できます。
+        </p>
+      </div>
 
       <ImportQuestionsDialog
         open={importDialogOpen}

--- a/supabase/migrations/20260519070000_fix_org_scenarios_rls.sql
+++ b/supabase/migrations/20260519070000_fix_org_scenarios_rls.sql
@@ -1,0 +1,12 @@
+-- organization_scenarios_select_public の修正
+-- 問題: `auth.uid() IS NOT NULL` 条件により、認証済みの全ユーザーが全組織のシナリオを閲覧可能になっていた
+-- 修正: 公開シナリオ（org_status = 'available'）のみ誰でも閲覧可能にする
+--       自組織のシナリオは既存の org_scenarios_select_staff_or_admin ポリシーでカバー
+
+DROP POLICY IF EXISTS "organization_scenarios_select_public" ON public.organization_scenarios;
+
+CREATE POLICY organization_scenarios_select_public ON public.organization_scenarios FOR SELECT
+USING (org_status = 'available');
+
+COMMENT ON POLICY organization_scenarios_select_public ON public.organization_scenarios IS
+  '公開シナリオ（org_status=available）は未ログインでも閲覧可能。認証ユーザーの全閲覧は廃止。';

--- a/supabase/migrations/20260519080000_fix_is_shared_in_views.sql
+++ b/supabase/migrations/20260519080000_fix_is_shared_in_views.sql
@@ -1,0 +1,125 @@
+-- #200: organization_scenarios_with_master / scenarios_v2 ビューの
+-- is_shared が true にハードコードされていた問題を修正。
+-- scenario_masters に is_shared 列を追加し、ビューで参照する。
+--
+-- デフォルト true のため既存データへの影響なし。
+
+ALTER TABLE public.scenario_masters
+  ADD COLUMN IF NOT EXISTS is_shared boolean NOT NULL DEFAULT true;
+
+-- organization_scenarios_with_master を再作成
+-- ベース: 20260503120000_fix_restore_org_scenarios_view_full_columns.sql
+-- 変更点: true AS is_shared → sm.is_shared
+
+DROP VIEW IF EXISTS public.organization_scenarios_with_master;
+
+CREATE VIEW public.organization_scenarios_with_master AS
+SELECT
+  os.scenario_master_id AS id,
+  os.id AS org_scenario_id,
+  os.organization_id,
+  os.scenario_master_id,
+  os.slug,
+  os.org_status AS status,
+  os.org_status,
+  COALESCE(os.override_title, sm.title) AS title,
+  COALESCE(os.override_author, sm.author) AS author,
+  COALESCE(os.report_display_name, sm.report_display_name, COALESCE(os.override_author, sm.author)) AS report_display_name,
+  sm.author_email,
+  sm.author_id,
+  COALESCE(os.custom_key_visual_url, sm.key_visual_url) AS key_visual_url,
+  COALESCE(os.custom_description, sm.description) AS description,
+  COALESCE(os.custom_synopsis, sm.synopsis) AS synopsis,
+  COALESCE(os.custom_caution, sm.caution) AS caution,
+  COALESCE(os.override_player_count_min, sm.player_count_min) AS player_count_min,
+  COALESCE(os.override_player_count_max, sm.player_count_max) AS player_count_max,
+  os.male_count,
+  os.female_count,
+  os.other_count,
+  COALESCE(os.duration, sm.official_duration) AS duration,
+  os.weekend_duration,
+  COALESCE(os.override_genre, sm.genre) AS genre,
+  COALESCE(os.override_difficulty, sm.difficulty) AS difficulty,
+  COALESCE(os.override_has_pre_reading, sm.has_pre_reading) AS has_pre_reading,
+  sm.release_date,
+  sm.official_site_url,
+  sm.required_items AS required_props,
+  os.participation_fee,
+  os.gm_test_participation_fee,
+  os.participation_costs,
+  os.flexible_pricing,
+  os.use_flexible_pricing,
+  os.license_amount,
+  os.gm_test_license_amount,
+  os.franchise_license_amount,
+  os.franchise_gm_test_license_amount,
+  os.external_license_amount,
+  os.external_gm_test_license_amount,
+  os.fc_receive_license_amount,
+  os.fc_receive_gm_test_license_amount,
+  os.fc_author_license_amount,
+  os.fc_author_gm_test_license_amount,
+  os.gm_costs,
+  os.gm_count,
+  os.gm_assignments,
+  COALESCE((
+    SELECT array_agg(st.name ORDER BY st.name)
+    FROM staff_scenario_assignments ssa
+    JOIN staff st ON st.id = ssa.staff_id
+    WHERE ssa.scenario_master_id = os.scenario_master_id
+      AND ssa.organization_id = os.organization_id
+      AND (ssa.can_main_gm = true OR ssa.can_sub_gm = true)
+  ), ARRAY[]::text[]) AS available_gms,
+  COALESCE((
+    SELECT array_agg(st.name ORDER BY st.name)
+    FROM staff_scenario_assignments ssa
+    JOIN staff st ON st.id = ssa.staff_id
+    WHERE ssa.scenario_master_id = os.scenario_master_id
+      AND ssa.organization_id = os.organization_id
+      AND ssa.is_experienced = true
+      AND COALESCE(ssa.can_main_gm, false) = false
+      AND COALESCE(ssa.can_sub_gm, false) = false
+  ), ARRAY[]::text[]) AS experienced_staff,
+  os.available_stores,
+  os.production_cost,
+  os.production_costs,
+  os.depreciation_per_performance,
+  os.extra_preparation_time,
+  (
+    SELECT count(*)::integer
+    FROM schedule_events se
+    WHERE se.scenario_master_id = os.scenario_master_id
+      AND se.organization_id = os.organization_id
+      AND se.date <= CURRENT_DATE
+      AND se.is_cancelled IS NOT TRUE
+      AND se.category <> 'offsite'::text
+  ) AS play_count,
+  os.notes,
+  os.created_at,
+  os.updated_at,
+  sm.master_status,
+  os.pricing_patterns,
+  sm.is_shared,
+  COALESCE(os.scenario_type, 'normal'::text) AS scenario_type,
+  0::numeric AS rating,
+  COALESCE(os.kit_count, 1) AS kit_count,
+  '[]'::jsonb AS license_rewards,
+  COALESCE(os.is_recommended, false) AS is_recommended,
+  os.survey_url,
+  COALESCE(os.survey_enabled, false) AS survey_enabled,
+  COALESCE(os.survey_deadline_days, 1) AS survey_deadline_days,
+  COALESCE(os.characters, '[]'::jsonb) AS characters,
+  os.pre_reading_notice_message,
+  os.booking_start_date,
+  os.booking_end_date,
+  os.individual_notice_template,
+  COALESCE(os.character_assignment_method, 'survey'::text) AS character_assignment_method,
+  COALESCE(os.private_booking_time_slots, ARRAY[]::text[]) AS private_booking_time_slots,
+  COALESCE(os.private_booking_blocked_slots, ARRAY[]::text[]) AS private_booking_blocked_slots
+FROM organization_scenarios os
+JOIN scenario_masters sm ON sm.id = os.scenario_master_id;
+
+GRANT SELECT ON public.organization_scenarios_with_master TO authenticated;
+GRANT SELECT ON public.organization_scenarios_with_master TO anon;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

- **#195** `organization_scenarios_select_public` RLS から `auth.uid() IS NOT NULL` を削除 → 認証済みユーザーが他組織の全シナリオを閲覧できていたセキュリティ問題を修正。公開シナリオ（`org_status = 'available'`）のみに限定。
- **#200** `scenario_masters` に `is_shared boolean NOT NULL DEFAULT true` を追加。`organization_scenarios_with_master` ビューで `true` ハードコードを `sm.is_shared` 参照に変更。
- **#193** `performance_kits` 削除時に `organization_id = orgId` フィルターを追加。他組織のキットが誤って削除されるリスクを解消。
- **#196** scenarios API の POST/PATCH/DELETE を `admin/license_admin` に限定（DB RLS と統一）。staff はGETのみ。

## DB変更

ステージングDB適用済み:
- `20260519070000_fix_org_scenarios_rls.sql`
- `20260519080000_fix_is_shared_in_views.sql`

## Test plan

1. スタッフアカウントで他組織のシナリオ管理ページにアクセス → 管理データが見えないこと
2. 顧客アカウントでシナリオ詳細・公開シナリオ閲覧 → 正常に閲覧できること
3. 管理者でシナリオ作成・編集・削除 → 正常に動作すること
4. スタッフでシナリオ作成を試みる → 403 になること
5. シナリオ削除時に自組織の performance_kits のみ削除されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)