### PR TITLE
fix(rls): ゲスト招待ページの 401 を解消 (candidate_dates/date_responses SELECT を開放)

### DIFF
--- a/supabase/migrations/20260522020000_restore_anon_private_group_dates_select.sql
+++ b/supabase/migrations/20260522020000_restore_anon_private_group_dates_select.sql
@@ -1,0 +1,25 @@
+-- ゲスト (anon) が /group/invite/<code> から
+-- candidate_dates と date_responses を読めるよう、SELECT ポリシーを true に戻す。
+--
+-- 背景:
+--   20260519040000 (Phase 2) で「全認証ユーザー閲覧可」を「メンバー・自組織staff」に
+--   restrict したが、その RLS は `EXISTS ... JOIN staff` を含むため anon は staff への
+--   SELECT 権限がなく 42501 → PostgREST が 401 を返してゲスト入室が壊れていた。
+--
+--   そもそも親テーブル private_groups の SELECT ポリシーは USING (true) のため、
+--   子テーブル (candidate_dates / date_responses) だけ閉じても意味がない（group_id が分かれば
+--   private_groups は読める前提）。整合性のため SELECT を true に戻す。
+--
+--   INSERT/UPDATE/DELETE の制約は変更しない（書き込みは引き続きメンバー・自組織 staff のみ）。
+
+DROP POLICY IF EXISTS "private_group_candidate_dates_select" ON public.private_group_candidate_dates;
+CREATE POLICY "private_group_candidate_dates_select"
+  ON public.private_group_candidate_dates
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "private_group_date_responses_select" ON public.private_group_date_responses;
+CREATE POLICY "private_group_date_responses_select"
+  ON public.private_group_date_responses
+  FOR SELECT
+  USING (true);


### PR DESCRIPTION
## 不具合

\`/group/invite/<code>\` をゲストで開くと \`401 Unauthorized\` で表示できない。

ブラウザコンソール:
\`\`\`
private_groups?select=*,scenario_masters:...,members:...,candidate_dates:...
→ 401 Unauthorized
{"code":"42501","message":"permission denied for table staff"}
\`\`\`

## 原因

5/19 の \`20260519040000_fix_private_group_rls.sql\` (Phase 2) で
\`private_group_candidate_dates\` / \`private_group_date_responses\` の SELECT を
「メンバー・自組織 staff」に restrict したが、その policy 内に \`JOIN staff\` を含むため、
anon は \`staff\` テーブルへの SELECT 権限がなく **42501 → PostgREST が 401** で返していた。

ちなみに親テーブル \`private_groups\` の SELECT ポリシーは \`USING (true)\` のままなので、
子テーブルだけ閉じても実効的な防御になっていなかった (group_id が分かれば
private_groups は読める前提)。

## 修正

これら 2 テーブルの SELECT ポリシーを \`USING (true)\` に戻す。
INSERT/UPDATE/DELETE は変更しないので書き込みは引き続きメンバー・自組織 staff のみ。

## Test plan

- [ ] staging 適用後、未ログインで \`/group/invite/SHJA4NNK\` を開いて表示できるか
- [ ] 既存のメンバー/staff で同じページを開いて従来通り表示できるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)