### PR TITLE
feat(ci): anon RLS/GRANT 不整合 audit + ゲスト招待 E2E を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,11 @@ jobs:
       - name: Security guardrails
         run: npm run check:security-guardrails
 
-      - name: Install PostgreSQL client (for anon RLS / GRANT audit)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-client
-
       - name: Audit anon RLS / GRANT consistency
+        # Supabase Management API (HTTPS) 経由で staging に対して監査クエリを投げる。
+        # 直接 DB 接続 (db.<ref>.supabase.co) は GitHub Actions runner の IPv6 不通で使えない。
         env:
-          SUPABASE_DB_STAGING_PASSWORD: ${{ secrets.SUPABASE_DB_STAGING_PASSWORD }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: npm run check:anon-rls-grants
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Security guardrails
         run: npm run check:security-guardrails
 
+      - name: Install PostgreSQL client (for anon RLS / GRANT audit)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Audit anon RLS / GRANT consistency
+        env:
+          SUPABASE_DB_STAGING_PASSWORD: ${{ secrets.SUPABASE_DB_STAGING_PASSWORD }}
+        run: npm run check:anon-rls-grants
+
       - name: Build
         run: npm run build:fast
 

--- a/e2e/anon-invite.spec.ts
+++ b/e2e/anon-invite.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * 未ログイン (anon) で貸切グループ招待ページが表示できることを確認する。
+ *
+ * 過去事故 (2026-05-22):
+ *   Phase 2 RLS hardening (20260519040000) が anon 経路を壊し
+ *   「招待が見つかりません: permission denied for table staff」表示で
+ *   ゲストの入室が完全に止まった。
+ *
+ *   このテストはその種の RLS / GRANT 不整合による anon 入室の回帰を検出する。
+ *
+ * テストデータ:
+ *   staging に存在する確認済み (status='confirmed' or 'date_adjusting') の
+ *   private_groups.invite_code を1つ使用する。staging mirror で日次同期されるため
+ *   通常は安定。コードが消えた場合は private_groups テーブルから別のコードを選ぶ。
+ */
+
+// staging に長期存在する招待コード (confirmed)
+const STABLE_INVITE_CODE = 'SQZUM6PD'
+
+test.describe('ゲスト招待ページ', () => {
+  test('未ログインで招待ページが表示される（RLS/GRANT 不整合 401 検出）', async ({ page }) => {
+    // コンソールの 401 / permission denied を捕捉してテスト失敗にする
+    const consoleErrors: string[] = []
+    page.on('console', msg => {
+      const text = msg.text()
+      if (msg.type() === 'error' && (text.includes('401') || text.includes('permission denied'))) {
+        consoleErrors.push(text)
+      }
+    })
+    page.on('response', resp => {
+      if (resp.status() === 401 && resp.url().includes('supabase.co')) {
+        consoleErrors.push(`HTTP 401: ${resp.url()}`)
+      }
+    })
+
+    await page.goto(`/group/invite/${STABLE_INVITE_CODE}`)
+
+    // 「招待が見つかりません」エラー画面が出ていないこと
+    // (RLS / GRANT 不整合だとここに 401 を文字列化したものが入る)
+    await expect(page.getByText('招待が見つかりません')).not.toBeVisible({ timeout: 15000 })
+
+    // permission denied 文字列が画面に出ていないこと
+    await expect(page.getByText(/permission denied/)).not.toBeVisible()
+
+    // RLS / GRANT 不整合の console エラーが出ていないこと
+    expect(consoleErrors, `anon クエリで 401 / permission denied を検出:\n${consoleErrors.join('\n')}`).toHaveLength(0)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "check:multi-tenant": "./scripts/check-multi-tenant.sh",
+    "check:anon-rls-grants": "./scripts/audit-anon-rls-grants.sh",
     "pre-commit": "npm run check:security-guardrails && npm run check:cancellation-rpcs && npm run check:multi-tenant && npm run typecheck",
     "supabase:start": "npx supabase start",
     "supabase:stop": "npx supabase stop",

--- a/scripts/audit-anon-rls-grants.sh
+++ b/scripts/audit-anon-rls-grants.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# anon が SELECT 可能なテーブルの RLS policy が anon-blocked テーブルを参照していないか監査する。
+#
+# 使い方:
+#   ローカル:  bash scripts/audit-anon-rls-grants.sh  # staging に接続
+#   CI:        SUPABASE_DB_STAGING_URL="postgresql://..." bash scripts/audit-anon-rls-grants.sh
+#
+# 1 行でも返れば exit 1 で CI を落とす。
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SQL_FILE="$SCRIPT_DIR/audit-anon-rls-grants.sql"
+
+# DB URL を解決
+if [ -n "${SUPABASE_DB_STAGING_URL:-}" ]; then
+  DB_URL="$SUPABASE_DB_STAGING_URL"
+elif [ -n "${SUPABASE_DB_STAGING_PASSWORD:-}" ]; then
+  DB_URL="postgresql://postgres:${SUPABASE_DB_STAGING_PASSWORD}@db.lavutzztfqbdndjiwluc.supabase.co:5432/postgres"
+elif command -v security >/dev/null 2>&1; then
+  # macOS keychain
+  PWD_VAL=$(security find-generic-password -s supabase-db-staging -a postgres -w 2>/dev/null || true)
+  if [ -z "$PWD_VAL" ]; then
+    echo "❌ ステージング DB のパスワードが取得できません。"
+    echo "   SUPABASE_DB_STAGING_URL か SUPABASE_DB_STAGING_PASSWORD を環境変数で渡してください。"
+    exit 2
+  fi
+  DB_URL="postgresql://postgres:${PWD_VAL}@db.lavutzztfqbdndjiwluc.supabase.co:5432/postgres"
+else
+  echo "❌ DB URL を解決できません。"
+  exit 2
+fi
+
+# 監査 SQL を実行（ヘッダ抑制 + 末尾の "(N rows)" 抑制）
+RESULT=$(psql "$DB_URL" --no-align --tuples-only --field-separator='|' -f "$SQL_FILE")
+
+if [ -n "$RESULT" ]; then
+  echo "🚨 anon RLS / GRANT 不整合を検出しました（401 時限爆弾）:"
+  echo
+  echo "host_table | policy | refs_anon_blocked"
+  echo "$RESULT" | sed 's/^/  /'
+  echo
+  echo "対処: 参照先テーブルに GRANT SELECT ON ... TO anon を付与するか、policy を書き直してください。"
+  echo "詳細: scripts/audit-anon-rls-grants.sql のコメント参照"
+  exit 1
+fi
+
+echo "✅ anon RLS / GRANT 整合性: OK"

--- a/scripts/audit-anon-rls-grants.sh
+++ b/scripts/audit-anon-rls-grants.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # anon が SELECT 可能なテーブルの RLS policy が anon-blocked テーブルを参照していないか監査する。
 #
-# 使い方:
-#   ローカル:  bash scripts/audit-anon-rls-grants.sh  # staging に接続
-#   CI:        SUPABASE_DB_STAGING_URL="postgresql://..." bash scripts/audit-anon-rls-grants.sh
+# 接続方法 (優先順):
+#   1. SUPABASE_ACCESS_TOKEN + STAGING_PROJECT_REF (CI 推奨, Management API 経由・HTTPS)
+#   2. SUPABASE_DB_STAGING_URL (フル URL を直接指定)
+#   3. SUPABASE_DB_STAGING_PASSWORD (直接 host 接続, ローカルのみ・GitHub Actions では IPv6 不通)
+#   4. macOS Keychain (`supabase-db-staging`) (ローカル開発)
 #
 # 1 行でも返れば exit 1 で CI を落とす。
 
@@ -12,37 +14,80 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SQL_FILE="$SCRIPT_DIR/audit-anon-rls-grants.sql"
 
-# DB URL を解決
-if [ -n "${SUPABASE_DB_STAGING_URL:-}" ]; then
-  DB_URL="$SUPABASE_DB_STAGING_URL"
-elif [ -n "${SUPABASE_DB_STAGING_PASSWORD:-}" ]; then
-  DB_URL="postgresql://postgres:${SUPABASE_DB_STAGING_PASSWORD}@db.lavutzztfqbdndjiwluc.supabase.co:5432/postgres"
-elif command -v security >/dev/null 2>&1; then
-  # macOS keychain
-  PWD_VAL=$(security find-generic-password -s supabase-db-staging -a postgres -w 2>/dev/null || true)
-  if [ -z "$PWD_VAL" ]; then
-    echo "❌ ステージング DB のパスワードが取得できません。"
-    echo "   SUPABASE_DB_STAGING_URL か SUPABASE_DB_STAGING_PASSWORD を環境変数で渡してください。"
-    exit 2
+STAGING_REF="${STAGING_PROJECT_REF:-lavutzztfqbdndjiwluc}"
+
+run_via_management_api() {
+  local sql
+  sql=$(cat "$SQL_FILE")
+  # JSON 文字列としてエスケープ
+  local payload
+  payload=$(jq -n --arg q "$sql" '{query: $q}')
+
+  local response
+  response=$(curl -fsS -X POST \
+    "https://api.supabase.com/v1/projects/${STAGING_REF}/database/query" \
+    -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$payload")
+
+  # response は配列。空配列なら OK。中身があれば不整合
+  local row_count
+  row_count=$(echo "$response" | jq 'length')
+
+  if [ "$row_count" -gt 0 ]; then
+    echo "🚨 anon RLS / GRANT 不整合を検出しました（401 時限爆弾）:"
+    echo
+    echo "$response" | jq -r '.[] | "  - \(.host_table) | \(.polname) | refs: \(.refs_anon_blocked)"'
+    echo
+    echo "対処: 参照先テーブルに GRANT SELECT ON ... TO anon を付与するか、policy を書き直してください。"
+    echo "詳細: scripts/audit-anon-rls-grants.sql のコメント参照"
+    exit 1
   fi
-  DB_URL="postgresql://postgres:${PWD_VAL}@db.lavutzztfqbdndjiwluc.supabase.co:5432/postgres"
-else
-  echo "❌ DB URL を解決できません。"
-  exit 2
+  echo "✅ anon RLS / GRANT 整合性: OK (Management API)"
+}
+
+run_via_psql() {
+  local db_url="$1"
+  local result
+  result=$(psql "$db_url" --no-align --tuples-only --field-separator='|' -f "$SQL_FILE")
+  if [ -n "$result" ]; then
+    echo "🚨 anon RLS / GRANT 不整合を検出しました（401 時限爆弾）:"
+    echo
+    echo "host_table | policy | refs_anon_blocked"
+    echo "$result" | sed 's/^/  /'
+    echo
+    echo "対処: 参照先テーブルに GRANT SELECT ON ... TO anon を付与するか、policy を書き直してください。"
+    exit 1
+  fi
+  echo "✅ anon RLS / GRANT 整合性: OK (psql)"
+}
+
+# 1. Management API (CI 推奨)
+if [ -n "${SUPABASE_ACCESS_TOKEN:-}" ]; then
+  run_via_management_api
+  exit 0
 fi
 
-# 監査 SQL を実行（ヘッダ抑制 + 末尾の "(N rows)" 抑制）
-RESULT=$(psql "$DB_URL" --no-align --tuples-only --field-separator='|' -f "$SQL_FILE")
-
-if [ -n "$RESULT" ]; then
-  echo "🚨 anon RLS / GRANT 不整合を検出しました（401 時限爆弾）:"
-  echo
-  echo "host_table | policy | refs_anon_blocked"
-  echo "$RESULT" | sed 's/^/  /'
-  echo
-  echo "対処: 参照先テーブルに GRANT SELECT ON ... TO anon を付与するか、policy を書き直してください。"
-  echo "詳細: scripts/audit-anon-rls-grants.sql のコメント参照"
-  exit 1
+# 2. フル URL 指定
+if [ -n "${SUPABASE_DB_STAGING_URL:-}" ]; then
+  run_via_psql "$SUPABASE_DB_STAGING_URL"
+  exit 0
 fi
 
-echo "✅ anon RLS / GRANT 整合性: OK"
+# 3. パスワード環境変数 (ローカル)
+if [ -n "${SUPABASE_DB_STAGING_PASSWORD:-}" ]; then
+  run_via_psql "postgresql://postgres:${SUPABASE_DB_STAGING_PASSWORD}@db.${STAGING_REF}.supabase.co:5432/postgres"
+  exit 0
+fi
+
+# 4. macOS Keychain (ローカル開発)
+if command -v security >/dev/null 2>&1; then
+  PWD_VAL=$(security find-generic-password -s supabase-db-staging -a postgres -w 2>/dev/null || true)
+  if [ -n "$PWD_VAL" ]; then
+    run_via_psql "postgresql://postgres:${PWD_VAL}@db.${STAGING_REF}.supabase.co:5432/postgres"
+    exit 0
+  fi
+fi
+
+echo "❌ 接続情報が見つかりません。SUPABASE_ACCESS_TOKEN または SUPABASE_DB_STAGING_PASSWORD を設定してください。"
+exit 2

--- a/scripts/audit-anon-rls-grants.sql
+++ b/scripts/audit-anon-rls-grants.sql
@@ -1,0 +1,44 @@
+-- anon が SELECT 可能なテーブルの RLS policy が、anon に GRANT のないテーブルを参照していると
+-- planner が permission denied (42501) を投げて PostgREST が 401 を返す時限爆弾になる。
+--
+-- このクエリは、その時限爆弾を検出する。1 行でも返れば CI を落とす。
+--
+-- 過去事例: 2026-05-22 にゲスト招待ページが Phase 2 RLS hardening 由来で 401 化した。
+-- 参考: feedback_no_silent_scope_creep, project_org_scope_api_migration
+
+WITH anon_grants AS (
+  SELECT table_name FROM information_schema.table_privileges
+  WHERE table_schema = 'public'
+    AND grantee = 'anon'
+    AND privilege_type = 'SELECT'
+),
+anon_blocked AS (
+  -- anon が SELECT GRANT を持たない public テーブル
+  SELECT tablename
+  FROM pg_tables
+  WHERE schemaname = 'public'
+    AND tablename NOT IN (SELECT table_name FROM anon_grants)
+),
+suspect_policies AS (
+  SELECT
+    c.relname AS host_table,
+    pol.polname,
+    (
+      SELECT string_agg(b.tablename, ', ' ORDER BY b.tablename)
+      FROM anon_blocked b
+      WHERE pg_get_expr(pol.polqual, pol.polrelid) ~ ('\m' || b.tablename || '\M')
+    ) AS refs_anon_blocked
+  FROM pg_policy pol
+  JOIN pg_class c ON c.oid = pol.polrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND pol.polcmd = 'r'  -- SELECT only
+    AND c.relname IN (SELECT table_name FROM anon_grants)  -- anon-accessible host
+    AND EXISTS (
+      SELECT 1 FROM anon_blocked b
+      WHERE pg_get_expr(pol.polqual, pol.polrelid) ~ ('\m' || b.tablename || '\M')
+    )
+)
+SELECT host_table, polname, refs_anon_blocked
+FROM suspect_policies
+ORDER BY host_table, polname;


### PR DESCRIPTION
## 目的

5/22 のゲスト招待ページ崩壊事故（Phase 2 RLS hardening 由来）の **再発防止層** を追加する。

「依頼外の policy 変更を勝手にしない」という feedback だけだと AI / 人の善意依存で脆い。
コードで自動検知する層を入れる。

## 変更内容

### A. CI に SQL audit を追加

\`\`\`
scripts/audit-anon-rls-grants.sql  -- 監査クエリ
scripts/audit-anon-rls-grants.sh   -- 実行ラッパ (staging に psql 接続)
package.json                       -- "check:anon-rls-grants" script
.github/workflows/ci.yml           -- Verify job に audit step を追加
\`\`\`

**検知する不整合**: anon が SELECT 可能なテーブルの RLS policy が、anon に GRANT のない
テーブルを参照している (= planner が 42501 を返して PostgREST 401 になる時限爆弾)。

ローカル動作確認済み: 現在の staging では \`✅ anon RLS / GRANT 整合性: OK\` を返す。

### B. Playwright E2E

\`\`\`
e2e/anon-invite.spec.ts
\`\`\`

未ログインで \`/group/invite/SQZUM6PD\` (staging の安定コード) にアクセス、
- 「招待が見つかりません」が表示されない
- 「permission denied」文字列が表示されない
- HTTP 401 レスポンスが Supabase ドメインから返ってこない

を検証。ローカル run 済み (3.2s で pass)。

## 何を防ぐか

| シナリオ | 検知 |
|---|---|
| 5/22 と同じ 401 時限爆弾 | A (静的監査) |
| anon 経路の React 側不具合 (try/catch 漏れ等) | B (実 UI 検証) |
| 全く別の RLS 変更で anon が壊れる | A + B (両方) |

## 関連

- 直前の事故対応: #257 (candidate_dates 修正), #258 (8 件 GRANT), #259 (messages 修正)
- memory: \`feedback_no_silent_scope_creep.md\`, \`project_org_scope_api_migration.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)