### PR TITLE
fix: グループチャットで最新100件を取得するよう変更（#275）

### DIFF
--- a/src/pages/PrivateGroupManage/components/GroupChat.tsx
+++ b/src/pages/PrivateGroupManage/components/GroupChat.tsx
@@ -467,15 +467,16 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
     const fetchMessages = async () => {
       setLoading(true)
       try {
+        // 昇順+limitだと古い100件で打ち切られ最新の個別お知らせが表示されないため、最新100件を取得して反転する（#275）
         const { data, error } = await supabase
           .from('private_group_messages')
           .select('id, group_id, member_id, message, created_at')
           .eq('group_id', groupId)
-          .order('created_at', { ascending: true })
+          .order('created_at', { ascending: false })
           .limit(100)
 
         if (error) throw error
-        setMessages(data || [])
+        setMessages((data || []).reverse())
       } catch (err) {
         logger.error('Failed to fetch messages', err)
       } finally {


### PR DESCRIPTION
## 不具合

ハンドアウト（個別お知らせ）を配布済みなのに、お客様のグループチャットに表示されない（#275）。スタッフ側の送信履歴には「配布済み」と表示されるため、ログと症状が食い違っていた。

## 原因

`GroupChat.tsx` の `fetchMessages` が

```ts
.order('created_at', { ascending: true })
.limit(100)
```

で取得しており、**古い方から100件で打ち切り**になっていた。グループの累計メッセージが100件を超えると、101件目以降（公演直前に配布される個別お知らせ等）はリロード後に一切表示されない。スタッフ側（`SurveyResponsesTab.tsx`）は降順・実質無制限で取得しているため配布済みに見える。Realtime購読があるため「配布の瞬間に画面を開いていた人には見え、リロードすると消える」挙動になる。

## 修正

取得を `ascending: false` + `limit(100)` に変更し、表示前に `reverse()` で古い順へ戻す（＝最新100件を表示）。変更は `fetchMessages` 内の3行のみ。

## 検証

- ローカルで `typecheck` / `lint` / `build:fast` 通過済み（調査時に検証）
- staging と本ブランチの diff が意図した3行＋コメント1行のみであることを確認済み

Closes #275