### PR TITLE
fix(coupons): platform 顧客対応 — クーポンが MyPage に表示されないバグ修正

### DIFF
--- a/api/coupons.ts
+++ b/api/coupons.ts
@@ -63,19 +63,23 @@ const CUSTOMER_COUPON_WITH_CUSTOMER_FIELDS = `
   )
 `
 
-// JWT user.id から customer 行を1件取得（重複行があっても order + limit(1) で安全）
+// JWT user.id から customer 行を1件取得。
+// platform_customers_phase1 マイグレーション以降、ログイン済み顧客の customers 行は
+// organization_id = NULL（プラットフォーム共通）になっているため、user_id だけで一意に引く。
+// organizationId 引数は呼び出し側互換のため残すが使わない（customers の org フィルタは外す）。
 async function findCustomerByUserId(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   database: any,
   userId: string,
-  organizationId: string | null,
+  _organizationId: string | null,
   selectFields = 'id'
 ): Promise<Record<string, unknown> | null> {
-  let query = database.from('customers').select(selectFields).eq('user_id', userId)
-  if (organizationId) {
-    query = query.eq('organization_id', organizationId)
-  }
-  const { data } = await query.order('created_at', { ascending: true }).limit(1)
+  const { data } = await database
+    .from('customers')
+    .select(selectFields)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true })
+    .limit(1)
   return (data?.[0] as Record<string, unknown>) ?? null
 }
 


### PR DESCRIPTION
## Summary
クーポンを所持していた顧客がマイページの「クーポン」タブで自分のクーポンが見えなくなっていた。

## 原因
`platform_customers_phase1` マイグレーション以降、**ログイン済み顧客の `customers.organization_id` は NULL** にされて platform-shared になった。一方 [api/coupons.ts:74-76](api/coupons.ts#L74-L76) の `findCustomerByUserId` は `.eq('organization_id', orgId)` で絞っていたため、customers 行が見つからず（NULL != orgId）、`handleAvailable` / `handleAll` / `handleUsages` 全てが空配列を返していた。

## 修正
- `findCustomerByUserId` で **customers の org_id フィルタを除去**
- platform 顧客は 1 user_id = 1 customer 行で一意なので、user_id 単独で引いて問題なし
- 呼び出し側互換のため `organizationId` 引数は残すが unused（`_organizationId` にリネーム）
- **`customer_coupons.organization_id` 側のフィルタ（= 発行組織で絞る）は影響なし**、そのまま維持

## 関係性
[supabase/migrations/20260519000000_platform_customers_phase1.sql](supabase/migrations/20260519000000_platform_customers_phase1.sql) と同じ系統の積み残し対応（PR #231 の延長）。

## Test plan
- [ ] クーポンを持っているログイン済み顧客で MyPage → クーポンタブを開き、クーポンが表示されること
- [ ] 予約画面で「利用可能クーポン」も表示されること
- [ ] クーポン使用履歴（usages）も表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)