### PR TITLE
fix(rls): ゲスト招待ページのチャットが見えない問題を解消

### DIFF
--- a/supabase/migrations/20260522040000_restore_anon_private_group_messages_select.sql
+++ b/supabase/migrations/20260522040000_restore_anon_private_group_messages_select.sql
@@ -1,0 +1,15 @@
+-- ゲスト (anon) が /group/invite/<code> 内でチャットを見られるよう、
+-- private_group_messages の SELECT ポリシーを true に戻す。
+--
+-- 20260522020000 と同じ事故。Phase 2 (20260519040000) の hardening でこれも
+-- 「メンバー・自組織 staff」に restrict されたが、親 private_groups は USING (true)
+-- のため整合性がなく、ゲスト入室後にチャットが表示されない症状を起こしていた。
+--
+-- INSERT/UPDATE/DELETE 制約は変更しない。
+-- 関連: [[feedback-no-silent-scope-creep]]
+
+DROP POLICY IF EXISTS "private_group_messages_select" ON public.private_group_messages;
+CREATE POLICY "private_group_messages_select"
+  ON public.private_group_messages
+  FOR SELECT
+  USING (true);


### PR DESCRIPTION
## 不具合

ゲストで招待ページに入室後、グループチャットが表示されない（メッセージ 0 件）。

## 原因

Phase 2 (5/19 ac842783) で \`private_group_messages\` の SELECT policy を「メンバー・自組織 staff」に restrict したが、親 \`private_groups\` は \`USING (true)\` のまま整合性なし。ゲストはチャット 0 行で表示される。

5/22 の同様修正 (#257) では candidate_dates / date_responses だけ対応していて、messages は後追い。

## 修正

\`private_group_messages\` の SELECT も同様に \`USING (true)\` に戻す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)