### PR TITLE
feat(private-booking): 確定カードに承認情報・選択強調表示、二度押し防止

### DIFF
--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -53,6 +53,8 @@ interface BookingRequest {
   scenario_player_count_range?: { min: number; max: number } | null
   status: string
   created_at: string
+  approver_name?: string
+  approved_at?: string
   notes?: string
   invite_code?: string
   candidate_datetimes?: {
@@ -321,7 +323,9 @@ export const BookingRequestCard = ({
               {request.candidate_datetimes?.candidates?.map((candidate) => {
                 const isGMAvailable = request.gm_responses?.some(r => isGmAvailableForCandidate(r, candidate.order - 1))
                 const availableGMs = request.gm_responses?.filter(r => isGmAvailableForCandidate(r, candidate.order - 1)) ?? []
-                const isConfirmed = request.status === 'confirmed'
+                const isReservationConfirmed = request.status === 'confirmed'
+                const isThisCandidateChosen = candidate.status === 'confirmed'
+                const isThisDimmed = isReservationConfirmed && !isThisCandidateChosen
                 const isThisSelected = selectedCandidateOrder === candidate.order
                 const clickable = !!onSelectCandidate
 
@@ -337,7 +341,11 @@ export const BookingRequestCard = ({
                         clickable ? 'cursor-pointer' : '',
                         isThisSelected
                           ? 'border-purple-400 bg-purple-50 rounded-b-none'
-                          : isConfirmed && isGMAvailable
+                          : isReservationConfirmed && isThisCandidateChosen
+                          ? 'border-green-400 bg-green-50 ring-2 ring-green-300 font-medium'
+                          : isThisDimmed
+                          ? 'border-gray-200 bg-gray-50/60 text-gray-400 opacity-60'
+                          : isReservationConfirmed && isGMAvailable
                           ? 'border-green-200 bg-green-50'
                           : clickable
                           ? 'border-gray-200 bg-gray-50 hover:border-purple-300 hover:bg-purple-50/40'
@@ -346,13 +354,20 @@ export const BookingRequestCard = ({
                     >
                       {/* 1行目：アイコン + 日付 + 時間 + 店舗バッジ */}
                       <div className="flex items-center gap-2 flex-wrap">
-                        {isConfirmed && isGMAvailable
+                        {isReservationConfirmed && isThisCandidateChosen
+                          ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
+                          : isThisDimmed
+                          ? <XCircle className="w-4 h-4 text-gray-300 shrink-0" />
+                          : isReservationConfirmed && isGMAvailable
                           ? <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0" />
                           : isThisSelected
                           ? <CheckCircle2 className="w-4 h-4 text-purple-500 shrink-0" />
                           : <CircleDashed className="w-4 h-4 text-gray-400 shrink-0" />}
-                        <span className="font-medium">{formatDate(candidate.date)}</span>
+                        <span className={cn('font-medium', isThisDimmed && 'line-through')}>{formatDate(candidate.date)}</span>
                         <span className="text-muted-foreground text-xs whitespace-nowrap">{candidate.timeSlot} {candidate.startTime}–{candidate.endTime}</span>
+                        {isReservationConfirmed && isThisCandidateChosen && (
+                          <span className="text-xs px-1.5 py-0.5 rounded bg-green-600 text-white font-semibold">確定</span>
+                        )}
                         {availableStores && availableStores.length === 0 && (
                           <span className="text-xs text-red-500">空き店舗なし</span>
                         )}
@@ -396,9 +411,28 @@ export const BookingRequestCard = ({
 
           {/* ── 確定済み店舗 ── */}
           {request.candidate_datetimes?.confirmedStore && (
-            <div className="p-3 rounded border bg-purple-50 border-purple-200 text-sm">
-              <span className="text-purple-800">開催店舗: </span>
-              <span className="text-purple-900 font-medium">{request.candidate_datetimes.confirmedStore.storeName}</span>
+            <div className="p-3 rounded border bg-purple-50 border-purple-200 text-sm space-y-1">
+              <div>
+                <span className="text-purple-800">開催店舗: </span>
+                <span className="text-purple-900 font-medium">{request.candidate_datetimes.confirmedStore.storeName}</span>
+              </div>
+              {request.status === 'confirmed' && (request.approver_name || request.approved_at) && (
+                <div className="text-xs text-purple-700">
+                  {request.approver_name && (
+                    <>
+                      <span>承認者: </span>
+                      <span className="font-medium">{request.approver_name}</span>
+                    </>
+                  )}
+                  {request.approver_name && request.approved_at && <span className="mx-1">・</span>}
+                  {request.approved_at && (
+                    <>
+                      <span>承認日: </span>
+                      <span className="font-medium">{formatDate(request.approved_at)}</span>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
           )}
 

--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -25,7 +25,7 @@ function addMinutesToTime(time: string, minutes: number): string {
 }
 
 interface UseBookingApprovalProps {
-  onSuccess: () => void
+  onSuccess: () => void | Promise<void>
 }
 
 /**
@@ -244,7 +244,9 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
       logger.log('貸切承認RPC成功:', { requestId, scheduleEventId })
 
       // ✅ RPC成功後すぐに画面を更新（通知・メール・ログはバックグラウンドで実行）
-      onSuccess()
+      // onSuccess の完了（一覧再フェッチなど）まで await して、submitting=true を保つ。
+      // これにより承認ボタンの再活性化前にリストが最新化され、二度押しでの重複承認を防ぐ。
+      await onSuccess()
 
       // バックグラウンド処理（awaitしない）
       ;(async () => {

--- a/src/pages/PrivateBookingManagement/hooks/usePrivateBookingData.ts
+++ b/src/pages/PrivateBookingManagement/hooks/usePrivateBookingData.ts
@@ -46,6 +46,10 @@ export interface PrivateBookingRequest {
   scenario_player_count_range?: { min: number; max: number } | null
   notes: string
   status: string
+  /** 承認者（confirmed_by → staff.name） */
+  approver_name?: string
+  /** 承認日時（confirmed のときに updated_at を流用） */
+  approved_at?: string
   gm_responses?: Array<{
     staff_id?: string
     gm_name?: string
@@ -123,7 +127,8 @@ export const usePrivateBookingData = ({ userId, userRole, activeTab }: UsePrivat
         .select(`
           *,
           scenario_masters:scenario_master_id(title),
-          customers:customer_id(name, phone)
+          customers:customer_id(name, phone),
+          confirmer:confirmed_by(name)
         `)
         .eq('reservation_source', RESERVATION_SOURCE.WEB_PRIVATE)
         .order('created_at', { ascending: false })
@@ -186,6 +191,8 @@ export const usePrivateBookingData = ({ userId, userRole, activeTab }: UsePrivat
         customer_notes?: string
         status: string
         created_at: string
+        updated_at?: string
+        confirmer?: { name: string } | null
       }
 
       const formattedData: PrivateBookingRequest[] = await Promise.all(
@@ -231,6 +238,8 @@ export const usePrivateBookingData = ({ userId, userRole, activeTab }: UsePrivat
             participant_count: req.participant_count || 0,
             notes: req.customer_notes || '',
             status: req.status,
+            approver_name: req.confirmer?.name,
+            approved_at: req.status === 'confirmed' ? req.updated_at : undefined,
             gm_responses: transformedGMResponses,
             created_at: req.created_at
           }

--- a/src/pages/PrivateBookingManagement/index.tsx
+++ b/src/pages/PrivateBookingManagement/index.tsx
@@ -99,7 +99,7 @@ export function PrivateBookingManagement() {
       setSelectedSubGmId('')
       setSelectedStoreId('')
       setSelectedCandidateOrder(null)
-      loadRequests()
+      return loadRequests()
     }
   })
 


### PR DESCRIPTION
## Summary

- 確定済み貸切カードで **選ばれた候補日時を視覚的に強調**（緑 ring + 「確定」バッジ）、選ばれなかった候補は **dim + 取り消し線** で区別
- 確定済み店舗ブロックに **承認者名 + 承認日** を表示（`confirmed_by` → `staff.name` を JOIN、`updated_at` を承認日として流用）
- 承認後 `onSuccess`（一覧再フェッチ）を await してから `submitting=false` に。**承認ボタンの再活性化前にリストが最新化**されるので、ユーザーが「同じカードがまだ pending に見える → もう一度押す」問題を防ぐ

## 変更内容

| ファイル | 変更 |
|---|---|
| `usePrivateBookingData.ts` | SELECT に `confirmer:confirmed_by(name)` JOIN 追加、`PrivateBookingRequest` に `approver_name` / `approved_at` 追加 |
| `useBookingApproval.ts` | `onSuccess` シグネチャを `() => void \| Promise<void>` に拡張し、`await onSuccess()` |
| `index.tsx` | `onSuccess` から `loadRequests()` を `return` して await 可能に |
| `BookingRequestCard.tsx` | 候補単位の選択判定（`candidate.status === 'confirmed'`）、承認者情報の表示 |

## Test plan

- [ ] 確定済み貸切カードで、承認時に選ばれた候補日時のみ強調表示（緑バッジ「確定」）
- [ ] 選ばれなかった候補日が dim + 取り消し線で表示
- [ ] 確定済み店舗ブロックに「承認者: えいきち ・ 承認日: 2026年5月21日(木)」のような行が出る
- [ ] 未処理タブで貸切承認 → ボタン押下後、リストが更新されるまで承認ボタンが disabled に戻らないこと
- [ ] 既存の未確定（pending_gm 等）カードの見た目に変化がないこと
- [ ] 候補日選択 → 承認モードのインライン UI が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)