### PR TITLE
fix: 個別お知らせの表示判定を多重化＋未ログイン閲覧に警告バナー（#275/#278）

### DIFF
--- a/src/components/schedule/modal/SurveyResponsesTab.tsx
+++ b/src/components/schedule/modal/SurveyResponsesTab.tsx
@@ -349,6 +349,8 @@ export function SurveyResponsesTab({
             action: 'individual_notice',
             target_member_id: memberId,
             target_member_name: memberName,
+            // 宛先ユーザーID（メンバー行が退出等で再作成されても user_id 照合で表示できるように #278）
+            target_user_id: member?.user_id || null,
             message: fullMessage,
             character_id: selectedCharId || null,
             character_name: selectedChar?.name || null,

--- a/src/pages/PrivateGroupManage/components/GroupChat.tsx
+++ b/src/pages/PrivateGroupManage/components/GroupChat.tsx
@@ -9,6 +9,7 @@ import { supabase } from '@/lib/supabase'
 import type { RpcSetCharacterPreferenceParams, RpcUpsertCharacterAssignmentsToSurveyParams } from '@/lib/rpcTypes'
 import { useAuth } from '@/contexts/AuthContext'
 import { logger } from '@/utils/logger'
+import { Sentry } from '@/lib/sentry'
 import { toast } from 'sonner'
 import type { PrivateGroupMessage, PrivateGroupMember } from '@/types'
 import { SurveyResponseForm } from '@/pages/PrivateGroupInvite/components/SurveyResponseForm'
@@ -37,6 +38,7 @@ interface SystemMessage {
   // 個別お知らせ用
   target_member_id?: string
   target_member_name?: string
+  target_user_id?: string
   // 配役結果用
   assignments?: Record<string, string>
 }
@@ -97,6 +99,8 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
   const [sending, setSending] = useState(false)
   const [members, setMembers] = useState<PrivateGroupMember[]>(initialMembers)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  // 個別お知らせのフォールバック表示を検知したら1回だけ診断ログを送る（#278）
+  const noticeFallbackLoggedRef = useRef(false)
   const [showSurveyDialog, setShowSurveyDialog] = useState(false)
   // 配役方法変更の確認ダイアログ（アンケート回答カード/キャラクター選択カードの両方から起動）
   const [showResetCharAssignmentConfirm, setShowResetCharAssignmentConfirm] = useState(false)
@@ -650,6 +654,14 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
     <Card className={`flex flex-col ${fullHeight ? 'flex-1 h-full border-0 shadow-none' : 'h-[500px]'}`}>
       <CardContent className="flex-1 flex flex-col p-0 overflow-hidden">
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {/* 未ログイン閲覧の警告（#275: 未ログインでもページは正常表示されるが個別お知らせだけ消えるため） */}
+          {!user && !currentMemberId && (
+            <div className="flex justify-center">
+              <div className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-800 max-w-sm text-center">
+                ログインしていないため、あなた宛の個別のお知らせは表示されません。参加時のアカウントでログインしてご確認ください。
+              </div>
+            </div>
+          )}
           {messages.length === 0 ? (
             <div className="text-center text-muted-foreground text-sm py-8">
               まだメッセージがありません。<br />
@@ -984,11 +996,24 @@ export function GroupChat({ groupId, currentMemberId, members: initialMembers, f
 
                   // システムメッセージ（個別お知らせ）- 対象者本人のみに表示
                   if (systemMsg && systemMsg.action === 'individual_notice') {
-                    // 対象メンバー本人でなければ表示しない
-                    if (systemMsg.target_member_id !== currentMemberId) {
+                    // 対象本人か判定（#275/#278）:
+                    // - member_id 一致（prop の currentMemberId が未解決でも user_id から引き直した effectiveMemberId で補完）
+                    // - または通知に埋め込まれた target_user_id とログインユーザーの一致（メンバー行の再作成後も届く）
+                    const isTargetByMember = !!effectiveMemberId && systemMsg.target_member_id === effectiveMemberId
+                    const isTargetByUser = !!user && !!systemMsg.target_user_id && systemMsg.target_user_id === user.id
+                    if (!isTargetByMember && !isTargetByUser) {
                       return null
                     }
-                    const currentMember = members.find(m => m.id === currentMemberId)
+                    // 診断: currentMemberId prop では不一致だがフォールバックで表示できた場合を記録（#278）
+                    if (systemMsg.target_member_id !== currentMemberId && !noticeFallbackLoggedRef.current) {
+                      noticeFallbackLoggedRef.current = true
+                      Sentry.captureMessage('individual_notice: currentMemberId未解決のためフォールバック表示', {
+                        level: 'warning',
+                        tags: { feature: 'group-chat' },
+                        extra: { groupId, currentMemberId, memberIdFromUser, hasUser: !!user },
+                      })
+                    }
+                    const currentMember = members.find(m => m.id === effectiveMemberId)
                     const nickname = currentMember?.guest_name || 'あなた'
                     return (
                       <div key={msg.id} className="flex justify-center my-4">


### PR DESCRIPTION
## 背景（#275 / #278）

7/5「エンドロールは流れない」のハンドアウト非表示（#275）の原因調査で、報告者は**セッション切れの端末**でグループページを閲覧していたことがSentryログ＋DB照合で確定した（詳細は #278）。グループページは未ログインでも正常に表示されるため本人は気づけず、`individual_notice`だけが静かに消える。あわせて、退出（物理DELETE）で通知の宛先が孤児化する構造問題も確認された。

## 変更内容

**GroupChat.tsx**
1. `individual_notice`の表示判定を`currentMemberId`完全一致から多重判定に変更:
   - `effectiveMemberId`（user_idから引き直すフォールバック付き）とのmember_id一致
   - 通知JSONの`target_user_id`とログインユーザーの一致（メンバー行が削除・再作成されても届く）
2. `currentMemberId`未解決でフォールバック表示した場合、Sentryへ診断ログを1回送信（今後同症状が起きた際にお客様への聞き取りなしで原因が判明する）
3. **未ログイン閲覧時にバナー表示**「ログインしていないため、あなた宛の個別のお知らせは表示されません」——今回の真因（未ログインでも見た目が完全に正常）への直接対策

**SurveyResponsesTab.tsx**
4. 個別お知らせ送信時にJSONへ`target_user_id`を併記（1の後段判定の供給元）

## 検証

- staging/本番DBの既存通知（`target_user_id`なし）は1のフォールバック判定で従来どおり表示される（後方互換）
- 変更ファイルはローカル検証版とpush内容の完全一致をdiffで確認済み

## 残タスク（別対応）

- 退出のソフトデリート化・アンケート回答CASCADE見直し・宛先生存チェック（#278の中期項目）
- **Vercelの環境変数 `VITE_APP_ENV` / `VITE_APP_VERSION` が未設定**でSentryのrelease追跡が壊れている（#278参照・要ダッシュボード設定）

Refs #275, #278