### PR TITLE
fix: platform customer を組織横断で予約可能にする

### DIFF
--- a/api/reservations.ts
+++ b/api/reservations.ts
@@ -344,8 +344,14 @@ async function handleCreate(req: VercelRequest, res: VercelResponse, user: AuthU
     return res.status(404).json({ error: 'customer が見つかりません' })
   }
   // platform customer (organization_id = NULL) は全組織で利用可
-  // guest customer は自組織のみ
-  if (cust.organization_id !== null && cust.organization_id !== user.orgId) {
+  // 本人 (cust.user_id === user.userId) は自分の customer 行で全組織のイベントに予約可
+  //   ※ サインアップ経路の差で customers.organization_id が org に張り付いた行があるため
+  // それ以外（guest customer 等）は自組織のみ
+  if (
+    cust.organization_id !== null &&
+    cust.organization_id !== user.orgId &&
+    cust.user_id !== user.userId
+  ) {
     return res.status(403).json({ error: '他組織の customer は指定できません' })
   }
   // 顧客ロールの場合は自分自身の customers 行のみ作成可

--- a/src/pages/CompleteProfile.tsx
+++ b/src/pages/CompleteProfile.tsx
@@ -486,6 +486,11 @@ export function CompleteProfile() {
         campaign_notifications: acceptNewsletter
       }
 
+      // customers.organization_id は platform customer (role='customer') では NULL に固定する。
+      // 予約は org をまたいで可能なので、customer 行は組織非依存にする必要がある。
+      // staff/admin が自分用に customer 行を作る場合は所属組織に紐付ける。
+      const customerOrganizationId = role === 'customer' ? null : organizationId
+
       const customerProfilePayload = {
         name: name.trim(),
         nickname: nickname.trim() || null,
@@ -493,7 +498,7 @@ export function CompleteProfile() {
         phone: phone.trim(),
         prefecture: prefecture,
         birth_date: birthDateForDB,
-        organization_id: organizationId,
+        organization_id: customerOrganizationId,
         notification_settings: notificationSettings,
         updated_at: new Date().toISOString()
       }
@@ -528,7 +533,7 @@ export function CompleteProfile() {
             phone: phone.trim(),
             prefecture: prefecture,
             birth_date: birthDateForDB,
-            organization_id: organizationId,
+            organization_id: customerOrganizationId,
             notification_settings: notificationSettings,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString()

--- a/supabase/migrations/20260521030000_backfill_platform_customers_org_null.sql
+++ b/supabase/migrations/20260521030000_backfill_platform_customers_org_null.sql
@@ -1,0 +1,20 @@
+-- platform customer (role='customer' で auth ユーザー紐付け済み) の
+-- customers.organization_id を NULL に統一する。
+--
+-- 背景:
+--   customers.organization_id が org に張り付いた行があると、
+--   その customer 本人が別組織のイベントに予約しようとした際に
+--   api/reservations.ts の境界チェックで「他組織の customer は指定できません」と拒否される。
+--   予約は customer 側の所属組織と独立であるべき (platform customer モデル)。
+--
+-- 対象: user_id IS NOT NULL かつ organization_id IS NOT NULL かつ users.role = 'customer'
+-- staff/admin が自分用に作った customer 行 (users.role != 'customer') は影響を受けない。
+
+UPDATE public.customers AS c
+SET organization_id = NULL,
+    updated_at = NOW()
+FROM public.users AS u
+WHERE c.user_id = u.id
+  AND c.user_id IS NOT NULL
+  AND c.organization_id IS NOT NULL
+  AND u.role = 'customer';


### PR DESCRIPTION
## 背景

問い合わせメール (5/20 22:49 kaito19900404@yahoo.co.jp): 「他組織の customer は指定できません」と表示されて予約操作が完了しない。

### 原因

- \`public.users.organization_id = NULL\` (platform customer) のユーザーが
- \`public.customers.organization_id = MMQ org\` (org に張り付いた行) を持っていると
- \`api/reservations.ts:348\` の境界チェック \`cust.organization_id !== null && cust.organization_id !== user.orgId\` で 403

本番DB調査: platform user × org=set のバグ状態が **9 行** 存在 (admin の 2 行は handle_new_user trigger による正常な作成なので除外)。

## 修正

### A. \`api/reservations.ts\` (即時救済)
本人 (\`cust.user_id === user.userId\`) なら org に関わらず予約を通す。

### B. \`src/pages/CompleteProfile.tsx\` (根本)
\`role='customer'\` の customers 行は \`organization_id = NULL\` で作成する。
staff/admin が自分用に作る場合は所属組織に紐付ける (現状維持)。

### C. \`supabase/migrations/20260521030000_backfill_platform_customers_org_null.sql\`
既存の 9 行を NULL に backfill。

## 影響範囲

- 予約作成パス: \`user_id\` 一致で通すため、これまで弾かれていた case が通る (本人が自分の customer 行を使う場合のみ)
- 新規 signup: customers 行が org=NULL で作成される (platform customer モデル)
- 既存データ: 9 行が org=NULL に。これらの行を参照する staff 側クエリは直近 PR (#239-242, #248) で org=NULL 対応済み

## Test plan

- [ ] kaito19900404 が予約完了できることを確認 (staging 適用後)
- [ ] 新規 customer signup → CompleteProfile → 予約のフローで organization_id=NULL になることを確認
- [ ] 既存 platform customer の予約 / 検索 / もぎる等が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)