### PR TITLE
fix(auth): platform customer の orgId 型エラー修正（build 失敗を解消）

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -6,7 +6,7 @@ export type ApiRole = 'admin' | 'staff' | 'customer' | 'license_admin'
 
 export type AuthUser = {
   userId: string
-  orgId: string | null  // platform customer は organization_id = NULL
+  orgId: string  // platform customer は '' (空文字)。スタッフ系ルートは requireStaff で別途チェック
   role: ApiRole
   /**
    * 元の JWT。SECURITY DEFINER な RPC で auth.uid() を必要とする場合、
@@ -66,7 +66,7 @@ export async function requireAuth(req: VercelRequest): Promise<AuthUser> {
 
   return {
     userId: user.id,
-    orgId: (profile.organization_id as string | null) ?? null,
+    orgId: (profile.organization_id as string | null) ?? '',
     role: profile.role as ApiRole,
     jwt,
   }


### PR DESCRIPTION
## 修正

PR #224 で `orgId` を `string | null` に変更したことで全 API ファイルに型エラーが波及し Vercel build が失敗した。

`orgId` を `string` のまま維持し、`organization_id = NULL` の platform customer には空文字 `''` を返すよう変更。
- スタッフ専用ルートは `requireStaff()` で別途ブロックされるため影響なし
- customer が呼べる `api/reservations.ts` は `orgId` が空でも動作するよう既に実装済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)