### PR TITLE
fix(discord-interactions): Discordユーザーの複数組織staff兼任を許容

### DIFF
--- a/supabase/functions/discord-interactions/index.ts
+++ b/supabase/functions/discord-interactions/index.ts
@@ -137,21 +137,24 @@ async function processUnavailable(interaction: any, requestId: string) {
     const gmUserId = interaction.member?.user?.id
     const gmUserName = interaction.member?.nick || interaction.member?.user?.global_name || interaction.member?.user?.username || 'Unknown GM'
     
+    // 1 人の Discord ユーザーが複数組織で staff として登録されることを許容するため、
+    // この予約の organization_id に限定して引く（同一 discord_user_id でも組織内 1 行に絞られる）。
     let staffId = null
     let staffNameForConflict: string | null = null
     const { data: staffData } = await supabase
       .from('staff')
       .select('id, name')
       .eq('discord_user_id', gmUserId)
-      .single()
-    
+      .eq('organization_id', organizationId)
+      .maybeSingle()
+
     if (staffData) {
       staffId = staffData.id
       staffNameForConflict = staffData.name || null
     }
 
     if (!staffId) {
-      console.error('❌ Staff not found for Discord user ID:', gmUserId)
+      console.error('❌ Staff not found for Discord user ID:', gmUserId, 'org:', organizationId)
       const webhookUrl = `https://discord.com/api/v10/webhooks/${interaction.application_id}/${interaction.token}/messages/@original`
       await fetch(webhookUrl, {
         method: 'PATCH',
@@ -285,16 +288,19 @@ async function processDateSelection(interaction: any, dateIndex: number, request
     console.log('👤 GM User:', { id: gmUserId, name: gmUserName })
     
     // Discord IDからstaff_idを取得
+    // 1 人の Discord ユーザーが複数組織で staff として登録されることを許容するため、
+    // この予約の organization_id に限定して引く。
     let staffId = null
     let staffNameForConflict: string | null = null
     const { data: staffData, error: staffError } = await supabase
       .from('staff')
       .select('id, name')
       .eq('discord_user_id', gmUserId)
-      .single()
-    
+      .eq('organization_id', organizationId)
+      .maybeSingle()
+
     if (staffError || !staffData) {
-      console.error('❌ Staff not found for Discord user ID:', gmUserId, staffError)
+      console.error('❌ Staff not found for Discord user ID:', gmUserId, 'org:', organizationId, staffError)
       const webhookUrl = `https://discord.com/api/v10/webhooks/${interaction.application_id}/${interaction.token}/messages/@original`
       await fetch(webhookUrl, {
         method: 'PATCH',


### PR DESCRIPTION
## Summary
1 人の Discord ユーザーが複数組織で staff として登録されているケースで、Discord 通知のボタン応答時に「スタッフが見つかりません」エラー。原因は staff 引き当てクエリが `.single()` で全組織を横断していたため。

## 変更内容
`supabase/functions/discord-interactions/index.ts` の staff 引き当て 2 箇所：
- `processUnavailable` (line 142 付近)
- `processDateSelection` (line 293 付近)

両方とも：
```ts
.eq('discord_user_id', gmUserId)
.eq('organization_id', organizationId)   // ← 追加
.maybeSingle()                            // ← .single() から変更
```
`organizationId` は同じハンドラ内で `reservation.organization_id` から既に取れている。

3 つ目のクエリ (line 632) は `if (false && ...)` でガードされた dead code なので変更不要。

## 確認した実データ
本番 staff 重複：
| discord_user_id | rows | names | orgs |
|---|---|---|---|
| 575304486784860160 | 2 | sososo / えいきち | 2 organizations |

## デプロイ
`supabase/functions/**` の変更があるため、`.github/workflows/deploy-supabase.yml` が staging への push 時に自動で Edge Function を deploy する。

## Test plan
- [ ] staging で `discord_user_id` 重複している staff の所属組織から貸切リクエストを作る
- [ ] Discord ボタンを押して「スタッフが見つかりません」が出ないこと
- [ ] `gm_availability_responses` に対象組織の `staff_id` で行が入ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)