### PR TITLE
feat(scripts): prod → staging 完全クローン用スクリプト

### DIFF
--- a/scripts/clone-prod-to-staging-full.sh
+++ b/scripts/clone-prod-to-staging-full.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 本番DB → ステージングDB 完全複製スクリプト (auth 除外)
+#
+# 含めるもの:
+#   - public スキーマ (table 定義 + データ + RLS + function)
+#   - storage スキーマ (buckets / objects のメタデータ)
+#   - storage 実ファイル (S3 blob、700件・380MB)
+#
+# 除外するもの:
+#   - auth スキーマ (PII / ログインアカウント)
+#   - supabase_migrations (両者既に同期済み・触らない)
+#
+# 使い方:
+#   bash scripts/clone-prod-to-staging-full.sh phase1   # 各 phase 単独実行
+#   bash scripts/clone-prod-to-staging-full.sh phase2
+#   ...
+#
+# 各 phase の機能:
+#   phase1: staging の現状フルバックアップを /tmp に出力 (read-only)
+#   phase2: staging.public / staging.storage を DROP CASCADE (破壊)
+#   phase3: pg_dump prod.public + storage → pg_restore to staging
+#   phase4: storage 実ファイル (S3 blob) を prod から staging へ Storage API 経由でコピー
+#   phase5: 検証 (件数比較・サンプル確認)
+# =============================================================================
+
+set -euo pipefail
+
+PROD_REF="cznpcewciwywcqcxktba"
+STAGING_REF="lavutzztfqbdndjiwluc"
+
+PROD_HOST="db.${PROD_REF}.supabase.co"
+STAGING_HOST="db.${STAGING_REF}.supabase.co"
+DB_PORT=5432
+DB_USER=postgres
+DB_NAME=postgres
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="/tmp/staging-backup-${TIMESTAMP}.sql.gz"
+DUMP_FILE="/tmp/prod-clone-${TIMESTAMP}.dump"
+
+# パスワード取得
+PROD_PASSWORD=$(security find-generic-password -s supabase-db-prod -a postgres -w 2>/dev/null)
+STAGING_PASSWORD=$(security find-generic-password -s supabase-db-staging -a postgres -w 2>/dev/null)
+
+if [ -z "$PROD_PASSWORD" ] || [ -z "$STAGING_PASSWORD" ]; then
+  echo "❌ Keychain から DB パスワードを取得できません。supabase-db-prod / supabase-db-staging を登録してください。"
+  exit 2
+fi
+
+prod_psql() {
+  PGPASSWORD="$PROD_PASSWORD" psql -h "$PROD_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" "$@"
+}
+staging_psql() {
+  PGPASSWORD="$STAGING_PASSWORD" psql -h "$STAGING_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" "$@"
+}
+
+phase1_backup_staging() {
+  echo "========================================="
+  echo " Phase 1: staging 現状を /tmp にバックアップ (read-only)"
+  echo "========================================="
+  echo "出力先: $BACKUP_FILE"
+
+  PGPASSWORD="$STAGING_PASSWORD" pg_dump \
+    -h "$STAGING_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    --schema=public --schema=storage --schema=supabase_migrations \
+    --no-owner --no-privileges \
+    | gzip > "$BACKUP_FILE"
+
+  SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+  echo "✅ バックアップ完了 (${SIZE})"
+  echo
+  echo "   復元したい場合: gunzip -c $BACKUP_FILE | psql 'STAGING_URL'"
+}
+
+phase2_drop_staging_schemas() {
+  echo "========================================="
+  echo " Phase 2: staging.public + staging.storage を DROP CASCADE"
+  echo "========================================="
+  echo "⚠️  staging の public・storage の全データ・全テーブル・全関数が消えます。"
+  echo
+  echo "現在の staging の public テーブル数:"
+  staging_psql -tA -c "SELECT COUNT(*) FROM pg_tables WHERE schemaname='public';"
+
+  staging_psql <<'SQL'
+-- 1) storage は内部スキーマなので一旦 truncate のみ (DROP すると extension が壊れる可能性)
+TRUNCATE storage.objects, storage.buckets CASCADE;
+
+-- 2) public は DROP → 後で pg_restore で作り直し
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+GRANT USAGE ON SCHEMA public TO postgres, anon, authenticated, service_role;
+GRANT ALL ON SCHEMA public TO postgres, service_role;
+SQL
+
+  echo "✅ Phase 2 完了"
+}
+
+phase3_dump_and_restore() {
+  echo "========================================="
+  echo " Phase 3: prod から public + storage を dump → staging に restore"
+  echo "========================================="
+  echo "出力先: $DUMP_FILE"
+
+  # public のスキーマ + データ
+  PGPASSWORD="$PROD_PASSWORD" pg_dump \
+    -h "$PROD_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    --schema=public \
+    --no-owner --no-privileges \
+    -Fc -f "${DUMP_FILE}.public" 2>&1 | grep -v "^pg_dump:" || true
+  echo "  ✓ prod.public dump 完了"
+
+  # storage はテーブルデータのみ (extension で作られた構造は staging 側にもある前提)
+  PGPASSWORD="$PROD_PASSWORD" pg_dump \
+    -h "$PROD_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    --schema=storage --table=storage.buckets --table=storage.objects \
+    --data-only \
+    --no-owner --no-privileges \
+    -Fc -f "${DUMP_FILE}.storage" 2>&1 | grep -v "^pg_dump:" || true
+  echo "  ✓ prod.storage data dump 完了"
+
+  # staging に restore
+  PGPASSWORD="$STAGING_PASSWORD" pg_restore \
+    -h "$STAGING_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    --no-owner --no-privileges --if-exists --clean \
+    "${DUMP_FILE}.public" 2>&1 | tail -5 || true
+  echo "  ✓ staging.public restore 完了"
+
+  PGPASSWORD="$STAGING_PASSWORD" pg_restore \
+    -h "$STAGING_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    --no-owner --no-privileges --data-only \
+    "${DUMP_FILE}.storage" 2>&1 | tail -5 || true
+  echo "  ✓ staging.storage data restore 完了"
+
+  echo "✅ Phase 3 完了"
+}
+
+phase4_copy_storage_blobs() {
+  echo "========================================="
+  echo " Phase 4: storage 実ファイル (S3 blob) を prod → staging へコピー"
+  echo "========================================="
+  echo "対象: ${PROD_BLOB_COUNT:-700} 件 / ~380 MB"
+  echo
+
+  # service_role keys
+  PROD_SR_KEY="${PROD_SUPABASE_SERVICE_ROLE_KEY:-}"
+  STG_SR_KEY="${STG_SUPABASE_SERVICE_ROLE_KEY:-}"
+
+  if [ -z "$PROD_SR_KEY" ] || [ -z "$STG_SR_KEY" ]; then
+    echo "❌ 環境変数 PROD_SUPABASE_SERVICE_ROLE_KEY と STG_SUPABASE_SERVICE_ROLE_KEY が必要です。"
+    echo "   Vercel の prod / staging 環境変数からコピーしてください。"
+    return 2
+  fi
+
+  node scripts/clone-storage-blobs.mjs \
+    --prod-url "https://${PROD_REF}.supabase.co" \
+    --prod-key "$PROD_SR_KEY" \
+    --staging-url "https://${STAGING_REF}.supabase.co" \
+    --staging-key "$STG_SR_KEY"
+
+  echo "✅ Phase 4 完了"
+}
+
+phase5_verify() {
+  echo "========================================="
+  echo " Phase 5: 検証"
+  echo "========================================="
+
+  echo "--- public 主要テーブルの件数比較 ---"
+  for tbl in reservations customers users staff schedule_events private_groups; do
+    PROD_C=$(prod_psql -tA -c "SELECT COUNT(*) FROM public.$tbl" 2>/dev/null || echo "?")
+    STG_C=$(staging_psql -tA -c "SELECT COUNT(*) FROM public.$tbl" 2>/dev/null || echo "?")
+    MARK=$([ "$PROD_C" = "$STG_C" ] && echo "✓" || echo "✗")
+    printf "  %s %-25s prod=%s staging=%s\n" "$MARK" "$tbl" "$PROD_C" "$STG_C"
+  done
+
+  echo
+  echo "--- storage.objects 件数比較 ---"
+  PROD_OBJ=$(prod_psql -tA -c "SELECT COUNT(*) FROM storage.objects")
+  STG_OBJ=$(staging_psql -tA -c "SELECT COUNT(*) FROM storage.objects")
+  echo "  prod=$PROD_OBJ staging=$STG_OBJ"
+
+  echo
+  echo "--- schema_migrations 同期確認 ---"
+  PROD_MIG=$(prod_psql -tA -c "SELECT COUNT(*) FROM supabase_migrations.schema_migrations")
+  STG_MIG=$(staging_psql -tA -c "SELECT COUNT(*) FROM supabase_migrations.schema_migrations")
+  echo "  prod=$PROD_MIG staging=$STG_MIG"
+
+  echo
+  echo "✅ Phase 5 完了"
+}
+
+case "${1:-help}" in
+  phase1) phase1_backup_staging ;;
+  phase2) phase2_drop_staging_schemas ;;
+  phase3) phase3_dump_and_restore ;;
+  phase4) phase4_copy_storage_blobs ;;
+  phase5) phase5_verify ;;
+  help|*)
+    echo "Usage: bash scripts/clone-prod-to-staging-full.sh <phase>"
+    echo "  phase1: staging を /tmp にバックアップ (read-only)"
+    echo "  phase2: staging.public + storage を DROP/TRUNCATE"
+    echo "  phase3: prod から dump → staging に restore"
+    echo "  phase4: storage 実ファイル (S3 blob) をコピー"
+    echo "  phase5: 検証"
+    ;;
+esac

--- a/scripts/clone-storage-blobs.mjs
+++ b/scripts/clone-storage-blobs.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Supabase Storage の実ファイル (S3 blob) を prod から staging へ全件コピーする。
+ *
+ * 使い方:
+ *   node scripts/clone-storage-blobs.mjs \
+ *     --prod-url https://<prod-ref>.supabase.co \
+ *     --prod-key <prod service_role key> \
+ *     --staging-url https://<staging-ref>.supabase.co \
+ *     --staging-key <staging service_role key>
+ *
+ * 仕様:
+ *   - 全 bucket・全 object を順に走査
+ *   - 同じ path に既に存在する場合は upsert で上書き
+ *   - 失敗したファイルは末尾にまとめて表示 (続行する)
+ *   - 並列度 4 (Storage API の rate limit を考慮した安全側)
+ */
+
+import { createClient } from '@supabase/supabase-js'
+
+function parseArgs() {
+  const args = {}
+  for (let i = 2; i < process.argv.length; i += 2) {
+    const k = process.argv[i].replace(/^--/, '')
+    args[k] = process.argv[i + 1]
+  }
+  for (const required of ['prod-url', 'prod-key', 'staging-url', 'staging-key']) {
+    if (!args[required]) {
+      console.error(`❌ --${required} が必要です`)
+      process.exit(2)
+    }
+  }
+  return args
+}
+
+async function listAllObjects(supabase, bucket) {
+  const all = []
+  const pageSize = 1000
+  let offset = 0
+  // 再帰でフォルダ階層も含めて列挙
+  async function walk(prefix) {
+    let pageOffset = 0
+    while (true) {
+      const { data, error } = await supabase.storage
+        .from(bucket)
+        .list(prefix, { limit: pageSize, offset: pageOffset })
+      if (error) throw error
+      if (!data || data.length === 0) break
+      for (const entry of data) {
+        if (entry.id === null) {
+          // フォルダ
+          await walk(prefix ? `${prefix}/${entry.name}` : entry.name)
+        } else {
+          all.push({ bucket, path: prefix ? `${prefix}/${entry.name}` : entry.name })
+        }
+      }
+      if (data.length < pageSize) break
+      pageOffset += pageSize
+    }
+  }
+  await walk('')
+  return all
+}
+
+async function copyOne(prod, staging, { bucket, path }) {
+  // prod から download
+  const { data: blob, error: dlErr } = await prod.storage.from(bucket).download(path)
+  if (dlErr) throw new Error(`download ${bucket}/${path}: ${dlErr.message}`)
+
+  // staging に upload (upsert)
+  const arrayBuf = await blob.arrayBuffer()
+  const { error: upErr } = await staging.storage.from(bucket).upload(path, arrayBuf, {
+    contentType: blob.type || 'application/octet-stream',
+    upsert: true,
+  })
+  if (upErr) throw new Error(`upload ${bucket}/${path}: ${upErr.message}`)
+}
+
+async function ensureStagingBuckets(prod, staging) {
+  const { data: prodBuckets, error: prodErr } = await prod.storage.listBuckets()
+  if (prodErr) throw prodErr
+  const { data: stgBuckets, error: stgErr } = await staging.storage.listBuckets()
+  if (stgErr) throw stgErr
+
+  const stgNames = new Set((stgBuckets || []).map(b => b.name))
+  for (const b of prodBuckets) {
+    if (!stgNames.has(b.name)) {
+      console.log(`  📁 staging に bucket 作成: ${b.name} (public=${b.public})`)
+      const { error } = await staging.storage.createBucket(b.name, {
+        public: b.public,
+        fileSizeLimit: b.file_size_limit,
+        allowedMimeTypes: b.allowed_mime_types,
+      })
+      if (error && !error.message.includes('already exists')) throw error
+    }
+  }
+  return prodBuckets
+}
+
+async function main() {
+  const args = parseArgs()
+  const prod = createClient(args['prod-url'], args['prod-key'])
+  const staging = createClient(args['staging-url'], args['staging-key'])
+
+  console.log('🪣 bucket 同期...')
+  const buckets = await ensureStagingBuckets(prod, staging)
+  console.log(`   ${buckets.length} buckets`)
+
+  console.log('\n📋 prod の全 object を列挙...')
+  const allObjects = []
+  for (const b of buckets) {
+    const objs = await listAllObjects(prod, b.name)
+    console.log(`   ${b.name}: ${objs.length} 件`)
+    allObjects.push(...objs)
+  }
+  console.log(`   合計: ${allObjects.length} 件`)
+
+  console.log('\n📤 コピー実行 (並列度 4)...')
+  let done = 0
+  const failures = []
+  const concurrency = 4
+  const queue = [...allObjects]
+
+  async function worker() {
+    while (queue.length > 0) {
+      const item = queue.shift()
+      if (!item) break
+      try {
+        await copyOne(prod, staging, item)
+      } catch (e) {
+        failures.push({ ...item, error: e.message })
+      }
+      done++
+      if (done % 50 === 0 || done === allObjects.length) {
+        process.stdout.write(`\r   ${done}/${allObjects.length} (失敗 ${failures.length})`)
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()))
+  process.stdout.write('\n')
+
+  if (failures.length > 0) {
+    console.log(`\n⚠️  ${failures.length} 件失敗:`)
+    for (const f of failures.slice(0, 20)) {
+      console.log(`   ${f.bucket}/${f.path}: ${f.error}`)
+    }
+    if (failures.length > 20) console.log(`   ... 他 ${failures.length - 20} 件`)
+    process.exit(1)
+  }
+
+  console.log('\n✅ 全 blob コピー完了')
+}
+
+main().catch(err => {
+  console.error('❌ エラー:', err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## 目的

staging DB が prod からずれた状態を「数十分で完全リセットして prod の最新状態に揃える」運用ツール。

## 含めるもの

| 対象 | 方法 |
|---|---|
| public スキーマ (table + data + RLS + function) | \`pg_dump --schema=public\` + \`pg_restore\` |
| storage メタ (buckets / objects) | \`pg_dump --table=storage.buckets/objects\` |
| storage 実ファイル (S3 blob) | Supabase Storage API でループコピー (並列度 4) |

## 含めないもの

- \`auth\` スキーマ (PII / ログインアカウント)
- \`supabase_migrations.schema_migrations\` (両環境同期済み)

## 使い方

\`\`\`bash
bash scripts/clone-prod-to-staging-full.sh phase1   # /tmp にバックアップ
bash scripts/clone-prod-to-staging-full.sh phase2   # staging を DROP/TRUNCATE
bash scripts/clone-prod-to-staging-full.sh phase3   # prod → staging データ転送
PROD_SUPABASE_SERVICE_ROLE_KEY=... STG_SUPABASE_SERVICE_ROLE_KEY=... \\
  bash scripts/clone-prod-to-staging-full.sh phase4  # storage blob 転送
bash scripts/clone-prod-to-staging-full.sh phase5   # 検証
\`\`\`

## 実績

2026-05-22 に staging へ初回実行：

- 596 MB の DB クローン、700 個の storage blob コピー成功
- Phase 4 で 1 件 transient エラー → 手動で curl 再送
- 関連で schedule_events CASCADE TRUNCATE して staging を「公演 0 件」状態に（cron で本番顧客にメール飛ぶ事故予防）

🤖 Generated with [Claude Code](https://claude.com/claude-code)