### PR TITLE
fix(OrgSignup): already_in_org を親切なメッセージに分岐

### DIFF
--- a/src/pages/OrgSignup/index.tsx
+++ b/src/pages/OrgSignup/index.tsx
@@ -342,7 +342,12 @@ export default function OrgSignup() {
     } catch (err: unknown) {
       logger.error('Registration failed:', err)
       const msg = err instanceof Error ? err.message : '登録に失敗しました'
-      if (msg.includes('already registered')) {
+      if (msg.includes('already_in_org')) {
+        // ログイン中のアカウントが既に別組織に所属しているため新組織を作れない
+        setError(
+          'このアカウントは既に別の組織に所属しているため、新しい組織を作成できません。一度ログアウトしてから新規アカウントで登録してください。',
+        )
+      } else if (msg.includes('already registered')) {
         setError('このメールアドレスは既に登録されています')
       } else if (msg.includes('slug_already_exists')) {
         setError('この識別子は既に使用されています')


### PR DESCRIPTION
## Summary
`/start` で既存ログインユーザーが新組織を作ろうとすると、`claim_organization_as_admin` RPC が `already_in_org` 例外を投げ、UI には汎用の「登録に失敗しました」しか表示されず原因不明だった。

## 変更内容
[src/pages/OrgSignup/index.tsx:345-353](src/pages/OrgSignup/index.tsx#L345-L353) の catch 分岐に `already_in_org` ケースを追加し、「このアカウントは既に別の組織に所属しているため、新しい組織を作成できません。一度ログアウトしてから新規アカウントで登録してください。」と表示。

## 仕様
RPC 側のロジック ([supabase/migrations/20260516050000_add_claim_organization_as_admin_rpc.sql:43-50](supabase/migrations/20260516050000_add_claim_organization_as_admin_rpc.sql#L43-L50)) は変更しない。これは「1 アカウント = 1 組織所属」のルールを保つための設計通りの拒否なので、UI 側で誘導するだけ。

## Test plan
- [ ] 既に組織所属のアカウントで `/start` から新組織を作ろうとすると「別の組織に所属しているため…」が表示される
- [ ] それ以外のエラー（slug 重複・メアド重複等）の分岐は従来通り動く
- [ ] ログアウトして新規アカウント作成パスに進むと従来通り作成できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)