### PR TITLE
fix: 貸切時間枠の平日/土日祝UIを復元

### DIFF
--- a/src/components/modals/ScenarioEditDialogV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2.tsx
@@ -761,6 +761,7 @@ export function ScenarioEditDialogV2({ isOpen, onClose, scenarioId, onSaved, onS
           available_stores: scenario.available_stores || [],
           extra_preparation_time: scenario.extra_preparation_time || undefined,
           private_booking_time_slots: scenario.private_booking_time_slots || [],
+          private_booking_time_slots_weekend: scenario.private_booking_time_slots_weekend ?? null,
           caution: '',
           characters: [],  // organization_scenariosから後で取得
         })
@@ -972,8 +973,9 @@ export function ScenarioEditDialogV2({ isOpen, onClose, scenarioId, onSaved, onS
         })),
         // 公演可能店舗
         available_stores: formData.available_stores || [],
-        // 貸切受付時間枠
+        // 貸切受付時間枠（平日/土日祝）
         private_booking_time_slots: formData.private_booking_time_slots || null,
+        private_booking_time_slots_weekend: formData.private_booking_time_slots_weekend ?? null,
         updated_at: new Date().toISOString()
       }
 

--- a/src/components/modals/ScenarioEditDialogV2/sections/BasicInfoSectionV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2/sections/BasicInfoSectionV2.tsx
@@ -326,26 +326,54 @@ export function BasicInfoSectionV2({ formData, setFormData, scenarioId, onDelete
           </div>
         </div>
 
-        {/* 貸切受付時間枠 */}
+        {/* 貸切受付時間枠（平日/土日祝） */}
         <div className="flex items-start gap-3">
           <span className="text-xs text-muted-foreground w-[72px] shrink-0 text-right pt-1.5">貸切時間枠</span>
-          <div className="flex-1">
-            <div className="flex gap-2">
-              {['朝公演', '昼公演', '夜公演'].map((slot) => {
-                const isSelected = (formData.private_booking_time_slots || []).includes(slot)
-                return (
-                  <button key={slot} type="button"
-                    onClick={() => setFormData(prev => {
-                      const currentSlots = prev.private_booking_time_slots || []
-                      return { ...prev, private_booking_time_slots: isSelected ? currentSlots.filter(s => s !== slot) : [...currentSlots, slot] }
+          <div className="flex-1 space-y-2">
+            {([
+              { label: '平日', field: 'private_booking_time_slots' as const },
+              { label: '土日・祝日', field: 'private_booking_time_slots_weekend' as const },
+            ] as const).map(({ label, field }) => {
+              const slots: string[] = field === 'private_booking_time_slots'
+                ? (formData.private_booking_time_slots || [])
+                : (formData.private_booking_time_slots_weekend || [])
+              const isEmpty = slots.length === 0
+              return (
+                <div key={field}>
+                  <p className="text-[11px] text-slate-500 font-medium mb-1">{label}</p>
+                  <div className="flex gap-2 flex-wrap">
+                    {['朝公演', '昼公演', '夜公演'].map((slot) => {
+                      const isSelected = slots.includes(slot)
+                      return (
+                        <button key={slot} type="button"
+                          onClick={() => setFormData(prev => {
+                            const current: string[] = field === 'private_booking_time_slots'
+                              ? (prev.private_booking_time_slots || [])
+                              : (prev.private_booking_time_slots_weekend || [])
+                            const next = isSelected ? current.filter(s => s !== slot) : [...current, slot]
+                            return { ...prev, [field]: next }
+                          })}
+                          className={`px-3 py-1 text-xs rounded-md border transition-colors ${isSelected ? 'bg-primary text-white border-primary' : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400'}`}>
+                          {slot}
+                        </button>
+                      )
                     })}
-                    className={`px-3 py-1 text-xs rounded-md border transition-colors ${isSelected ? 'bg-primary text-white border-primary' : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400'}`}>
-                    {slot}
-                  </button>
-                )
-              })}
-            </div>
-            <p className="text-[11px] text-muted-foreground mt-0.5">未選択で全時間枠を受付</p>
+                    {field === 'private_booking_time_slots_weekend' && !isEmpty && (
+                      <button type="button"
+                        onClick={() => setFormData(prev => ({ ...prev, private_booking_time_slots_weekend: [] }))}
+                        className="px-2 py-1 text-[11px] text-red-500 hover:text-red-700">
+                        クリア（平日と同じにする）
+                      </button>
+                    )}
+                  </div>
+                  <p className="text-[11px] text-muted-foreground mt-0.5">
+                    {field === 'private_booking_time_slots_weekend' && isEmpty
+                      ? '未選択のため平日設定を流用'
+                      : isEmpty ? '全枠受付' : ''}
+                  </p>
+                </div>
+              )
+            })}
           </div>
         </div>
 

--- a/src/components/modals/ScenarioEditModal/types.ts
+++ b/src/components/modals/ScenarioEditModal/types.ts
@@ -106,9 +106,11 @@ export interface ScenarioFormData {
   kit_count?: number
   // 追加準備時間（分）- 通常の60分に加算される
   extra_preparation_time?: number
-  // 貸切受付可能時間枠（'朝公演', '昼公演', '夜公演'）
+  // 貸切受付可能時間枠・平日（'朝公演', '昼公演', '夜公演'）
   private_booking_time_slots?: string[]
-  // 貸切受付不可時間帯（'午前', '午後', '夜'）
+  // 貸切受付可能時間枠・土日祝（未設定の場合は平日設定を流用）
+  private_booking_time_slots_weekend?: string[] | null
+  // 貸切受付不可時間帯（廃止予定）
   private_booking_blocked_slots?: string[]
   // 貸切募集期間
   booking_start_date?: string | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -346,8 +346,9 @@ export interface Scenario {
   available_stores?: string[] // 公演可能店舗ID
   gm_assignments?: Array<{ role: string; staff_id?: string; reward?: number }> // GM配置情報
   extra_preparation_time?: number // 追加準備時間（分）。通常の60分に加算される
-  private_booking_time_slots?: string[] // 貸切受付可能時間枠（'朝公演', '昼公演', '夜公演'）。未設定の場合は全て受付
-  private_booking_blocked_slots?: string[] // 貸切ブロック済み時間枠
+  private_booking_time_slots?: string[] // 貸切受付可能時間枠・平日（'朝公演', '昼公演', '夜公演'）
+  private_booking_time_slots_weekend?: string[] | null // 貸切受付可能時間枠・土日祝（未設定の場合は平日設定を流用）
+  private_booking_blocked_slots?: string[] // 貸切ブロック済み時間枠（廃止予定）
   booking_start_date?: string | null // 貸切募集開始日（YYYY-MM-DD）。NULLの場合は制限なし
   booking_end_date?: string | null // 貸切募集終了日（YYYY-MM-DD）。NULLの場合は制限なし
   individual_notice_template?: string | null // 個別お知らせ送信時に添付できる定型文


### PR DESCRIPTION
UI redesign 時に上書きされた weekday/weekend split を再実装。

🤖 Generated with [Claude Code](https://claude.com/claude-code)