### PR TITLE
fix(invite): ゲスト入室時の permission denied for staff を解消

### DIFF
--- a/src/hooks/usePrivateGroup.ts
+++ b/src/hooks/usePrivateGroup.ts
@@ -873,20 +873,32 @@ export function usePrivateGroupByInviteCode(inviteCode: string | null): {
       let resStatus: string | null = null
       let confirmedBy: string | null = null
       if (data?.reservation_id) {
-        const { data: resRow } = await supabase
-          .from('reservations')
-          .select('status, confirmed_by')
-          .eq('id', data.reservation_id)
-          .maybeSingle()
-        resStatus = resRow?.status ?? null
-        
-        if (resRow?.confirmed_by) {
-          const { data: staffRow } = await supabase
-            .from('staff')
-            .select('name')
-            .eq('id', resRow.confirmed_by)
+        // 招待ページは anon (ゲスト) からもアクセスされるため、reservations / staff の RLS で
+        // permission denied になっても招待表示自体は壊さない。
+        try {
+          const { data: resRow } = await supabase
+            .from('reservations')
+            .select('status, confirmed_by')
+            .eq('id', data.reservation_id)
             .maybeSingle()
-          confirmedBy = staffRow?.name ?? null
+          resStatus = resRow?.status ?? null
+
+          if (resRow?.confirmed_by) {
+            try {
+              const { data: staffRow } = await supabase
+                .from('staff')
+                .select('name')
+                .eq('id', resRow.confirmed_by)
+                .maybeSingle()
+              confirmedBy = staffRow?.name ?? null
+            } catch {
+              // staff RLS は anon を弾くので、確認者名はゲストでは表示できない
+              confirmedBy = null
+            }
+          }
+        } catch {
+          resStatus = null
+          confirmedBy = null
         }
       }
       setLinkedReservationStatus(resStatus)


### PR DESCRIPTION
## 不具合

ゲスト (anon) が \`/group/invite/{code}\` を開くと「招待が見つかりません — permission denied for table staff」と表示され、貸切グループに入室できない。

## 原因

[src/hooks/usePrivateGroup.ts:883-890](src/hooks/usePrivateGroup.ts#L883-L890) の \`usePrivateGroupByInviteCode\` 内で、確認者名表示用に \`reservations.confirmed_by\` から \`staff.name\` を SELECT していた。staff テーブルは anon に対して RLS で SELECT 不可なので permission denied になり、外側の try/catch が \`setError(err.message)\` で全体エラーにしてしまっていた。

## 修正

reservations / staff の lookup を個別に try/catch で囲み、失敗しても \`resStatus = null\`, \`confirmedBy = null\` のままページを表示する。

ゲストでは確認者名・予約ステータスは表示されなくなる（そもそも見えなくて良い情報）が、招待ページ自体は機能する。ログイン済みユーザー（staff RLS を通れる）では従来通り表示される。

## Test plan

- [ ] 未ログイン状態で \`/group/invite/<code>\` を開いて入室できるか
- [ ] ログイン済み状態で確認者名が従来通り表示されるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)