### PR TITLE
staging → main デプロイ: グループチャット最新100件取得の修正（#275）

### DIFF
--- a/src/pages/PrivateGroupManage/components/GroupChat.tsx
+++ b/src/pages/PrivateGroupManage/components/GroupChat.tsx
@@ -467,15 +467,16 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
     const fetchMessages = async () => {
       setLoading(true)
       try {
+        // 昇順+limitだと古い100件で打ち切られ最新の個別お知らせが表示されないため、最新100件を取得して反転する（#275）
         const { data, error } = await supabase
           .from('private_group_messages')
           .select('id, group_id, member_id, message, created_at')
           .eq('group_id', groupId)
-          .order('created_at', { ascending: true })
+          .order('created_at', { ascending: false })
           .limit(100)
 
         if (error) throw error
-        setMessages(data || [])
+        setMessages((data || []).reverse())
       } catch (err) {
         logger.error('Failed to fetch messages', err)
       } finally {


### PR DESCRIPTION
## staging → main デプロイ

- fix: グループチャットで最新100件を取得するよう変更（#275 / PR #276）

### 内容

`GroupChat.tsx` の `fetchMessages` が昇順+`limit(100)`だったため、累計100件超のグループで最新の個別お知らせ（ハンドアウト）が表示されなかった問題の修正。降順取得+`reverse()`で最新100件を表示する。

### 検証

- CI（typecheck / lint / build / Playwright E2E / claude-review）全通過（#276）
- staging DBで再現テスト実施済み: 総113件のグループで、旧クエリでは最新通知が取得されず、新クエリでは取得されることを確認
- staging環境のUIでも最新メッセージの表示を確認済み

🤖 Generated with Claude