### PR TITLE
fix(private-booking): slug未設定orgで貸切店舗ドロップダウンが空になる問題を修正

### DIFF
--- a/src/pages/ScenarioDetailPage/hooks/usePrivateBooking.ts
+++ b/src/pages/ScenarioDetailPage/hooks/usePrivateBooking.ts
@@ -46,7 +46,11 @@ export function usePrivateBooking({ stores, scenarioId, scenario, organizationId
     if (stores.length > 0 && !hasInitialized) {
       setHasInitialized(true)
 
-      const scenarioAvailableStores = scenario?.available_stores || scenario?.available_stores_ids
+      const rawAvailableStores = scenario?.available_stores || scenario?.available_stores_ids
+      // slug が未設定の場合、別組織のシナリオが返ることがある。
+      // その場合 available_stores は参照組織のものなので無視する（全店舗対応扱い）
+      const isCrossOrg = organizationId && scenario?.organization_id && scenario.organization_id !== organizationId
+      const scenarioAvailableStores = isCrossOrg ? [] : rawAvailableStores
       const hasScenarioStoreLimit = Array.isArray(scenarioAvailableStores) && scenarioAvailableStores.length > 0
 
       const validStores = stores.filter(s =>
@@ -158,7 +162,9 @@ export function usePrivateBooking({ stores, scenarioId, scenario, organizationId
   }, [selectedTimeSlots])
 
   const availableStores = useMemo(() => {
-    const scenarioAvailableStores = scenario?.available_stores || scenario?.available_stores_ids
+    const rawAvailableStores = scenario?.available_stores || scenario?.available_stores_ids
+    const isCrossOrg = organizationId && scenario?.organization_id && scenario.organization_id !== organizationId
+    const scenarioAvailableStores = isCrossOrg ? [] : rawAvailableStores
     const hasScenarioStoreLimit = Array.isArray(scenarioAvailableStores) && scenarioAvailableStores.length > 0
 
     return stores.filter(s =>
@@ -169,7 +175,7 @@ export function usePrivateBooking({ stores, scenarioId, scenario, organizationId
         ? scenarioAvailableStores.includes(s.id)
         : true)
     )
-  }, [scenario, stores])
+  }, [scenario, stores, organizationId])
 
   const isNextMonthDisabled = useMemo(() => {
     const today = new Date()


### PR DESCRIPTION
## 原因

aaa org の Factor に `slug = null`（未設定）のため、`/aaa/scenario/factor` にアクセスすると API が QW の Factor（slug='factor'）を返していた。

QW の Factor の `available_stores = [QW店舗IDs]` → `usePrivateBooking` で aaa の店舗が一致しない → `availableStores = []` → 貸切店舗ドロップダウンが空 → 日程スロットも「—」。

## 修正

`usePrivateBooking` で `organizationId`（URLのorg）と `scenario.organization_id`（APIが返したorg）が異なる場合（クロスオーグ取得）、`available_stores` 制限を無視して全店舗を対象にする。

## Test plan

1. `/aaa/scenario/factor?tab=private` を開く → 「aaa」店舗がドロップダウンに表示されること
2. 店舗選択後、カレンダーに営業時間ベースのスロットが表示されること
3. QW など slug が設定されている組織のシナリオは従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)