### PR TITLE
fix(rls): anon GRANT 不足による 401 時限爆弾を 8 件まとめて解消

### DIFF
--- a/supabase/migrations/20260522030000_grant_anon_select_on_policy_referenced_tables.sql
+++ b/supabase/migrations/20260522030000_grant_anon_select_on_policy_referenced_tables.sql
@@ -1,0 +1,33 @@
+-- anon が SELECT 可能なテーブルの RLS policy が、anon に GRANT のないテーブルを参照していると
+-- planner が permission denied (42501) を投げて PostgREST が 401 を返す時限爆弾になる。
+--
+-- 該当監査結果 (2026-05-22):
+--   anon触れる host                       | refs anon-blocked
+--   ------------------------------------------------------------------
+--   album_character_records              | customers
+--   customer_org_stats                   | customers
+--   email_logs                           | users
+--   manual_internal_performance_overrides| users
+--   private_group_messages               | staff      ← 同 Phase 2 由来
+--   private_group_survey_responses       | staff
+--   scenario_characters                  | online_scenarios
+--   schedule_slot_memos                  | staff
+--
+-- 修正:
+--   staff / users / customers / online_scenarios の SELECT を anon に GRANT する。
+--   それぞれの RLS は anon を引き続き完全にブロックする（online_scenarios は設計通り
+--   is_published=true のみ閲覧許可、これは元々 RLS でそう書かれている）。
+--
+--   各 RLS の anon 実効挙動:
+--     - staff:    auth.uid() 系条件のみ → 0 行
+--     - users:    is_admin / id=auth.uid() → 0 行
+--     - customers: user_id=auth.uid() / staff_or_admin / license_admin → 0 行
+--     - online_scenarios: is_published=true は anon でも参照可（公開済みのみ）
+--
+-- 関連事故: 20260522020000 (Phase 2 RLS が anon staff GRANT 不足で 401 を起こした件)
+--           [[feedback-no-silent-scope-creep]]
+
+GRANT SELECT ON public.staff TO anon;
+GRANT SELECT ON public.users TO anon;
+GRANT SELECT ON public.customers TO anon;
+GRANT SELECT ON public.online_scenarios TO anon;


### PR DESCRIPTION
## 背景

5/19 の Phase 2 RLS hardening の余波で、anon が SELECT 可能なテーブルの policy が
\`staff\` / \`users\` / \`customers\` / \`online_scenarios\` を参照していると、
**anon に GRANT がなく planner が 42501 を返して PostgREST が 401** になる時限爆弾になっていた。

audit 結果（8件）:

| anon触れる host | refs anon-blocked |
|---|---|
| album_character_records | customers |
| customer_org_stats | customers |
| email_logs | users |
| manual_internal_performance_overrides | users |
| **private_group_messages** | **staff**（Phase 2 由来・チャット崩壊予備軍） |
| private_group_survey_responses | staff |
| scenario_characters | online_scenarios |
| schedule_slot_memos | staff |

## 修正

該当 4 テーブルの SELECT を anon に GRANT する。RLS は引き続き anon を完全ブロックする
（online_scenarios のみ \`is_published=true\` を設計通り公開）。

\`\`\`sql
GRANT SELECT ON public.staff TO anon;
GRANT SELECT ON public.users TO anon;
GRANT SELECT ON public.customers TO anon;
GRANT SELECT ON public.online_scenarios TO anon;
\`\`\`

## 安全性チェック (本番DBで確認済)

各 RLS の anon 実効挙動:
- staff: \`is_staff_or_admin AND org=...\` OR \`user_id=auth.uid()\` → anon は両方 false → **0 行**
- users: \`is_admin AND org=...\` OR \`id=auth.uid()\` → **0 行**
- customers: \`user_id=auth.uid()\` OR \`is_license_admin()\` OR \`is_staff_or_admin AND ...\` → **0 行**
- online_scenarios: \`is_published=true\` → 公開シナリオのみ（既存設計通り、Users can view published scenarios policy）

## 関連

- 直前の修正 #257 (\`20260522020000\`) — private_group_candidate_dates/date_responses の SELECT を true に戻した件
- 根本原因の Phase 2 commit: ac842783 (依頼外の RLS 強化が混入していた)

🤖 Generated with [Claude Code](https://claude.com/claude-code)