### PR TITLE
ci: ai-todoラベル付与で実装Claudeを自動起動（issue→PRの配線）

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,0 +1,42 @@
+name: Claude Implement (ai-todo)
+
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: claude-implement-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  implement:
+    if: github.event.label.name == 'ai-todo'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            gh issue view ${{ github.event.issue.number }} --comments で issue を読み、
+            「調査してほしいこと」を順に検証して原因を特定し、修正を実装してください。
+
+            - 作業ブランチは staging から作成し、PR は gh pr create --base staging で作成する
+            - PR 本文には原因・修正内容・「受入条件」との対応を書き、Refs #${{ github.event.issue.number }} を含める
+            - PR 作成後、issue に PR へのリンクをコメントする
+            - コードから原因を特定できない、またはデータ起因の可能性が高い場合は、
+              修正せず調査結果と仮説・確認手順を issue にコメントして終了する
+          claude_args: |
+            --allowedTools "Edit,MultiEdit,Glob,Grep,LS,Read,Write,Bash(git add:*),Bash(git checkout:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(npm run typecheck:*),Bash(npm run build:fast:*)"
+            --append-system-prompt "作業ブランチは staging から作成し、PR は必ず --base staging で作成する（main への PR は絶対に作らない）。organization_id によるマルチテナント分離を必ず維持する。reservation_source は src/lib/constants.ts の定数を使う。RLS ポリシーの変更は行わず SECURITY DEFINER RPC で対応する。コードコメントは原則書かない（WHYが非自明な場合のみ）。"


### PR DESCRIPTION
## 背景

Discord報告 → 自動起票 → groomer整形 → 実装 → PR → 自動レビュー のパイプラインのうち、「整形済みissue → 実装」の接続が存在せず、実装は `@claude` 手動コメントでしか始まらなかった。`ai-todo` ラベルを着手指示として使い、この区間を自動化する。

## 変更内容

`.github/workflows/claude-implement.yml` を新規追加。

- `issues: [labeled]` で発火し、ラベル名が `ai-todo` のときのみ実行
- issueの「調査してほしいこと」「受入条件」に沿って原因調査 → 修正 → `--base staging` でPR作成 → issueにPRリンクをコメント
- 原因を特定できない・データ起因の疑いが強い場合は、修正せず調査結果と仮説をissueにコメントして終了（空振り時の暴走防止）
- 制約（staging基点・マルチテナント分離・RLS方針等）と許可ツールは既存 `claude.yml` に準拠（`gh issue view` / `gh issue comment` を追加）
- `concurrency` で同一issueの多重起動を防止

## 有効化条件（重要）

`issues` イベントは**デフォルトブランチ（main）上のワークフロー定義でのみ発火**するため、本PRのマージ（staging）だけでは動作しない。次回の staging → main デプロイPRに含まれた時点で有効になる。

## 運用

- **ai-todo付与＝着手指示**。付与は人間またはCoworkセッションの判断で行う（groomerには自動付与させない）
- 現在のキュー: #289 / #297。有効化後にラベルを一度外して再付与すると発火する

🤖 Generated with Claude (Cowork)