### PR TITLE
fix(scroll): ダイアログ query param 追加で最上部にスクロールする問題を修正

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -197,6 +197,22 @@ function BookingShellLazyFallback() {
 // - 初回マウント（リロード・新規タブの直リンク）: トップへ飛ばさない
 //   → さもないと navType が POP 以外になり、scrollTo(0,0) が sessionStorage 復元より後に効いて潰す
 // - それ以外の同一タブ内のパス変更（PUSH/REPLACE）: トップへ
+//
+// ⚠️ ダイアログ状態用の query param（event=xxx 等）はナビゲーションと見なさない。
+//    setSearchParams で ?event=xxx を付けるとここで scroll=0 が走り、スケジュール
+//    画面で公演ダイアログを開いた瞬間に最上部に飛ぶ問題があったため。
+const DIALOG_QUERY_PARAMS = ['event']
+
+function stripDialogParams(search: string): string {
+  if (!search) return ''
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+  for (const key of DIALOG_QUERY_PARAMS) {
+    params.delete(key)
+  }
+  const result = params.toString()
+  return result ? `?${result}` : ''
+}
+
 function ScrollToTop() {
   const { pathname, search } = useLocation()
   const navType = useNavigationType()
@@ -204,7 +220,8 @@ function ScrollToTop() {
 
   useLayoutEffect(() => {
     // pathname + search で同一ページ判定（tab切替もここで検出）
-    const currentKey = `${pathname}${search}`
+    // ただしダイアログ系の query param は除外して比較する
+    const currentKey = `${pathname}${stripDialogParams(search)}`
     if (navType === 'POP') {
       prevKeyRef.current = currentKey
       return


### PR DESCRIPTION
## Summary

スケジュール画面で公演ダイアログを開いた瞬間にスクロールが最上部に戻る問題の **真の修正**。PR #249 (`onCloseAutoFocus`) は close 時のみ対象で、open 時の現象は別原因だった。

## 原因

`AppRoot.tsx` の `ScrollToTop` コンポーネントが `pathname + search` 全体で navigation を検知。`useEventOperations.handleEditPerformance` が `setSearchParams` で `?event=xxx` を付けると **「ページ遷移」と誤検知** して `container.scrollTop = 0` を発火。

## 修正

ダイアログ状態専用 query param リスト `DIALOG_QUERY_PARAMS` (`['event']`) を導入し、これらを除外して navigation 判定する。今後ダイアログ用 query param を増やす場合はリストに追記する形で拡張可能。

## Test plan

- [ ] スケジュール画面の中ほどの公演をクリック → ダイアログが開く → スクロール位置維持される
- [ ] ダイアログ保存 → 閉じる → スクロール位置維持される
- [ ] 別ページへの遷移 / 戻る (POP) は従来通り適切にスクロール処理される
- [ ] タブ切替（tab=... 等のクエリ変更）は従来通りトップへスクロール

🤖 Generated with [Claude Code](https://claude.com/claude-code)