### PR TITLE
fix(apiClient): allowAnon オプションで未ログイン GET を許可（シナリオ詳細 401 の本命）

### DIFF
--- a/src/lib/api/scenarioApi.ts
+++ b/src/lib/api/scenarioApi.ts
@@ -62,7 +62,12 @@ export const scenarioApi = {
   async getById(_id: string, _organizationId?: string): Promise<Scenario | null> {
     try {
       const params = new URLSearchParams({ id: _id })
-      const result = await apiClient.get<Scenario | null>(`/api/scenarios?${params}`)
+      // org_id が分かっていれば anon でも呼べるよう付与（顧客向けシナリオ詳細用）
+      if (_organizationId) params.set('org_id', _organizationId)
+      const result = await apiClient.get<Scenario | null>(
+        `/api/scenarios?${params}`,
+        { allowAnon: Boolean(_organizationId) },
+      )
       return result
     } catch (err) {
       logger.error('[scenarioApi.getById] エラー:', err)
@@ -106,7 +111,11 @@ export const scenarioApi = {
     try {
       const params = new URLSearchParams({ slug })
       if (organizationId) params.set('org_id', organizationId)
-      const result = await apiClient.get<Scenario | null>(`/api/scenarios?${params}`)
+      // org_id が分かっていれば anon でも呼べるよう許可（顧客向けシナリオ詳細用）
+      const result = await apiClient.get<Scenario | null>(
+        `/api/scenarios?${params}`,
+        { allowAnon: Boolean(organizationId) },
+      )
       return result
     } catch (err) {
       logger.error('[scenarioApi.getBySlug] エラー:', err)

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -24,16 +24,23 @@ export class ApiClientError extends Error {
  * Supabase 初期化時（_recoverAndRefresh）にも同じ問題が起きるため、
  * リクエスト前に expires_at を確認し、期限切れなら先にリフレッシュする。
  * SDK 内部のロックにより _recoverAndRefresh との競合は自動的に直列化される。
+ *
+ * allowAnon=true のとき、セッションが無くてもエラーにせず Authorization ヘッダ
+ * を付けずに返す（公開エンドポイント用）。
  */
-async function getAuthHeaders(): Promise<Record<string, string>> {
+async function getAuthHeaders(allowAnon = false): Promise<Record<string, string>> {
   const { data: { session }, error } = await supabase.auth.getSession()
-  if (error || !session) throw new ApiClientError(401, 'ログインが必要です')
+  if (error || !session) {
+    if (allowAnon) return { 'Content-Type': 'application/json' }
+    throw new ApiClientError(401, 'ログインが必要です')
+  }
 
   // トークンが期限切れ（または60秒以内に期限切れ）の場合はリフレッシュ
   const now = Math.floor(Date.now() / 1000)
   if ((session.expires_at ?? 0) < now + 60) {
     const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession()
     if (refreshError || !refreshed.session) {
+      if (allowAnon) return { 'Content-Type': 'application/json' }
       throw new ApiClientError(401, 'セッションの更新に失敗しました。再ログインしてください')
     }
     return {
@@ -48,16 +55,20 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
   }
 }
 
-async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const headers = await getAuthHeaders()
+type ApiFetchOptions = RequestInit & { allowAnon?: boolean }
+
+async function apiFetch<T>(path: string, options?: ApiFetchOptions): Promise<T> {
+  const { allowAnon, ...fetchOptions } = options ?? {}
+  const headers = await getAuthHeaders(allowAnon)
   const res = await fetch(path, {
-    ...options,
-    headers: { ...headers, ...options?.headers },
+    ...fetchOptions,
+    headers: { ...headers, ...fetchOptions.headers },
   })
 
   // 401 の場合は refreshSession() で強制リフレッシュしてリトライ。
   // getSession() のキャッシュが古い可能性があるため、必ず新トークンを取得する。
-  if (res.status === 401) {
+  // ただし allowAnon の場合は 401 が「未ログイン顧客への正当な拒否」なのでリトライしない。
+  if (res.status === 401 && !allowAnon) {
     const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession()
     if (refreshError || !refreshed.session) {
       throw new ApiClientError(401, 'セッションの更新に失敗しました。再ログインしてください')
@@ -67,8 +78,8 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
       'Content-Type': 'application/json',
     }
     const retryRes = await fetch(path, {
-      ...options,
-      headers: { ...retryHeaders, ...options?.headers },
+      ...fetchOptions,
+      headers: { ...retryHeaders, ...fetchOptions.headers },
     })
     if (!retryRes.ok) {
       const body = await retryRes.json().catch(() => ({ error: `HTTP ${retryRes.status}` }))
@@ -86,7 +97,8 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
 }
 
 export const apiClient = {
-  get: <T>(path: string) => apiFetch<T>(path),
+  get: <T>(path: string, options?: { allowAnon?: boolean }) =>
+    apiFetch<T>(path, options),
   post: <T>(path: string, body: unknown) =>
     apiFetch<T>(path, { method: 'POST', body: JSON.stringify(body) }),
   patch: <T>(path: string, body: unknown) =>


### PR DESCRIPTION
## Summary
PR #232 で API サーバー側を anon 許可にしたが **クライアント側 apiClient がそもそも未ログイン時に「ログインが必要です」を即 throw** していて、リクエストが API に届いていなかった。今回はその修正。

## 変更内容
- **`src/lib/apiClient.ts`** —
  - `getAuthHeaders(allowAnon)`: `allowAnon=true` のときセッションが無くても Content-Type だけ返してエラーにしない
  - `apiFetch(opts)`: `allowAnon: true` を受け取れるように
  - `apiClient.get(path, { allowAnon })`: 第 2 引数でオプション受領
  - 401 リトライは `!allowAnon` のときのみ（anon の 401 は「未ログイン顧客への正当な拒否」なので追加リフレッシュ不要）
- **`src/lib/api/scenarioApi.ts`** —
  - `getBySlug` / `getById`: `organizationId` が渡されていれば `org_id` クエリを付与し `allowAnon: true` で呼ぶ

## 旧パスへの影響
- ログイン済みユーザー（admin/staff/customer）: `Authorization: Bearer ...` を従来通り送る。挙動変わらず
- 引数 `organizationId` を渡していない呼び出し（管理画面など）: `allowAnon: false` のまま（旧挙動）。`organizationId` 必須にはしていないので後方互換

## Test plan
- [ ] 未ログイン状態でシナリオ詳細ページ (`/<org-slug>/scenario/<slug>`) を開けることを確認
- [ ] ログイン済みでも従来通りシナリオ詳細を開けることを確認（admin/staff/customer）
- [ ] 管理画面のシナリオ一覧（一覧/統計）が引き続き 401 を要求することを確認（anon に開放してはいない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)