### PR TITLE
fix(api): platform customer 対応の防御的修正 (dead endpoints 2件)

### DIFF
--- a/api/coupons.ts
+++ b/api/coupons.ts
@@ -224,14 +224,17 @@ async function handleAvailable(
   const customer = await findCustomerByUserId(database, userId, organizationId)
   if (!customer) return res.status(200).json([])
 
-  const { data, error } = await database
+  // platform customer (organizationId='') では .eq('organization_id', '') が一致しないため
+  // org フィルタを条件付きに（customer_id 一致で本人特定済み）。
+  let availableQuery = database
     .from('customer_coupons')
     .select(CUSTOMER_COUPON_FIELDS)
     .eq('customer_id', customer.id)
-    .eq('organization_id', organizationId)
     .eq('status', 'active')
     .gt('uses_remaining', 0)
     .order('created_at', { ascending: false })
+  if (organizationId) availableQuery = availableQuery.eq('organization_id', organizationId)
+  const { data, error } = await availableQuery
 
   if (error) {
     console.error('[coupons:available] DB error:', error)

--- a/api/reservations.ts
+++ b/api/reservations.ts
@@ -248,12 +248,13 @@ async function handleGetAvailability(req: VercelRequest, res: VercelResponse, or
   }
 
   // マルチテナント境界: schedule_event が自組織のものか
-  const { data: ev, error: evError } = await db
+  // platform customer (orgId='') では org 一致を要求しない（schedule_event_id 単独で検証）
+  let evQ = db
     .from('schedule_events')
     .select('id')
     .eq('id', scheduleEventId)
-    .eq('organization_id', orgId)
-    .maybeSingle()
+  if (orgId) evQ = evQ.eq('organization_id', orgId)
+  const { data: ev, error: evError } = await evQ.maybeSingle()
   if (evError) {
     console.error('[reservations:availability] schedule_events check error:', evError)
     return res.status(500).json({ error: 'データ取得に失敗しました', detail: evError.message })


### PR DESCRIPTION
## Summary
PR #239〜#241 の audit で見つかった、**現状は呼び出し元のない 2 つのエンドポイント** にも同じ platform customer 対応を予防的に入れる。dead だが将来呼び出されたときに同じバグを踏まないようにしておく。

## 変更内容

### `api/coupons.ts` — `handleAvailable` (`?type=available`)
`customer_coupons` の `.eq('organization_id', organizationId)` を **`organizationId` が空でないときのみ適用** する条件付きに変更。customer_id 一致で本人特定済みなので org フィルタ無しでも安全。

### `api/reservations.ts` — `handleGetAvailability` (`?type=availability`)
schedule_events の org 検証 `.eq('organization_id', orgId)` を **`orgId` が空でないときのみ適用** する条件付きに変更。reservation_summary 自体は schedule_event_id でのみ絞っているので影響なし。

## なぜ dead か
- `getAvailableCoupons` (`src/lib/api/couponApi.ts:45`) は定義のみで src/ のどこからも import されていない
- `reservationApi.getAvailability` (`src/lib/reservationApi.ts:664`) も同様

## Test plan
両エンドポイントが未使用なので、フロントの動作確認では検出されない。CI の typecheck/lint だけで OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)