### PR TITLE
fix: platform customer の予約不可・MMQ全体のシナリオ非表示を修正

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -6,7 +6,7 @@ export type ApiRole = 'admin' | 'staff' | 'customer' | 'license_admin'
 
 export type AuthUser = {
   userId: string
-  orgId: string
+  orgId: string | null  // platform customer は organization_id = NULL
   role: ApiRole
   /**
    * 元の JWT。SECURITY DEFINER な RPC で auth.uid() を必要とする場合、
@@ -59,13 +59,14 @@ export async function requireAuth(req: VercelRequest): Promise<AuthUser> {
     throw new ApiError(403, 'ユーザープロフィールが見つかりません')
   }
 
-  if (!profile.organization_id) {
+  // platform customer（role='customer' かつ organization_id=NULL）は許可
+  if (!profile.organization_id && profile.role !== 'customer') {
     throw new ApiError(403, 'このユーザーは組織に属していません')
   }
 
   return {
     userId: user.id,
-    orgId: profile.organization_id as string,
+    orgId: (profile.organization_id as string | null) ?? null,
     role: profile.role as ApiRole,
     jwt,
   }

--- a/supabase/migrations/20260519100000_fix_scenario_masters_rls_org_published.sql
+++ b/supabase/migrations/20260519100000_fix_scenario_masters_rls_org_published.sql
@@ -1,0 +1,18 @@
+-- scenario_masters RLS 追加
+--
+-- 問題: scenario_masters_select_public を DROP したことで
+--   「組織が org_status=available で公開しているシナリオのマスタ」が
+--   顧客・匿名ユーザーから見えなくなった。
+--   承認済み(approved)でなくても、組織が公開済みなら予約サイトに表示すべき。
+--
+-- 修正: org_status='available' の organization_scenarios が存在する場合、
+--   master_status を問わず閲覧可能にする。
+
+CREATE POLICY scenario_masters_select_if_org_published ON public.scenario_masters FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM public.organization_scenarios
+    WHERE scenario_master_id = scenario_masters.id
+      AND org_status = 'available'
+  )
+);


### PR DESCRIPTION
## 修正内容

### 1. platform customer が予約できない問題
`api/_lib/auth.ts` の `requireAuth` が `organization_id = NULL` のユーザーを全員弾いていた。platform customer（`role='customer'` かつ `organization_id=NULL`）は組織なしで全組織の予約が可能な設計なので、customer ロールのみ例外として許可。

### 2. MMQ全体でクインズ以外のシナリオが表示されない問題
`scenario_masters_select_public` DROP後、`master_status='approved'` のマスタしか顧客に見えなくなっていた。組織が `org_status='available'` で公開したシナリオは `master_status` を問わず閲覧可能にする `scenario_masters_select_if_org_published` ポリシーを追加。ステージングDB適用済み。

## Test plan

1. プラットフォーム顧客アカウントで他組織の公演に予約申し込みができること
2. MMQトップでクインズ以外の組織のシナリオが表示されること
3. 各組織の予約サイトで自組織のシナリオが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)