### PR TITLE
fix(private-booking): 承認者・承認日時を常に表示・JOIN明示化

### DIFF
--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -9,6 +9,7 @@ import {
 import { StatusBadge } from './StatusBadge'
 import {
   formatDate,
+  formatDateTime,
   getElapsedTime,
   getElapsedDays,
   getCardClassName,
@@ -416,21 +417,13 @@ export const BookingRequestCard = ({
                 <span className="text-purple-800">開催店舗: </span>
                 <span className="text-purple-900 font-medium">{request.candidate_datetimes.confirmedStore.storeName}</span>
               </div>
-              {request.status === 'confirmed' && (request.approver_name || request.approved_at) && (
+              {request.status === 'confirmed' && (
                 <div className="text-xs text-purple-700">
-                  {request.approver_name && (
-                    <>
-                      <span>承認者: </span>
-                      <span className="font-medium">{request.approver_name}</span>
-                    </>
-                  )}
-                  {request.approver_name && request.approved_at && <span className="mx-1">・</span>}
-                  {request.approved_at && (
-                    <>
-                      <span>承認日: </span>
-                      <span className="font-medium">{formatDate(request.approved_at)}</span>
-                    </>
-                  )}
+                  <span>承認者: </span>
+                  <span className="font-medium">{request.approver_name || '不明'}</span>
+                  <span className="mx-1">・</span>
+                  <span>承認日時: </span>
+                  <span className="font-medium">{request.approved_at ? formatDateTime(request.approved_at) : '不明'}</span>
                 </div>
               )}
             </div>

--- a/src/pages/PrivateBookingManagement/hooks/usePrivateBookingData.ts
+++ b/src/pages/PrivateBookingManagement/hooks/usePrivateBookingData.ts
@@ -128,7 +128,7 @@ export const usePrivateBookingData = ({ userId, userRole, activeTab }: UsePrivat
           *,
           scenario_masters:scenario_master_id(title),
           customers:customer_id(name, phone),
-          confirmer:confirmed_by(name)
+          confirmer:staff!reservations_confirmed_by_fkey(name)
         `)
         .eq('reservation_source', RESERVATION_SOURCE.WEB_PRIVATE)
         .order('created_at', { ascending: false })


### PR DESCRIPTION
## Summary

PR #243 で入れた「承認者 / 承認日」表示が実際の確定カードに出ないバグへの追加修正。

- **常に表示**: `status === 'confirmed'` なら承認情報ブロックを常に出す。値が未取得の場合は「不明」と表示してデータ欠落を即可視化（条件式で隠さない）
- **時刻も表示**: 「承認日 2026年5月21日(木)」→「承認日時 2026/5/21 1:37」に変更（`formatDate` → `formatDateTime`）
- **JOIN明示化**: PostgREST embed を column-based の `confirmer:confirmed_by(name)` から FK 制約名指定の `confirmer:staff!reservations_confirmed_by_fkey(name)` へ変更。relation 解決ミスで confirmer が undefined になる事故を防ぐ。

## Test plan

- [ ] 確定済みカードに「承認者: えいきち ・ 承認日時: 2026/5/21 1:37」のような行が表示される
- [ ] confirmed_by が NULL の旧データに対して「承認者: 不明」と表示される
- [ ] 既存の未確定（pending_gm 等）カードには承認情報行が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)