### PR TITLE
fix(CompleteProfile): ログアウトボタンを scope:'local' + try/catch で確実に遷移させる

### DIFF
--- a/src/pages/CompleteProfile.tsx
+++ b/src/pages/CompleteProfile.tsx
@@ -852,7 +852,13 @@ export function CompleteProfile() {
             <Button
               type="button"
               onClick={async () => {
-                await supabase.auth.signOut()
+                // scope:'local' でローカルセッションだけクリア（OAuth refresh token の revoke で
+                // ハングする/エラーを投げるケースがあり、その場合に遷移しなくなるのを避ける）。
+                try {
+                  await supabase.auth.signOut({ scope: 'local' })
+                } catch (err) {
+                  logger.warn('signOut error (continuing anyway):', err)
+                }
                 sessionStorage.removeItem('oauth_mode')
                 navigate('/login', { replace: true })
               }}
@@ -1135,7 +1141,13 @@ export function CompleteProfile() {
                 <button
                   type="button"
                   onClick={async () => {
-                    await supabase.auth.signOut()
+                    // scope:'local' でローカルセッションだけクリア（OAuth refresh token の revoke で
+                    // ハングする/エラーを投げるケースがあり、その場合に遷移しなくなるのを避ける）。
+                    try {
+                      await supabase.auth.signOut({ scope: 'local' })
+                    } catch (err) {
+                      logger.warn('signOut error (continuing anyway):', err)
+                    }
                     window.location.href = '/'
                   }}
                   className="text-xs text-gray-400 hover:text-gray-600 underline"


### PR DESCRIPTION
## Summary
Gmail OAuth ログイン直後、CompleteProfile（アカウント設定）画面の **「ログアウトしてトップページに戻る」** を押しても遷移しないバグ。「ログアウトしてログイン画面へ」も同じ脆さがある。

## 原因
[src/pages/CompleteProfile.tsx:859, 1142](src/pages/CompleteProfile.tsx#L859) の onClick：
```ts
await supabase.auth.signOut()       // ← デフォルト scope:'global'
window.location.href = '/'
```

`scope:'global'` はサーバー側にも revoke リクエストを送る。OAuth (Google) セッションで何らかの理由でサーバー call が hang する or エラーを返した場合、次行に到達せずボタンが no-op に見える。

## 修正
- `scope:'local'` に変更し、localStorage のセッション破棄だけ確実に行う（ネットワーク不要）
- try/catch で signOut エラーを握り潰し、**必ず遷移**するようにする
- 同パターンの 2 箇所（line 859「ログイン画面へ」/ line 1142「トップへ」）両方に適用

## Test plan
- [ ] Gmail OAuth で初回ログインして CompleteProfile に飛んだ後、「ログアウトしてトップページに戻る」を押すとトップに戻ること
- [ ] 「ログアウトしてログイン画面へ」を押すとログイン画面に戻ること
- [ ] 通常のメール+パスワード登録経路は従来通り動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)