### PR TITLE
fix(GMAvailabilityCheck): max_rows 制限回避のため他GM回答取得をチャンク化

### DIFF
--- a/src/pages/GMAvailabilityCheck/hooks/useGMRequests.ts
+++ b/src/pages/GMAvailabilityCheck/hooks/useGMRequests.ts
@@ -100,14 +100,28 @@ async function fetchGMRequestsForUser(userId: string): Promise<{ requests: GMReq
   const otherGMResponses = new Set<string>()
 
   if (reservationIds.length > 0) {
-    const { data: allResponsesData } = await supabase
-      .from('gm_availability_responses')
-      .select('reservation_id, response_status, staff_id')
-      .in('reservation_id', reservationIds)
-      .neq('staff_id', staffId)
-      .in('response_status', ['available', 'all_unavailable'])
+    // ⚠️ PostgREST の max_rows (1000) 制限を回避するため、reservation_id を
+    //    100 件ずつチャンク化して並列フェッチする。
+    //    一括 .in() のままだと予約数が多いとき後半の reservation が拾えず、
+    //    「他 GM が回答済み」判定が落ちて UI 上で重複表示される（PR #235 と同パターン）。
+    const chunkSize = 100
+    const chunks: string[][] = []
+    for (let i = 0; i < reservationIds.length; i += chunkSize) {
+      chunks.push(reservationIds.slice(i, i + chunkSize))
+    }
+    const results = await Promise.all(
+      chunks.map(chunk =>
+        supabase
+          .from('gm_availability_responses')
+          .select('reservation_id, response_status, staff_id')
+          .in('reservation_id', chunk)
+          .neq('staff_id', staffId)
+          .in('response_status', ['available', 'all_unavailable']),
+      ),
+    )
+    const allResponsesData = results.flatMap(r => r.data || [])
 
-    allResponsesData?.forEach((r: any) => {
+    allResponsesData.forEach((r: any) => {
       if (r.response_status && r.response_status !== 'pending') {
         otherGMResponses.add(r.reservation_id)
       }


### PR DESCRIPTION
## Summary
PR #235（PrivateBookingManagement の `useBookingRequests`）と同じパターンの max_rows 切り詰めバグが [GMAvailabilityCheck/hooks/useGMRequests.ts](src/pages/GMAvailabilityCheck/hooks/useGMRequests.ts) にも存在していたため、予防的に修正。

## 何が起きていたか（潜在）
`useGMRequests` は「自分が抱えているリクエストに対して **他 GM が既に回答済みかどうか**」を判定するために、`gm_availability_responses` を `.in('reservation_id', [...自分の reservation 全 ID])` で取得していた。GM が抱えるリクエスト数が多いと PostgREST の `max_rows = 1000` 制限で結果が切られ、後半の reservation は「他 GM 未回答」と誤判定 → UI 上で本来出ないはずの重複バッジが出る。

## 変更内容
[src/pages/GMAvailabilityCheck/hooks/useGMRequests.ts](src/pages/GMAvailabilityCheck/hooks/useGMRequests.ts) の `.in()` クエリを、reservation_id 100 件ずつのチャンクに分割して並列フェッチ → `flatMap` で結合する形に変更。

## 関連調査
本セッションで API 化マイグレーションの弊害を audit した結果、他に検出された 3 件は：
- `CustomerBookingPage.tsx` — どこからも import されておらず dead code（修正不要）
- `PrivateBookingScenarioSelect.tsx` — 未ログインで型上 401 になりうるが、実際の貸切リクエストはログイン後にしか完遂しないので実害薄（要件次第で別 PR）
- `useAnnualAnalysis.ts` — `.range()` 二重ループで全件取得しており実は正しい実装（audit 誤検出）

## Test plan
- [ ] GM 可否確認ページを開いて、抱えているリクエストが多い GM でも表示崩れがないこと
- [ ] 他 GM 回答済みバッジの表示が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)