### PR TITLE
fix(db): 顧客紐付けmigration/RPCでorganization_idのNULLリセット漏れを修正

### DIFF
--- a/supabase/migrations/20260706220000_add_link_current_user_to_customer_rpc.sql
+++ b/supabase/migrations/20260706220000_add_link_current_user_to_customer_rpc.sql
@@ -13,7 +13,9 @@
 --   20260519000000_platform_customers_phase1.sql の不変条件「ログイン済み顧客
 --   (user_id IS NOT NULL) は organization_id = NULL」を保つため、user_id と同時に
 --   organization_id も NULL にする（20260521030000_backfill_platform_customers_org_null.sql
---   と同じ理由）。
+--   と同じ理由）。ただしリセットするのは呼び出しユーザーの public.users.role = 'customer'
+--   のときのみ。20260521030000 と同じガードで、staff/admin/license_admin が自分用に持つ
+--   customer 行の organization_id は変更しない。
 --
 -- 組織横断のゲスト重複について:
 --   未紐付け候補の一意性チェック（下記 v_match_count）は organization_id を問わずグローバルに
@@ -30,6 +32,7 @@ AS $$
 DECLARE
   v_uid         uuid := auth.uid();
   v_email       text;
+  v_role        app_role;
   v_customer_id uuid;
   v_match_count integer;
 BEGIN
@@ -55,6 +58,12 @@ BEGIN
     RETURN NULL;
   END IF;
 
+  -- 呼び出しユーザー自身の role（staff/admin/license_admin が自分用の customer 行を
+  -- 誤って組織から外さないためのガード。20260521030000 と同じ条件）
+  SELECT role INTO v_role
+  FROM public.users
+  WHERE id = v_uid;
+
   -- 未紐付けの候補が「ちょうど1件」のときのみ紐付ける（組織横断でグローバルにチェック。
   -- 重複メール・複数組織ゲスト重複は曖昧とみなしスキップ）
   SELECT count(*) INTO v_match_count
@@ -65,7 +74,7 @@ BEGIN
   IF v_match_count = 1 THEN
     UPDATE public.customers
     SET user_id = v_uid,
-        organization_id = NULL,
+        organization_id = CASE WHEN v_role = 'customer' THEN NULL ELSE organization_id END,
         updated_at = NOW()
     WHERE user_id IS NULL
       AND lower(email) = v_email

--- a/supabase/migrations/20260706220000_add_link_current_user_to_customer_rpc.sql
+++ b/supabase/migrations/20260706220000_add_link_current_user_to_customer_rpc.sql
@@ -7,6 +7,19 @@
 --   照合キーは「auth.users から取得した本人の検証済みメール」のみ。クライアント指定のメールは
 --   信用しないため、他人の customers 行を掴むことはできない。プラットフォーム顧客モデルでは
 --   email に全体ユニークインデックスがあり、1ユーザー=1顧客行に対応する。
+--
+-- organization_id のリセット:
+--   紐付け対象の行は元々ゲスト顧客（organization_id が特定の組織を指す）。
+--   20260519000000_platform_customers_phase1.sql の不変条件「ログイン済み顧客
+--   (user_id IS NOT NULL) は organization_id = NULL」を保つため、user_id と同時に
+--   organization_id も NULL にする（20260521030000_backfill_platform_customers_org_null.sql
+--   と同じ理由）。
+--
+-- 組織横断のゲスト重複について:
+--   未紐付け候補の一意性チェック（下記 v_match_count）は organization_id を問わずグローバルに
+--   行っている。同一人物が複数組織にゲストとして重複登録されている場合は v_match_count > 1 と
+--   なり意図的にスキップする（NULL を返す＝紐付けない）。誤って別組織の顧客行を紐付けるリスクを
+--   避けるための安全側の判断であり、該当ユーザーは自動では救済されない。
 
 CREATE OR REPLACE FUNCTION public.link_current_user_to_customer()
 RETURNS uuid
@@ -42,7 +55,8 @@ BEGIN
     RETURN NULL;
   END IF;
 
-  -- 未紐付けの候補が「ちょうど1件」のときのみ紐付ける（重複メールは曖昧なのでスキップ）
+  -- 未紐付けの候補が「ちょうど1件」のときのみ紐付ける（組織横断でグローバルにチェック。
+  -- 重複メール・複数組織ゲスト重複は曖昧とみなしスキップ）
   SELECT count(*) INTO v_match_count
   FROM public.customers
   WHERE user_id IS NULL
@@ -51,6 +65,7 @@ BEGIN
   IF v_match_count = 1 THEN
     UPDATE public.customers
     SET user_id = v_uid,
+        organization_id = NULL,
         updated_at = NOW()
     WHERE user_id IS NULL
       AND lower(email) = v_email

--- a/supabase/migrations/20260706220100_backfill_customers_user_id.sql
+++ b/supabase/migrations/20260706220100_backfill_customers_user_id.sql
@@ -3,10 +3,21 @@
 --
 -- 意図的にスキップされる（＝変更されない）行:
 --   - lower(email) が auth.users 側で複数一致 → 曖昧
---   - lower(email) が未紐付け customers 側で複数 → 重複メール（issue #308 で1組確認済み）
+--   - lower(email) が未紐付け customers 側で複数 → 重複メール（issue #308 で1組確認済み）。
+--     この一意性チェックは organization_id を問わずグローバルに行っているため、同一人物が
+--     複数組織にゲストとして重複登録されているケース（組織ごとに別行が正のモデル）もここで
+--     スキップされる。誤って別組織の顧客行を紐付けるリスクを避けるための安全側の判断であり、
+--     該当行は本バックフィルでは救済しない。手動での重複解消・案内は運用側で対応する。
 --   - auth.users に対応メールが存在しない → 照合不能
 --   - 対応 user_id が既に別の customers 行に紐付いている → 重複紐付け防止
 -- スキップされた行は user_id IS NULL のまま残る。RLS ポリシーは一切変更しない。
+--
+-- organization_id のリセット:
+--   紐付け対象の行は元々ゲスト顧客（organization_id が特定の組織を指す）。
+--   20260519000000_platform_customers_phase1.sql の不変条件「ログイン済み顧客
+--   (user_id IS NOT NULL) は organization_id = NULL」を保つため、user_id と同時に
+--   organization_id も NULL にする（20260521030000_backfill_platform_customers_org_null.sql
+--   と同じ理由。これを怠ると他組織での予約が api/reservations.ts の境界チェックで拒否される）。
 
 DO $$
 DECLARE
@@ -18,6 +29,7 @@ BEGIN
 
   UPDATE public.customers c
   SET user_id = au.id,
+      organization_id = NULL,
       updated_at = NOW()
   FROM auth.users au
   WHERE c.user_id IS NULL
@@ -26,7 +38,8 @@ BEGIN
     -- auth.users 側で一意
     AND (SELECT count(*) FROM auth.users au2
          WHERE lower(au2.email) = lower(c.email)) = 1
-    -- 未紐付け customers 側で一意（重複メールをスキップ）
+    -- 未紐付け customers 側で一意（組織横断でグローバルにチェック。重複メール・複数組織
+    -- ゲスト重複は曖昧とみなしスキップ）
     AND (SELECT count(*) FROM public.customers c2
          WHERE c2.user_id IS NULL AND lower(c2.email) = lower(c.email)) = 1
     -- その user_id が既に別行に紐付いていない

--- a/supabase/migrations/20260706220100_backfill_customers_user_id.sql
+++ b/supabase/migrations/20260706220100_backfill_customers_user_id.sql
@@ -18,6 +18,9 @@
 --   (user_id IS NOT NULL) は organization_id = NULL」を保つため、user_id と同時に
 --   organization_id も NULL にする（20260521030000_backfill_platform_customers_org_null.sql
 --   と同じ理由。これを怠ると他組織での予約が api/reservations.ts の境界チェックで拒否される）。
+--   ただしリセットするのは紐付け先の public.users.role = 'customer' の場合のみ。
+--   20260521030000 と同じガードで、staff/admin/license_admin が自分用に持つ customer 行の
+--   organization_id は変更しない。
 
 DO $$
 DECLARE
@@ -29,9 +32,10 @@ BEGIN
 
   UPDATE public.customers c
   SET user_id = au.id,
-      organization_id = NULL,
+      organization_id = CASE WHEN u.role = 'customer' THEN NULL ELSE c.organization_id END,
       updated_at = NOW()
   FROM auth.users au
+  LEFT JOIN public.users u ON u.id = au.id
   WHERE c.user_id IS NULL
     AND c.email IS NOT NULL
     AND lower(c.email) = lower(au.email)


### PR DESCRIPTION
## 概要
PR #309 のレビュー指摘(Claude・Codex両者が独立に指摘)に対応。

1. バックフィルmigrationとRPCの両方で、`user_id` を設定する際に `organization_id = NULL` も同時に設定(プラットフォーム顧客の不変条件。過去の是正migration `20260521030000` と同じ理由)
2. 組織横断のゲスト重複(同一emailが複数組織に存在)が意図的にスキップされる設計であることをmigration内コメントに明記

migrationはまだDB未適用のため、本番適用前にこの修正を取り込む(DB変更→フロントデプロイの順序は維持)。

Refs #309, #308

🤖 Generated with Claude (Cowork)