### PR TITLE
feat(ScenarioEditDialog): 保存不要の「MMQへ申請」ボタンを追加

### DIFF
--- a/src/components/modals/ScenarioEditDialogV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2.tsx
@@ -391,6 +391,7 @@ export function ScenarioEditDialogV2({ isOpen, onClose, scenarioId, onSaved, onS
   const [saveOptionsOpen, setSaveOptionsOpen] = useState(false)
   const [savePublishChoice, setSavePublishChoice] = useState<'available' | 'unavailable'>('available')
   const [submitToMMQ, setSubmitToMMQ] = useState(false)
+  const [isSubmittingToMMQ, setIsSubmittingToMMQ] = useState(false)
 
   // マスタ選択ダイアログ
   const [masterSelectOpen, setMasterSelectOpen] = useState(false)
@@ -1667,6 +1668,34 @@ export function ScenarioEditDialogV2({ isOpen, onClose, scenarioId, onSaved, onS
               >
                 <ArrowUp className="h-2.5 w-2.5" />
                 マスタ反映
+              </Button>
+            )}
+            {/* MMQへ申請ボタン（保存不要・draft マスタのみ表示） */}
+            {currentMasterId && currentScenario?.master_status === 'draft' && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-blue-600 border-blue-300 hover:bg-blue-50 hidden sm:inline-flex gap-0.5"
+                disabled={isSubmittingToMMQ}
+                onClick={async () => {
+                  setIsSubmittingToMMQ(true)
+                  try {
+                    await scenarioMasterApi.publish(currentMasterId)
+                    showToast.success('MMQへの掲載を申請しました', '審査後に掲載されます')
+                    queryClient.invalidateQueries({ queryKey: ['org-scenarios', 'list'] })
+                    queryClient.invalidateQueries({ queryKey: ['scenarios'] })
+                  } catch {
+                    showToast.error('申請に失敗しました', '時間をおいて再試行してください')
+                  } finally {
+                    setIsSubmittingToMMQ(false)
+                  }
+                }}
+              >
+                {isSubmittingToMMQ
+                  ? <RefreshCw className="h-3 w-3 animate-spin" />
+                  : <Shield className="h-3 w-3" />
+                }
+                MMQへ申請
               </Button>
             )}
             <Button


### PR DESCRIPTION
## Summary

シナリオ編集ダイアログに保存なしで MMQ 申請できるボタンを追加。

- 変更なしで保存ボタンが無効な状態でも、draft マスタのシナリオに「MMQへ申請」ボタンが表示される
- クリックで `scenarioMasterApi.publish()` を呼び出し draft → pending に遷移
- 申請後にシナリオ一覧キャッシュを invalidate して「審査中」表示に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)