### PR TITLE
fix(schedule): 公演ダイアログ保存後にページ最上部にスクロールする問題を修正

### DIFF
--- a/src/components/schedule/PerformanceModal.tsx
+++ b/src/components/schedule/PerformanceModal.tsx
@@ -764,7 +764,14 @@ export function PerformanceModal({
         onClose()
       }
     }}>
-      <DialogContent size="md" className="h-[85vh] sm:h-[80vh] max-w-[480px] overflow-hidden flex flex-col p-0 gap-0">
+      <DialogContent
+        size="md"
+        className="h-[85vh] sm:h-[80vh] max-w-[480px] overflow-hidden flex flex-col p-0 gap-0"
+        // 保存後、events 再フェッチでトリガー要素が一時的に消えると Radix の focus
+        // 復元先がなくなり body にフォールバックしてページ最上部までスクロールするため、
+        // close 時の auto-focus 復元を無効化する。
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         <DialogHeader className="px-2 sm:px-4 py-1.5 sm:py-2 border-b shrink-0">
           <div className="flex items-center justify-between gap-2">
             <DialogTitle className="text-sm sm:text-base">{modalTitle}</DialogTitle>


### PR DESCRIPTION
## Summary

スケジュールページで公演ダイアログの保存を押すと、ページ最上部までスクロールしてしまう問題の修正。

## 原因

Radix UI Dialog は close 時に「ダイアログを開いたトリガー要素」へ focus を戻すが、保存処理で events 再フェッチが走るとトリガー要素（クリックしたセル）が一瞬 unmount → focus 復元先が消失 → body にフォールバック → ブラウザが body の位置（最上部）までスクロール、という流れ。

## 修正

`PerformanceModal` の `DialogContent` に `onCloseAutoFocus={(e) => e.preventDefault()}` を渡して close 時の auto-focus 復元を無効化。これでスクロール位置が維持される。

## Test plan

- [ ] スケジュール画面で中ほどの日付の公演ダイアログを開く → 保存 → スクロール位置が維持される
- [ ] 新規公演追加でも同様にスクロール位置が維持される
- [ ] ダイアログを ESC / × / バックドロップで閉じた場合の挙動も問題ない（focus が戻らないがスクロール位置維持優先）

🤖 Generated with [Claude Code](https://claude.com/claude-code)