### PR TITLE
fix(private-booking): 却下時のメッセージとメールを1テンプレートに統合

### DIFF
--- a/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
+++ b/src/pages/PrivateBookingManagement/hooks/useBookingApproval.ts
@@ -461,16 +461,59 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
         
         // 却下通知を送信
         {
-          // システムメッセージ設定を取得
-          const { data: settings } = await supabase
-            .from('global_settings')
-            .select(GLOBAL_SETTINGS_MSG_SELECT.BOOKING_REJECTED)
-            .eq('organization_id', organizationId)
-            .maybeSingle()
-          
-          const title = settings?.system_msg_booking_rejected_title || '日程の再調整をお願いします'
-          const body = settings?.system_msg_booking_rejected_body || '店舗の都合がつかず、ご希望の日程でのご予約をお受けすることができませんでした。お手数ですが、別の候補日を選択のうえ再度お申し込みください。'
-          
+          // 候補日時を取得（メール・チャットメッセージ両方で使用）
+          const candidateDates = reservation?.candidate_datetimes?.candidates?.map((c: any) => ({
+            date: c.date,
+            startTime: c.startTime,
+            endTime: c.endTime
+          })) || []
+
+          // 却下メール（貸切専用）を送信し、その内容と同じ文章をチャットにも投稿する。
+          // → email_settings.private_rejection_template を取得して変数置換し、グループチャットの body として共有。
+          const rejectMailCustomerJoined = joinedCustomerFromReservation(reservation?.customers)
+          const rejectCustomerEmail = rejectMailCustomerJoined?.email || reservation?.customer_email || selectedRequest?.customer_email
+          const rejectCustomerName = rejectMailCustomerJoined?.name || reservation?.customer_name || selectedRequest?.customer_name
+
+          // store_id から email_settings.private_rejection_template を取得
+          const storeId = reservation?.store_id as string | undefined
+          let rejectionTemplate = ''
+          let companyName = ''
+          if (storeId) {
+            const { data: emailSettings } = await supabase
+              .from('email_settings')
+              .select('private_rejection_template, company_name')
+              .eq('store_id', storeId)
+              .maybeSingle()
+            rejectionTemplate = emailSettings?.private_rejection_template || ''
+            companyName = emailSettings?.company_name || ''
+          }
+
+          const formatDateForBody = (dateStr: string): string => {
+            if (!dateStr) return ''
+            try {
+              const d = new Date(`${dateStr}T12:00:00+09:00`)
+              const weekdays = ['日', '月', '火', '水', '木', '金', '土']
+              return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日(${weekdays[d.getDay()]})`
+            } catch {
+              return dateStr
+            }
+          }
+          const candidatesText = candidateDates.length > 0
+            ? candidateDates.map((c: { date: string; startTime: string; endTime: string }, i: number) =>
+                `候補${i + 1}: ${formatDateForBody(c.date)} ${c.startTime?.slice(0, 5) || ''} - ${c.endTime?.slice(0, 5) || ''}`
+              ).join('\n')
+            : ''
+
+          // 変数置換して body を生成
+          const sharedBody = rejectionTemplate
+            ? rejectionTemplate
+                .replace(/{customer_name}/g, rejectCustomerName || '')
+                .replace(/{scenario_title}/g, reservation?.title || '')
+                .replace(/{rejection_reason}/g, rejectionReason)
+                .replace(/{candidate_dates}/g, candidatesText)
+                .replace(/{company_name}/g, companyName)
+            : ''
+
           // グループチャットにシステムメッセージを送信
           const { error: msgInsertError } = await supabase
             .from('private_group_messages')
@@ -480,9 +523,8 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
               message: JSON.stringify({
                 type: 'system',
                 action: 'booking_rejected',
-                title,
-                body,
-                rejectionReason: rejectionReason
+                title: '貸切リクエストが却下されました',
+                body: sharedBody
               })
             })
           if (msgInsertError) {
@@ -490,18 +532,8 @@ export function useBookingApproval({ onSuccess }: UseBookingApprovalProps) {
           }
 
           // 却下メール（貸切専用）を送信
-          const rejectMailCustomerJoined = joinedCustomerFromReservation(reservation?.customers)
-          const rejectCustomerEmail = rejectMailCustomerJoined?.email || reservation?.customer_email || selectedRequest?.customer_email
-          const rejectCustomerName = rejectMailCustomerJoined?.name || reservation?.customer_name || selectedRequest?.customer_name
           if (reservation && rejectCustomerEmail && rejectCustomerName) {
             try {
-              // 候補日時を取得
-              const candidateDates = reservation.candidate_datetimes?.candidates?.map((c: any) => ({
-                date: c.date,
-                startTime: c.startTime,
-                endTime: c.endTime
-              })) || []
-
               const { error: rejectMailError } = await supabase.functions.invoke('send-private-booking-rejection', {
                 body: {
                   organizationId,

--- a/src/pages/PrivateGroupManage/components/GroupChat.tsx
+++ b/src/pages/PrivateGroupManage/components/GroupChat.tsx
@@ -863,7 +863,7 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
                               </p>
                             </div>
                           </div>
-                          <p className="text-xs text-gray-600 mt-2">
+                          <p className="text-xs text-gray-600 mt-2 whitespace-pre-wrap">
                             {systemMsg.body || '店舗の都合がつかず、ご希望の日程でのご予約をお受けすることができませんでした。お手数ですが、別の候補日を選択のうえ再度お申し込みください。'}
                           </p>
                           {systemMsg.rejectionReason && (

--- a/src/pages/Settings/pages/EmailSettings.tsx
+++ b/src/pages/Settings/pages/EmailSettings.tsx
@@ -712,7 +712,7 @@ const TEMPLATE_CONFIGS: TemplateConfig[] = [
   {
     key: 'private_rejection_template',
     title: '貸切リクエスト却下メール',
-    description: '貸切予約を受け付けられない場合に送信',
+    description: '貸切予約を受け付けられない場合に送信（グループチャットの却下メッセージにも同じ本文が使われます）',
     category: 'private',
     additionalVariables: ADDITIONAL_VARIABLES.rejection,
     getDefault: getDefaultPrivateRejectionTemplate

--- a/src/pages/Settings/pages/NotificationSettings.tsx
+++ b/src/pages/Settings/pages/NotificationSettings.tsx
@@ -540,7 +540,7 @@ export function NotificationSettings({ storeId }: NotificationSettingsProps) {
             { key: 'group_created', label: 'グループ作成時', color: 'purple', hasNote: true },
             { key: 'booking_requested', label: '予約申込時', color: 'blue', hasNote: false },
             { key: 'schedule_confirmed', label: '日程確定時', color: 'green', hasNote: false },
-            { key: 'booking_rejected', label: 'リクエスト却下時', color: 'red', hasNote: false },
+            // 「リクエスト却下時」はメール設定の private_rejection_template に統合（同じ本文を両方に使用）
             { key: 'booking_cancelled', label: '予約キャンセル時', color: 'gray', hasNote: false },
           ].map(({ key, label, color, hasNote }) => (
             <div key={key} className={`space-y-3 p-4 bg-${color}-50 rounded-lg`}>


### PR DESCRIPTION
## 背景

貸切管理ページで「却下」したとき、
- グループチャットに送られる **システムメッセージ本文** (`global_settings.system_msg_booking_rejected_body`)
- お客様に送られる **却下メール本文** (`email_settings.private_rejection_template`)

の2つが別々のテンプレートで管理されており、編集箇所も別ページ（通知設定 / メール設定）に分かれていた。

ユーザー要望: **1つのテンプレートで両方を編集できるよう EmailSettings に集約**、本文も同じ文章を使う。

## 修正

### 1. `useBookingApproval.ts` — 却下時にメールテンプレートを共有
- `email_settings.private_rejection_template` を `store_id` で取得
- フロント側で変数置換: `{customer_name}` / `{scenario_title}` / `{rejection_reason}` / `{candidate_dates}` / `{company_name}`
- 置換結果をグループチャットの system message `body` として送信
- メール送信は従来通り Edge Function `send-private-booking-rejection`（同じテンプレートを参照する）

### 2. `GroupChat.tsx` — 長文 body の改行を保持
- 却下システムメッセージの本文 `<p>` に `whitespace-pre-wrap` 追加（テンプレート由来の改行を反映）

### 3. `EmailSettings.tsx` — 説明文に兼用を明記
- 「貸切リクエスト却下メール」description に「グループチャットの却下メッセージにも同じ本文が使われます」を追加

### 4. `NotificationSettings.tsx` — 重複 UI を除外
- 「リクエスト却下時」のシステムメッセージ編集カードをリストから除外
- DBカラム `system_msg_booking_rejected_title/body` は副作用回避のため残存（読み書きのコードからは外れる）

## 影響範囲

- 貸切リクエスト却下時のグループチャット表示が、これまでの短い固定文 + 却下理由ボックスから、**メールテンプレートと同じフォーマット済み本文**に変わる
- 「通知設定」ページの一覧から「リクエスト却下時」カードが消える
- メールの内容自体は変更なし（Edge Function 側ロジックそのまま）

## Test plan

- [ ] 設定 → メール設定 → 「貸切リクエスト却下メール」を編集して保存
- [ ] 貸切リクエスト却下を実行
- [ ] 受信メールが新テンプレ通り
- [ ] グループチャットの却下メッセージが同じ本文で表示される
- [ ] 通知設定ページに「リクエスト却下時」カードがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)