### PR TITLE
fix(check-performance-cancellation): 中止メール送信を env フォールバックで防御化

### DIFF
--- a/supabase/functions/check-performance-cancellation/index.ts
+++ b/supabase/functions/check-performance-cancellation/index.ts
@@ -234,7 +234,21 @@ async function sendCancellationNotifications(
   }
 
   // 4. 各予約者にメール送信（APIキーが設定されている場合のみ）
-  if (reservations && reservations.length > 0 && emailSettings.resendApiKey) {
+  // ⚠️ getEmailSettings は内部で env フォールバックしているが、戻り値が null のときに
+  //    短絡してしまうケースの保険として、ここでも env を直接フォールバック確認する。
+  //    send-cancellation-confirmation と同じ二重フォールバック方式に揃える。
+  const resolvedResendApiKey = emailSettings.resendApiKey || Deno.env.get('RESEND_API_KEY') || null
+  if (!resolvedResendApiKey) {
+    console.error('❌ Resend API キー未設定のため中止メール送信をスキップ:', {
+      eventId: event.event_id,
+      reservationsCount: reservations?.length || 0,
+      envHasKey: !!Deno.env.get('RESEND_API_KEY'),
+      settingsHasKey: !!emailSettings.resendApiKey
+    })
+  }
+  if (reservations && reservations.length > 0 && resolvedResendApiKey) {
+    // emailSettings を mutating せず、resolvedResendApiKey で上書きしたコピーを渡す
+    const effectiveEmailSettings = { ...emailSettings, resendApiKey: resolvedResendApiKey }
     for (const reservation of reservations) {
       // メールアドレスを取得（customer_email → スタッフテーブルからの検索）
       let emailToSend = reservation.customer_email
@@ -253,7 +267,7 @@ async function sendCancellationNotifications(
 
       try {
         await sendCancellationEmail(
-          emailSettings,
+          effectiveEmailSettings,
           emailToSend,
           reservation.customer_name || 'お客様',
           event,


### PR DESCRIPTION
## Summary

cron-job.org の 23:59 中止判定トリガーから走る `check-performance-cancellation` Edge Function の **中止メール送信パスが過去一度も成功していなかった** バグの修正。

email_logs に `email_type = 'performance_cancellation'` が **0 件** あったことから、`if (emailSettings.resendApiKey)` 条件で短絡し続けていたと推定。`send-cancellation-confirmation` 側は `emailSettings.resendApiKey || Deno.env.get('RESEND_API_KEY')` の二重フォールバックで救われていたので、同じパターンに揃えた。

スキップ時には `envHasKey` / `settingsHasKey` の診断ログを出すようにしたので、次回 23:59 トリガー後に Edge Function ログを見れば原因が一発で分かる。

## 影響範囲

- 23:59 前日判定 で人数未達中止になった予約者へのメールが届いてなかった事故の再発を防止
- 例: 5/20 23:59 中止「季節のマーダーミステリー／アニクシィ」5/21 13:30 → 紅露紘史さんへの中止メールが未送信だった件は別途手動でリカバリ送信済み

## Test plan

- [ ] 次回 23:59 JST cron-job.org トリガーで `email_type='performance_cancellation'` の email_logs 行が作られ status='sent' になること
- [ ] env に `RESEND_API_KEY` が無い場合（staging 等）に診断ログが出てスキップされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)