### PR TITLE
fix(private-booking): カードの再通知ボタンと申込時刻表示を改善

### DIFF
--- a/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
+++ b/src/pages/PrivateBookingManagement/components/BookingRequestCard.tsx
@@ -106,7 +106,6 @@ export const BookingRequestCard = ({
 
   const elapsedDays = getElapsedDays(request.created_at)
   const elapsedTimeColor = elapsedDays >= 3 ? 'text-red-600 font-medium' : 'text-purple-600'
-  const hasUnrespondedGMs = request.gm_responses?.some(r => !hasGmResponded(r))
   const isWaitingStatus = ['pending', 'pending_gm', 'pending_store'].includes(request.status)
 
   const handleResend = async () => {
@@ -137,7 +136,9 @@ export const BookingRequestCard = ({
         <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1.5 text-xs text-muted-foreground">
           <span>#{request.reservation_number}</span>
           <span>{request.customer_name}・{formatPrivateBookingParticipantLabel(request.participant_count, request.joined_member_count)}</span>
-          <span className={elapsedTimeColor}>{getElapsedTime(request.created_at)}</span>
+          <span className={elapsedTimeColor} title={formatDateTime(request.created_at)}>
+            {getElapsedTime(request.created_at)}（{formatDateTime(request.created_at)}）
+          </span>
         </div>
 
         {/* ── 連絡先・招待コード ── */}
@@ -207,7 +208,7 @@ export const BookingRequestCard = ({
               <div className="flex items-center justify-between mb-1.5">
                 <h4 className="text-xs font-semibold text-purple-800 uppercase tracking-wide">GM回答状況</h4>
                 <div className="flex items-center gap-1">
-                  {onResendDiscordNotification && hasUnrespondedGMs && isWaitingStatus && (
+                  {onResendDiscordNotification && isWaitingStatus && (
                     <Button variant="ghost" size="sm"
                       className="h-6 px-2 text-xs text-purple-700 hover:text-purple-900 hover:bg-purple-100"
                       onClick={handleResend} disabled={resending}


### PR DESCRIPTION
## 修正内容

### 1. Discord 再通知ボタン
- 旧条件: \`pending 系ステータス AND 未回答 GM がいるとき\` のみ表示
- 新条件: \`pending 系ステータスならいつでも表示\`

「店舗承認待ち」タブの状態（GMs 全員回答済み）でもボタンが消えてしまい再通知できなかった問題を解消。

### 2. 申込日時の表示
- 旧: \`1時間前\` だけ
- 新: \`1時間前（2026/05/22 09:45）\` の併記

ぱっと見の相対時刻と正確な日時の両方が分かるように。

🤖 Generated with [Claude Code](https://claude.com/claude-code)