### PR TITLE
fix(PrivateBookingManagement): GM回答取得を 100 件チャンクに分割し PostgREST max_rows 切り詰めを回避

### DIFF
--- a/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts
@@ -142,12 +142,27 @@ async function fetchRawBookingRequests(
             .in('scenario_master_id', masterIds)
         : Promise.resolve({ data: [], error: null })
     })(),
-    reservationsList.length > 0
-      ? supabase
-          .from('gm_availability_responses')
-          .select('reservation_id, staff_id, gm_name, response_status, available_candidates, selected_candidate_index, notes, response_datetime, responded_at, updated_at, created_at, staff:staff_id(name, avatar_color)')
-          .in('reservation_id', reservationsList.map((r: any) => r.id))
-      : Promise.resolve({ data: [], error: null }),
+    // ⚠️ 一括 .in() は PostgREST の max_rows (1000) で結果が切られて貸切リクエストの
+    //    最初の方の予約しか GM 回答が UI に表示されなくなる。
+    //    予約 ID を 100 件ずつチャンク化して並列フェッチし、最後に concat する。
+    (async () => {
+      if (reservationsList.length === 0) return { data: [] as any[], error: null }
+      const ids = reservationsList.map((r: any) => r.id)
+      const chunkSize = 100
+      const chunks: string[][] = []
+      for (let i = 0; i < ids.length; i += chunkSize) chunks.push(ids.slice(i, i + chunkSize))
+      const results = await Promise.all(
+        chunks.map(chunk =>
+          supabase
+            .from('gm_availability_responses')
+            .select('reservation_id, staff_id, gm_name, response_status, available_candidates, selected_candidate_index, notes, response_datetime, responded_at, updated_at, created_at, staff:staff_id(name, avatar_color)')
+            .in('reservation_id', chunk),
+        ),
+      )
+      const firstError = results.find(r => r.error)?.error ?? null
+      const data = results.flatMap(r => r.data || [])
+      return { data, error: firstError }
+    })(),
     privateGroupIds.length > 0
       ? supabase
           .from('private_group_candidate_dates')


### PR DESCRIPTION
## Summary
貸切リクエスト管理画面で **古い予約ほど GM 回答が表示されなくなる** バグ。Discord 経由で回答済みなのに UI に出ず「未回答」のまま見える状態。

## 原因
[useBookingRequests.ts:145-149](src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts#L145-L149) が全予約に対する `gm_availability_responses` を **単一の `.in('reservation_id', [...])` クエリ**で取得していた。返却行数が PostgREST の `max_rows = 1000` 制限を超えると、`reservation_id` 昇順で前から 1000 行で切られ、後半の予約の回答が UI に反映されない。

## 確認した本番データ
- 対象 org の貸切予約 + GM 回答合計は明らかに 1000 行超
- Network タブの response 配列に問題の予約 (`ec8eaaff-...`) が **含まれていない**
- 該当行は DB 上には 9 行存在（=データは生きている）

## 変更内容
[src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts](src/pages/PrivateBookingManagement/hooks/useBookingRequests.ts)
- reservation_id を 100 件ずつにチャンク化
- 各チャンクを `Promise.all` で並列フェッチ
- 結果を `flatMap` で結合してこれまでと同じ形を返す
- エラーは最初に遭遇したものを返す

## Test plan
- [ ] 貸切リクエスト管理を開き、古い（reservation_id が後ろの方の）予約でも GM 回答が表示されること
- [ ] 一覧の表示性能が著しく劣化していないこと（並列なので体感差はないはず）
- [ ] 既存の絞り込み・タブ切り替えが従来通り動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)