### PR TITLE
fix(customers): platform_customers_phase1 で削除されたカラムへの INSERT/UPDATE を除去

### DIFF
--- a/src/pages/CompleteProfile.tsx
+++ b/src/pages/CompleteProfile.tsx
@@ -528,8 +528,6 @@ export function CompleteProfile() {
             phone: phone.trim(),
             prefecture: prefecture,
             birth_date: birthDateForDB,
-            visit_count: 0,
-            total_spent: 0,
             organization_id: organizationId,
             notification_settings: notificationSettings,
             created_at: new Date().toISOString(),

--- a/src/pages/CustomerManagement/components/CustomerEditModal.tsx
+++ b/src/pages/CustomerManagement/components/CustomerEditModal.tsx
@@ -9,7 +9,6 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
 import { supabase } from '@/lib/supabase'
 import { useOrganization } from '@/hooks/useOrganization'
 import type { Customer } from '@/types'
@@ -32,7 +31,6 @@ export function CustomerEditModal({ isOpen, onClose, customer, onSave }: Custome
     email: '',
     phone: '',
     line_id: '',
-    notes: '',
   })
   const [saving, setSaving] = useState(false)
 
@@ -43,7 +41,6 @@ export function CustomerEditModal({ isOpen, onClose, customer, onSave }: Custome
         email: customer.email || '',
         phone: customer.phone || '',
         line_id: customer.line_id || '',
-        notes: customer.notes || '',
       })
     } else {
       setFormData({
@@ -51,7 +48,6 @@ export function CustomerEditModal({ isOpen, onClose, customer, onSave }: Custome
         email: '',
         phone: '',
         line_id: '',
-        notes: '',
       })
     }
   }, [customer, isOpen])
@@ -92,9 +88,6 @@ export function CustomerEditModal({ isOpen, onClose, customer, onSave }: Custome
             email: formData.email || null,
             phone: formData.phone || null,
             line_id: formData.line_id || null,
-            notes: formData.notes || null,
-            visit_count: 0,
-            total_spent: 0,
             organization_id: organizationId,
           })
 
@@ -159,17 +152,6 @@ export function CustomerEditModal({ isOpen, onClose, customer, onSave }: Custome
               value={formData.line_id}
               onChange={(e) => setFormData({ ...formData, line_id: e.target.value })}
               placeholder="@line_id"
-            />
-          </div>
-
-          <div>
-            <Label htmlFor="notes">メモ</Label>
-            <Textarea
-              id="notes"
-              value={formData.notes}
-              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-              placeholder="顧客に関するメモを入力..."
-              rows={4}
             />
           </div>
         </div>

--- a/src/pages/MyPage/pages/SettingsPage.tsx
+++ b/src/pages/MyPage/pages/SettingsPage.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
 import {
   Dialog,
@@ -52,7 +51,6 @@ export function SettingsPage() {
     phone: '',
     address: '',
     lineId: '',
-    notes: '',
   })
   const [emailFormData, setEmailFormData] = useState({
     newEmail: '',
@@ -168,7 +166,6 @@ export function SettingsPage() {
           phone: data.phone || '',
           address: data.address || '',
           lineId: data.line_id || '',
-          notes: '',
         })
         // 通知設定を読み込み
         if (data.notification_settings) {
@@ -251,7 +248,6 @@ export function SettingsPage() {
                 phone: formData.phone.trim() || null,
                 address: formData.address || null,
                 line_id: formData.lineId || null,
-                notes: formData.notes || null,
                 email: user.email || null,
                 organization_id: orgId,
                 updated_at: new Date().toISOString(),
@@ -267,10 +263,7 @@ export function SettingsPage() {
                 phone: formData.phone.trim() || null,
                 address: formData.address || null,
                 line_id: formData.lineId || null,
-                notes: formData.notes || null,
                 email: user.email || null,
-                visit_count: 0,
-                total_spent: 0,
                 organization_id: orgId,
               })
 
@@ -700,17 +693,6 @@ export function SettingsPage() {
                 value={formData.lineId}
                 onChange={(e) => setFormData({ ...formData, lineId: e.target.value })}
                 placeholder="@your_line_id"
-                className="mt-1"
-              />
-            </div>
-            <div>
-              <Label htmlFor="notes">備考</Label>
-              <Textarea
-                id="notes"
-                value={formData.notes}
-                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                placeholder="特記事項"
-                rows={2}
                 className="mt-1"
               />
             </div>


### PR DESCRIPTION
## Summary
- platform_customers_phase1 マイグレーション (2026-05-19) で customers から
  `notes / visit_count / total_spent / last_visit` が削除されたが、フロント
  3 ファイルで同カラムへの INSERT/UPDATE が残っており、書き込みパスが 400 で
  落ちていた。これを除去。
- 該当カラムは customer_org_stats（PK: customer_id + organization_id）に
  移行済みのため、最終的にはそちらを読み書きする UI に作り直す必要があるが、
  本 PR はクラッシュ除去に集中する。

## 変更内容
- **CompleteProfile.tsx** — INSERT から `visit_count: 0, total_spent: 0` を削除
- **MyPage/SettingsPage.tsx** — UPDATE/INSERT から `notes / visit_count / total_spent` を削除。「備考」フォーム UI も削除（保存先が無いため）
- **CustomerManagement/CustomerEditModal.tsx** — 新規作成 INSERT から `notes / visit_count / total_spent` を削除。「メモ」フォーム UI も削除（同上）

## 影響範囲（残課題）
- `CustomerRow` / `useCustomerData` の visit_count / total_spent / last_visit 表示
  は `?? 0` フォールバックで動くが値は常に 0 表示。per-org 集計の正しい
  表示は customer_org_stats を読みに行く別タスクとして follow-up。
- `types/index.ts` の Customer 型に optional フィールドが残るが、API は
  返さないため実害なし。型整理も follow-up。

## Test plan
- [ ] 新規ユーザーで /complete-profile に進み、プロフィール作成が成功する（既に 23502 で落ちていたケース）
- [ ] MyPage 設定ページからプロフィール（初回作成 + 既存更新）が保存できる
- [ ] CustomerManagement の「新規顧客作成」が成功する
- [ ] CustomerManagement 一覧で visit_count / total_spent が "0回 / ¥0" 表示でクラッシュしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)