### PR TITLE
feat(security): PINをsecretsテーブルへ分離＋bcryptハッシュ化（#281/#283）

### DIFF
--- a/supabase/migrations/20260705120000_create_member_secrets_table.sql
+++ b/supabase/migrations/20260705120000_create_member_secrets_table.sql
@@ -1,0 +1,30 @@
+-- #281 / #283: ゲストPINをmembersテーブルから分離した秘匿テーブル。
+--
+-- 背景（#280 監査）:
+--   private_group_members は RLS が USING(true) の全開放で、anon から access_pin を
+--   直接 SELECT できてしまう（本番検証済み）。列単位 GRANT は PostgREST の埋め込み取得と
+--   相性が悪く permission denied を招くため使えない（#281 コメント参照）。
+--   よって PIN を別テーブルへ分離し、RLS で全ロール遮断、SECURITY DEFINER RPC のみが
+--   アクセスできる構成にする。ハッシュ化（#283）も同時に満たす。
+--
+-- failed_attempts / locked_until は #282（レート制限）で使用する器も兼ねる。
+
+CREATE TABLE IF NOT EXISTS public.private_group_member_secrets (
+  member_id       UUID PRIMARY KEY REFERENCES public.private_group_members(id) ON DELETE CASCADE,
+  access_pin_hash TEXT NOT NULL,
+  failed_attempts INT NOT NULL DEFAULT 0,
+  locked_until    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.private_group_member_secrets ENABLE ROW LEVEL SECURITY;
+
+-- RLS 有効・ポリシー無し = anon / authenticated からの直接アクセスは一切不可。
+-- SECURITY DEFINER 関数（テーブル所有者権限で実行）だけが読み書きする。
+-- 念のため明示的にテーブル権限も剥奪しておく。
+REVOKE ALL ON public.private_group_member_secrets FROM anon;
+REVOKE ALL ON public.private_group_member_secrets FROM authenticated;
+
+COMMENT ON TABLE public.private_group_member_secrets IS
+  'ゲストPINのbcryptハッシュと認証試行状態。RLSで全ロール遮断し、SECURITY DEFINER RPCのみアクセス可（#281/#283）';

--- a/supabase/migrations/20260705120100_update_pin_rpcs_to_hashed_secrets.sql
+++ b/supabase/migrations/20260705120100_update_pin_rpcs_to_hashed_secrets.sql
@@ -1,0 +1,131 @@
+-- #281 / #283: PIN の保存・認証 RPC を secrets テーブル（bcryptハッシュ）ベースに差し替える。
+-- シグネチャは既存のまま維持するため、アプリ側のコード変更は不要。
+
+-- ============================================================
+-- 1) save_guest_access_pin: 平文保存 → secrets への bcrypt ハッシュ保存
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.save_guest_access_pin(
+  p_member_id UUID,
+  p_pin TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_member RECORD;
+BEGIN
+  SELECT * INTO v_member
+  FROM public.private_group_members
+  WHERE id = p_member_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Member not found';
+  END IF;
+
+  -- ゲストユーザー（user_id が NULL）のみ PIN 設定可能
+  IF v_member.user_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Only guest members can have PIN';
+  END IF;
+
+  -- secrets に bcrypt ハッシュで upsert
+  INSERT INTO public.private_group_member_secrets (member_id, access_pin_hash, failed_attempts, locked_until, updated_at)
+  VALUES (p_member_id, crypt(p_pin, gen_salt('bf')), 0, NULL, now())
+  ON CONFLICT (member_id)
+  DO UPDATE SET access_pin_hash = EXCLUDED.access_pin_hash,
+                failed_attempts = 0,
+                locked_until    = NULL,
+                updated_at      = now();
+
+  -- 平文カラムには保存しない（露出防止）。移行期間中の後方互換のため列自体は残すが NULL 化する。
+  UPDATE public.private_group_members
+  SET access_pin = NULL
+  WHERE id = p_member_id;
+
+  RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.save_guest_access_pin IS
+  'ゲストPINをsecretsテーブルにbcryptハッシュで保存する（#281/#283）';
+
+GRANT EXECUTE ON FUNCTION public.save_guest_access_pin TO anon;
+GRANT EXECUTE ON FUNCTION public.save_guest_access_pin TO authenticated;
+
+-- ============================================================
+-- 2) authenticate_guest_by_pin: 平文照合 → secrets のハッシュ照合
+--    後方互換: secrets が無いメンバーは旧 access_pin(平文) で照合し、
+--    成功時に secrets へ自動移行してから平文を NULL 化する（段階移行のフォールバック）。
+--    OUTパラメータ名(member_id 等)とテーブル列名の衝突を避けるため #variable_conflict use_column を指定。
+-- ============================================================
+DROP FUNCTION IF EXISTS public.authenticate_guest_by_pin(uuid, text, text);
+
+CREATE FUNCTION public.authenticate_guest_by_pin(
+  p_group_id UUID,
+  p_email TEXT,
+  p_pin TEXT
+)
+RETURNS TABLE (
+  member_id UUID,
+  guest_name TEXT,
+  guest_email TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+#variable_conflict use_column
+DECLARE
+  v_member RECORD;
+  v_hash TEXT;
+  v_ok BOOLEAN := FALSE;
+BEGIN
+  SELECT pgm.id, pgm.guest_name, pgm.guest_email, pgm.access_pin
+  INTO v_member
+  FROM public.private_group_members pgm
+  WHERE pgm.group_id = p_group_id
+    AND LOWER(pgm.guest_email) = LOWER(p_email)
+    AND pgm.status = 'joined'
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  SELECT s.access_pin_hash INTO v_hash
+  FROM public.private_group_member_secrets s
+  WHERE s.member_id = v_member.id;
+
+  IF v_hash IS NOT NULL THEN
+    -- 通常経路: bcrypt ハッシュ照合
+    IF v_hash = crypt(p_pin, v_hash) THEN
+      v_ok := TRUE;
+    END IF;
+  ELSIF v_member.access_pin IS NOT NULL THEN
+    -- フォールバック: 旧平文で照合し、成功したら secrets へ移行して平文を NULL 化
+    IF v_member.access_pin = p_pin THEN
+      v_ok := TRUE;
+      INSERT INTO public.private_group_member_secrets (member_id, access_pin_hash, updated_at)
+      VALUES (v_member.id, crypt(p_pin, gen_salt('bf')), now())
+      ON CONFLICT (member_id) DO NOTHING;
+      UPDATE public.private_group_members SET access_pin = NULL WHERE id = v_member.id;
+    END IF;
+  END IF;
+
+  IF v_ok THEN
+    member_id   := v_member.id;
+    guest_name  := v_member.guest_name;
+    guest_email := v_member.guest_email;
+    RETURN NEXT;
+  END IF;
+
+  RETURN;
+END;
+$$;
+
+COMMENT ON FUNCTION public.authenticate_guest_by_pin IS
+  'ゲストPIN認証。secretsのbcryptハッシュ照合＋旧平文フォールバック自動移行（#281/#283）';
+
+GRANT EXECUTE ON FUNCTION public.authenticate_guest_by_pin TO anon;
+GRANT EXECUTE ON FUNCTION public.authenticate_guest_by_pin TO authenticated;

--- a/supabase/migrations/20260705120200_migrate_existing_plaintext_pins.sql
+++ b/supabase/migrations/20260705120200_migrate_existing_plaintext_pins.sql
@@ -1,0 +1,23 @@
+-- #281 / #283: 既存の平文 access_pin を secrets へ bcrypt ハッシュで一括移行し、平文を NULL 化する。
+--
+-- 冪等性:
+--   - INSERT は ON CONFLICT DO NOTHING で、既に secrets がある member はスキップ。
+--   - UPDATE は secrets にハッシュが存在する行のみ NULL 化。
+--   本 migration を複数回流しても安全。
+--
+-- 補足:
+--   仮に移行を取りこぼした member がいても、authenticate_guest_by_pin の
+--   フォールバック（旧平文照合→自動移行）で救済されるため、既存ゲストは締め出されない。
+
+-- 平文 PIN を secrets へハッシュ移行
+INSERT INTO public.private_group_member_secrets (member_id, access_pin_hash, updated_at)
+SELECT id, crypt(access_pin, gen_salt('bf')), now()
+FROM public.private_group_members
+WHERE access_pin IS NOT NULL
+ON CONFLICT (member_id) DO NOTHING;
+
+-- 移行済みの平文を消去（露出防止）
+UPDATE public.private_group_members m
+SET access_pin = NULL
+WHERE m.access_pin IS NOT NULL
+  AND EXISTS (SELECT 1 FROM public.private_group_member_secrets s WHERE s.member_id = m.id);


### PR DESCRIPTION
## ⚠️ クローズ: 設計方針の誤りが判明したため

本番適用直前の調査で、**本 PR の「新規 secrets テーブル方式」は本番スキーマと不整合**であることが判明したためクローズする。

- 本番には既に `private_group_members_pii` テーブルがあり、現行の `authenticate_guest_by_pin` はそちらの `access_pin` を照合している
- 本 PR は staging の古い実装（members 側 access_pin を参照）を前提に設計されており、本番に流すと使われていない新テーブルを見に行き**全ゲストが認証不能**になる恐れがあった
- 詳細と正しい再設計方針は #281 のコメント参照

ブランチ `security/280-281-283-pin-secrets-hash` は参考として残す。次セッションで「既存 `private_group_members_pii.access_pin` のハッシュ化」方式に作り直す。

（元の説明は履歴として残置）

---

（旧説明）secrets 分離＋ハッシュ化の実装。staging では検証済みだったが、本番スキーマとの drift により方式ごと見直し。