### PR TITLE
fix: 検索系の null.toLowerCase() クラッシュを一括防御（8 箇所）

### DIFF
--- a/src/components/modals/ScenarioEditDialogV2/sections/SurveySectionV2.tsx
+++ b/src/components/modals/ScenarioEditDialogV2/sections/SurveySectionV2.tsx
@@ -731,7 +731,7 @@ function ImportQuestionsDialog({ open, onOpenChange, onImport, currentScenarioMa
   }
 
   const filteredScenarios = searchTerm
-    ? scenarios.filter(s => s.title.toLowerCase().includes(searchTerm.toLowerCase()))
+    ? scenarios.filter(s => (s.title ?? '').toLowerCase().includes(searchTerm.toLowerCase()))
     : scenarios
 
   const getTypeLabel = (type: string) =>

--- a/src/pages/AuthorReport/hooks/useReportFilters.ts
+++ b/src/pages/AuthorReport/hooks/useReportFilters.ts
@@ -38,7 +38,7 @@ export function useReportFilters(monthlyData: MonthlyAuthorData[]) {
     return monthlyData.map(monthData => ({
       ...monthData,
       authors: monthData.authors.filter(author =>
-        author.author.toLowerCase().includes(searchAuthor.toLowerCase())
+        (author.author ?? '').toLowerCase().includes(searchAuthor.toLowerCase())
       )
     }))
   }, [monthlyData, searchAuthor])

--- a/src/pages/LicenseManagement/tabs/AuthorReports.tsx
+++ b/src/pages/LicenseManagement/tabs/AuthorReports.tsx
@@ -321,8 +321,8 @@ export function AuthorReports() {
   }
 
   // フィルタリング
-  const filteredData = authorData.filter(a => 
-    a.author.toLowerCase().includes(searchAuthor.toLowerCase())
+  const filteredData = authorData.filter(a =>
+    (a.author ?? '').toLowerCase().includes(searchAuthor.toLowerCase())
   )
 
   // 統計

--- a/src/pages/PlatformScenarioSearch/index.tsx
+++ b/src/pages/PlatformScenarioSearch/index.tsx
@@ -366,7 +366,7 @@ export function PlatformScenarioSearch() {
       // 検索
       if (searchTerm) {
         const term = searchTerm.toLowerCase()
-        const matchTitle = scenario.title.toLowerCase().includes(term)
+        const matchTitle = (scenario.title ?? '').toLowerCase().includes(term)
         const matchAuthor = scenario.author?.toLowerCase().includes(term)
         const matchGenre = scenario.genre?.some(g => g.toLowerCase().includes(term))
         const matchOrg = scenario.organization_name?.toLowerCase().includes(term)

--- a/src/pages/PrivateBookingScenarioSelect.tsx
+++ b/src/pages/PrivateBookingScenarioSelect.tsx
@@ -64,9 +64,9 @@ export function PrivateBookingScenarioSelect({ organizationSlug }: PrivateBookin
   const filteredScenarios = useMemo(() => {
     if (!searchTerm) return scenarios
     const term = searchTerm.toLowerCase()
-    return scenarios.filter(s => 
-      s.title.toLowerCase().includes(term) ||
-      s.author.toLowerCase().includes(term)
+    return scenarios.filter(s =>
+      (s.title ?? '').toLowerCase().includes(term) ||
+      (s.author ?? '').toLowerCase().includes(term)
     )
   }, [scenarios, searchTerm])
   

--- a/src/pages/ScenarioCatalog/index.tsx
+++ b/src/pages/ScenarioCatalog/index.tsx
@@ -277,7 +277,7 @@ export function ScenarioCatalog({ organizationSlug }: ScenarioCatalogProps) {
       // 検索
       if (searchTerm) {
         const term = searchTerm.toLowerCase()
-        const matchTitle = scenario.title.toLowerCase().includes(term)
+        const matchTitle = (scenario.title ?? '').toLowerCase().includes(term)
         const matchAuthor = scenario.author?.toLowerCase().includes(term)
         const matchGenre = scenario.genre?.some(g => g.toLowerCase().includes(term))
         const matchStore = scenario.available_stores?.some(s => s.toLowerCase().includes(term))

--- a/src/pages/ScenarioMatcher.tsx
+++ b/src/pages/ScenarioMatcher.tsx
@@ -306,7 +306,7 @@ export function ScenarioMatcher() {
                                   {allScenarios
                                     .filter(s => {
                                       const searchTerm = popoverSearchTerms[event.scenario] || ''
-                                      return s.title.toLowerCase().includes(searchTerm.toLowerCase())
+                                      return (s.title ?? '').toLowerCase().includes(searchTerm.toLowerCase())
                                     })
                                     .map((scenario) => {
                                       const isSelected = selectedMatches[event.scenario] === scenario.id
@@ -338,7 +338,7 @@ export function ScenarioMatcher() {
                                     })}
                                   {allScenarios.filter(s => {
                                     const searchTerm = popoverSearchTerms[event.scenario] || ''
-                                    return s.title.toLowerCase().includes(searchTerm.toLowerCase())
+                                    return (s.title ?? '').toLowerCase().includes(searchTerm.toLowerCase())
                                   }).length === 0 && (
                                     <div className="py-6 text-center text-sm text-gray-500">
                                       シナリオが見つかりません

--- a/src/pages/StaffProfile/index.tsx
+++ b/src/pages/StaffProfile/index.tsx
@@ -158,9 +158,9 @@ export function StaffProfile() {
   const filteredScenarios = useMemo(() => {
     if (!searchTerm) return scenarios
     const term = searchTerm.toLowerCase()
-    return scenarios.filter(s => 
-      s.title.toLowerCase().includes(term) || 
-      s.author.toLowerCase().includes(term)
+    return scenarios.filter(s =>
+      (s.title ?? '').toLowerCase().includes(term) ||
+      (s.author ?? '').toLowerCase().includes(term)
     )
   }, [scenarios, searchTerm])
 


### PR DESCRIPTION
## 不具合

カレンダーから貸切申込 → シナリオ検索で frontend がクラッシュ：
\`\`\`
TypeError: Cannot read properties of null (reading 'toLowerCase')
\`\`\`

## 監査結果

\`xxx.toLowerCase()\` の呼び出しで null になりうるフィールドを参照しているパターンを grep で全部洗い出し。**8 箇所**の crash 予備軍を一括で防御化。

## 修正

\`xxx.toLowerCase()\` → \`(xxx ?? '').toLowerCase()\` パターンで統一：

| ファイル | フィールド |
|---|---|
| PrivateBookingScenarioSelect.tsx | title, author |
| ScenarioMatcher.tsx (×2) | title |
| StaffProfile/index.tsx | title, author |
| ScenarioEditDialogV2/sections/SurveySectionV2.tsx | title |
| LicenseManagement/tabs/AuthorReports.tsx | author |
| AuthorReport/hooks/useReportFilters.ts | author |
| PlatformScenarioSearch/index.tsx | title |
| ScenarioCatalog/index.tsx | title |

\`scenario.author\` は既存コードで \`?.\` ガード済みのケースが多いため、ガードがないやつだけ修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)