### PR TITLE
fix(db): #320復旧 — 7/5本番適用済みmigration 5本を本番実装から復元

### DIFF
--- a/supabase/migrations/20260705130528_secure_private_group_members_full_view_step1_invoker.sql
+++ b/supabase/migrations/20260705130528_secure_private_group_members_full_view_step1_invoker.sql
@@ -1,24 +1,11 @@
--- [#320 復旧] 本ファイルは 2026-07-05 にローカルから本番へ直接適用済みの変更を、
--- 2026-07-07 に本番DBの実装(pg_get_viewdef / reloptions)から再構成したもの。
--- 本番: schema_migrations に本バージョン登録済みのため再実行されない(ファイル配置は履歴照合のため)。
--- staging: 本ファイルにより初適用される。冪等に記述。
+-- ====================================================================
+-- #281 対策 (第1段階/2): private_group_members_full ビューに
+--   security_invoker=true を設定し、ビュー経由でもRLSが評価されるようにする。
 --
--- 内容: private_group_members_full ビューを security_invoker=true にし、
--- ビュー経由のアクセスでも呼び出し元の権限・RLSで評価されるようにする。
-
-CREATE OR REPLACE VIEW public.private_group_members_full AS
- SELECT m.id,
-    m.group_id,
-    m.user_id,
-    m.is_organizer,
-    m.status,
-    m.joined_at,
-    m.created_at,
-    pii.guest_name,
-    pii.guest_email,
-    pii.guest_phone,
-    pii.access_pin
-   FROM public.private_group_members m
-     LEFT JOIN public.private_group_members_pii pii ON pii.member_id = m.id;
-
+-- この段階では権限(GRANT)は一切変更しない。よってアクセス可能性は変わらず、
+-- 機能に影響を与えずにRLSの多層防御だけを追加する。
+-- 第2段階でanon/authenticatedのアクセス権をREVOKEする。
+--
+-- 切り戻し: ALTER VIEW public.private_group_members_full SET (security_invoker = false);
+-- ====================================================================
 ALTER VIEW public.private_group_members_full SET (security_invoker = true);

--- a/supabase/migrations/20260705130528_secure_private_group_members_full_view_step1_invoker.sql
+++ b/supabase/migrations/20260705130528_secure_private_group_members_full_view_step1_invoker.sql
@@ -1,0 +1,24 @@
+-- [#320 復旧] 本ファイルは 2026-07-05 にローカルから本番へ直接適用済みの変更を、
+-- 2026-07-07 に本番DBの実装(pg_get_viewdef / reloptions)から再構成したもの。
+-- 本番: schema_migrations に本バージョン登録済みのため再実行されない(ファイル配置は履歴照合のため)。
+-- staging: 本ファイルにより初適用される。冪等に記述。
+--
+-- 内容: private_group_members_full ビューを security_invoker=true にし、
+-- ビュー経由のアクセスでも呼び出し元の権限・RLSで評価されるようにする。
+
+CREATE OR REPLACE VIEW public.private_group_members_full AS
+ SELECT m.id,
+    m.group_id,
+    m.user_id,
+    m.is_organizer,
+    m.status,
+    m.joined_at,
+    m.created_at,
+    pii.guest_name,
+    pii.guest_email,
+    pii.guest_phone,
+    pii.access_pin
+   FROM public.private_group_members m
+     LEFT JOIN public.private_group_members_pii pii ON pii.member_id = m.id;
+
+ALTER VIEW public.private_group_members_full SET (security_invoker = true);

--- a/supabase/migrations/20260705131941_secure_private_group_members_full_view_step2_revoke.sql
+++ b/supabase/migrations/20260705131941_secure_private_group_members_full_view_step2_revoke.sql
@@ -1,8 +1,13 @@
--- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
+-- ====================================================================
+-- #281 対策 (第2段階/2): private_group_members_full ビューへの
+--   anon / authenticated のアクセス権を剥奪する。
 --
--- 内容: PII を含む private_group_members_full ビューへの anon / authenticated の
--- 直接アクセスを剥奪し、service_role のみに限定する(本番の現行GRANT状態と一致)。
-
-REVOKE ALL ON public.private_group_members_full FROM anon;
-REVOKE ALL ON public.private_group_members_full FROM authenticated;
-GRANT ALL ON public.private_group_members_full TO service_role;
+-- 第1段階(security_invoker=true)でPII露出は既にRLSにより遮断済み。
+-- 本段階は多層防御として入口(GRANT)自体を閉じる。
+-- service_role の権限は維持する（管理系の動作に必要）。
+--
+-- フロント・Edge Function・DB内オブジェクトからの参照は無いことを確認済み。
+--
+-- 切り戻し: GRANT SELECT ON public.private_group_members_full TO anon, authenticated;
+-- ====================================================================
+REVOKE ALL ON public.private_group_members_full FROM anon, authenticated;

--- a/supabase/migrations/20260705131941_secure_private_group_members_full_view_step2_revoke.sql
+++ b/supabase/migrations/20260705131941_secure_private_group_members_full_view_step2_revoke.sql
@@ -1,0 +1,8 @@
+-- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
+--
+-- 内容: PII を含む private_group_members_full ビューへの anon / authenticated の
+-- 直接アクセスを剥奪し、service_role のみに限定する(本番の現行GRANT状態と一致)。
+
+REVOKE ALL ON public.private_group_members_full FROM anon;
+REVOKE ALL ON public.private_group_members_full FROM authenticated;
+GRANT ALL ON public.private_group_members_full TO service_role;

--- a/supabase/migrations/20260705133500_stop_syncing_access_pin_in_pii_trigger.sql
+++ b/supabase/migrations/20260705133500_stop_syncing_access_pin_in_pii_trigger.sql
@@ -1,13 +1,22 @@
--- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
+-- ====================================================================
+-- #281/#283 対策 (members.access_pin 封鎖 ステップ1/2)
 --
--- 内容: PII同期トリガーから access_pin の同期を除去する。
--- (members.access_pin は廃止予定の遺物。UPDATE のたびに NEW.access_pin(NULL) で
---  pii 側の PIN を消してしまう潜在バグもこれで解消)
-
+-- 同期トリガー sync_private_group_member_pii を修正し、access_pin を
+-- PII同期の対象から除外する。
+--
+-- 目的: 次ステップで members.access_pin を NULL 化する際、旧トリガーだと
+--       pii.access_pin まで NULL で上書きされ全ゲストのPINログインが不能に
+--       なる。これを防ぐため、先にトリガーから access_pin 同期を外す。
+--
+-- PIN の唯一の正規書き込み経路は save_guest_access_pin RPC（pii側にのみ書く）。
+-- このステップは関数定義の入れ替えのみで、既存データは変更しない。
+--
+-- 切り戻し: 旧定義（access_pin を EXCLUDED に含む版）を再適用する。
+-- ====================================================================
 CREATE OR REPLACE FUNCTION public.sync_private_group_member_pii()
- RETURNS trigger
- LANGUAGE plpgsql
- SECURITY DEFINER
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
 AS $function$
 BEGIN
   -- INSERT または UPDATE 時に PII テーブルへ個人情報を同期する。

--- a/supabase/migrations/20260705133500_stop_syncing_access_pin_in_pii_trigger.sql
+++ b/supabase/migrations/20260705133500_stop_syncing_access_pin_in_pii_trigger.sql
@@ -1,0 +1,24 @@
+-- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
+--
+-- 内容: PII同期トリガーから access_pin の同期を除去する。
+-- (members.access_pin は廃止予定の遺物。UPDATE のたびに NEW.access_pin(NULL) で
+--  pii 側の PIN を消してしまう潜在バグもこれで解消)
+
+CREATE OR REPLACE FUNCTION public.sync_private_group_member_pii()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  -- INSERT または UPDATE 時に PII テーブルへ個人情報を同期する。
+  -- access_pin はこのトリガーでは同期しない（members.access_pin は廃止予定の遺物）。
+  INSERT INTO public.private_group_members_pii (member_id, guest_name, guest_email, guest_phone, updated_at)
+  VALUES (NEW.id, NEW.guest_name, NEW.guest_email, NEW.guest_phone, NOW())
+  ON CONFLICT (member_id) DO UPDATE SET
+    guest_name = EXCLUDED.guest_name,
+    guest_email = EXCLUDED.guest_email,
+    guest_phone = EXCLUDED.guest_phone,
+    updated_at = NOW();
+  RETURN NEW;
+END;
+$function$;

--- a/supabase/migrations/20260705133524_null_out_legacy_members_access_pin.sql
+++ b/supabase/migrations/20260705133524_null_out_legacy_members_access_pin.sql
@@ -1,0 +1,8 @@
+-- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
+--
+-- 内容: 廃止予定の members.access_pin に残る平文PINを無効化(NULL化)する。
+-- PIN の正は private_group_members_pii.access_pin_hash (bcrypt)。冪等。
+
+UPDATE public.private_group_members
+SET access_pin = NULL
+WHERE access_pin IS NOT NULL;

--- a/supabase/migrations/20260705133524_null_out_legacy_members_access_pin.sql
+++ b/supabase/migrations/20260705133524_null_out_legacy_members_access_pin.sql
@@ -1,8 +1,24 @@
--- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
+-- ====================================================================
+-- #281/#283 対策 (members.access_pin 封鎖 ステップ2/2)
 --
--- 内容: 廃止予定の members.access_pin に残る平文PINを無効化(NULL化)する。
--- PIN の正は private_group_members_pii.access_pin_hash (bcrypt)。冪等。
-
-UPDATE public.private_group_members
+-- private_group_members.access_pin に残存する平文PIN(87件)をNULL化する。
+-- これにより anon がテーブル直接SELECTで平文PINを読める経路を塞ぐ。
+--
+-- 安全弁: pii 側に同一値のPINが保全されている行のみを対象にする。
+--         （万一保全されていない行があれば触らず、情報損失を防ぐ）
+-- ステップ1でトリガーからaccess_pin同期を除外済みのため、この更新で
+-- pii.access_pin が破壊されることはない。
+--
+-- 切り戻し: 値は pii 側に完全保全されているため、必要なら
+--   UPDATE private_group_members m SET access_pin = p.access_pin
+--   FROM private_group_members_pii p WHERE p.member_id = m.id;
+--   で書き戻せる（ただし戻す理由はない）。
+-- ====================================================================
+UPDATE public.private_group_members m
 SET access_pin = NULL
-WHERE access_pin IS NOT NULL;
+WHERE m.access_pin IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM public.private_group_members_pii p
+    WHERE p.member_id = m.id
+      AND p.access_pin = m.access_pin
+  );

--- a/supabase/migrations/20260705142458_hash_guest_access_pins_bcrypt.sql
+++ b/supabase/migrations/20260705142458_hash_guest_access_pins_bcrypt.sql
@@ -1,0 +1,106 @@
+-- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
+--
+-- 内容: ゲストPINの bcrypt ハッシュ化。
+-- 1) pii テーブルに必要列を追加(staging用・冪等)
+-- 2) 残存平文PINを一括ハッシュ化して平文を消去
+-- 3) 保存RPC: ハッシュのみ保存 / 認証RPC: bcrypt照合+旧平文からの遅延移行
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+
+ALTER TABLE public.private_group_members_pii ADD COLUMN IF NOT EXISTS access_pin_hash text;
+ALTER TABLE public.private_group_members_pii ADD COLUMN IF NOT EXISTS failed_attempts integer NOT NULL DEFAULT 0;
+ALTER TABLE public.private_group_members_pii ADD COLUMN IF NOT EXISTS locked_until timestamptz;
+
+UPDATE public.private_group_members_pii
+SET access_pin_hash = extensions.crypt(access_pin, extensions.gen_salt('bf')),
+    access_pin = NULL,
+    updated_at = now()
+WHERE access_pin IS NOT NULL
+  AND access_pin_hash IS NULL;
+
+CREATE OR REPLACE FUNCTION public.save_guest_access_pin(p_member_id uuid, p_pin text)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_member RECORD;
+BEGIN
+  SELECT * INTO v_member
+  FROM public.private_group_members
+  WHERE id = p_member_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Member not found';
+  END IF;
+
+  IF v_member.user_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Only guest members can have PIN';
+  END IF;
+
+  INSERT INTO public.private_group_members_pii (member_id, access_pin_hash, access_pin, failed_attempts, locked_until, updated_at)
+  VALUES (p_member_id, extensions.crypt(p_pin, extensions.gen_salt('bf')), NULL, 0, NULL, now())
+  ON CONFLICT (member_id) DO UPDATE SET
+    access_pin_hash = EXCLUDED.access_pin_hash,
+    access_pin = NULL,
+    failed_attempts = 0,
+    locked_until = NULL,
+    updated_at = now();
+
+  RETURN TRUE;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.authenticate_guest_by_pin(p_group_id uuid, p_email text, p_pin text)
+ RETURNS TABLE(member_id uuid, guest_name text, guest_email text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_name text;
+  v_email text;
+  v_hash text;
+  v_plain text;
+  v_ok boolean := false;
+BEGIN
+  SELECT pgm.id, pii.guest_name, pii.guest_email, pii.access_pin_hash, pii.access_pin
+  INTO v_member_id, v_name, v_email, v_hash, v_plain
+  FROM public.private_group_members pgm
+  JOIN public.private_group_members_pii pii ON pii.member_id = pgm.id
+  WHERE pgm.group_id = p_group_id
+    AND LOWER(pii.guest_email) = LOWER(p_email)
+    AND pgm.status = 'joined'
+  LIMIT 1;
+
+  IF v_member_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF v_hash IS NOT NULL THEN
+    IF v_hash = extensions.crypt(p_pin, v_hash) THEN
+      v_ok := true;
+    END IF;
+  ELSIF v_plain IS NOT NULL THEN
+    IF v_plain = p_pin THEN
+      v_ok := true;
+      UPDATE public.private_group_members_pii pii2
+      SET access_pin_hash = extensions.crypt(p_pin, extensions.gen_salt('bf')),
+          access_pin = NULL,
+          updated_at = now()
+      WHERE pii2.member_id = v_member_id;
+    END IF;
+  END IF;
+
+  IF v_ok THEN
+    member_id := v_member_id;
+    guest_name := v_name;
+    guest_email := v_email;
+    RETURN NEXT;
+  END IF;
+
+  RETURN;
+END;
+$function$;

--- a/supabase/migrations/20260705142458_hash_guest_access_pins_bcrypt.sql
+++ b/supabase/migrations/20260705142458_hash_guest_access_pins_bcrypt.sql
@@ -1,28 +1,17 @@
--- [#320 復旧] 2026-07-05 本番適用済み変更の再構成(詳細は 20260705130528 のヘッダ参照)。
---
--- 内容: ゲストPINの bcrypt ハッシュ化。
--- 1) pii テーブルに必要列を追加(staging用・冪等)
--- 2) 残存平文PINを一括ハッシュ化して平文を消去
--- 3) 保存RPC: ハッシュのみ保存 / 認証RPC: bcrypt照合+旧平文からの遅延移行
+-- #283: pii.access_pin の bcrypt ハッシュ化（staging検証済み構成と同一）
 
-CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+-- 1) 列追加（#282 レート制限の土台列も同時に用意。ロジックは #282 で別途）
+ALTER TABLE public.private_group_members_pii
+  ADD COLUMN IF NOT EXISTS access_pin_hash text,
+  ADD COLUMN IF NOT EXISTS failed_attempts integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS locked_until timestamptz;
 
-ALTER TABLE public.private_group_members_pii ADD COLUMN IF NOT EXISTS access_pin_hash text;
-ALTER TABLE public.private_group_members_pii ADD COLUMN IF NOT EXISTS failed_attempts integer NOT NULL DEFAULT 0;
-ALTER TABLE public.private_group_members_pii ADD COLUMN IF NOT EXISTS locked_until timestamptz;
-
-UPDATE public.private_group_members_pii
-SET access_pin_hash = extensions.crypt(access_pin, extensions.gen_salt('bf')),
-    access_pin = NULL,
-    updated_at = now()
-WHERE access_pin IS NOT NULL
-  AND access_pin_hash IS NULL;
-
+-- 2) 保存経路をハッシュ化版に差し替え（以後、平文は一切書き込まれない）
 CREATE OR REPLACE FUNCTION public.save_guest_access_pin(p_member_id uuid, p_pin text)
- RETURNS boolean
- LANGUAGE plpgsql
- SECURITY DEFINER
- SET search_path TO 'public', 'extensions'
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
 AS $function$
 DECLARE
   v_member RECORD;
@@ -52,11 +41,13 @@ BEGIN
 END;
 $function$;
 
+-- 3) 認証経路をハッシュ照合＋平文フォールバック（自動移行）版に差し替え
+--    フォールバック内 UPDATE は pii2 で修飾（RETURNS TABLE の member_id と衝突するため）
 CREATE OR REPLACE FUNCTION public.authenticate_guest_by_pin(p_group_id uuid, p_email text, p_pin text)
- RETURNS TABLE(member_id uuid, guest_name text, guest_email text)
- LANGUAGE plpgsql
- SECURITY DEFINER
- SET search_path TO 'public', 'extensions'
+RETURNS TABLE(member_id uuid, guest_name text, guest_email text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
 AS $function$
 DECLARE
   v_member_id uuid;
@@ -104,3 +95,33 @@ BEGIN
   RETURN;
 END;
 $function$;
+
+-- 4) 既存平文のバックフィル（3段階・安全弁付き）
+-- 4-1) 平文からハッシュを生成（この時点では平文を残す）
+UPDATE public.private_group_members_pii
+SET access_pin_hash = extensions.crypt(access_pin, extensions.gen_salt('bf')),
+    updated_at = now()
+WHERE access_pin IS NOT NULL
+  AND access_pin_hash IS NULL;
+
+-- 4-2) 安全弁: 全件をハッシュ照合で検証。1件でも不一致なら例外 → 全ロールバック
+DO $$
+DECLARE
+  v_bad integer;
+BEGIN
+  SELECT count(*) INTO v_bad
+  FROM public.private_group_members_pii
+  WHERE access_pin IS NOT NULL
+    AND (access_pin_hash IS NULL
+         OR access_pin_hash <> extensions.crypt(access_pin, access_pin_hash));
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'PIN hash verification failed for % rows - aborting migration (full rollback)', v_bad;
+  END IF;
+END $$;
+
+-- 4-3) 照合一致が確認できた行のみ平文を破棄
+UPDATE public.private_group_members_pii
+SET access_pin = NULL,
+    updated_at = now()
+WHERE access_pin IS NOT NULL
+  AND access_pin_hash = extensions.crypt(access_pin, access_pin_hash);


### PR DESCRIPTION
## 概要
#320(デプロイ全滅)の復旧第1弾。緊急対応でローカルから本番へ直接適用され、リポジトリに存在しなかったmigration 5本を復元する。

## ⭐ 原本であることの保証(巻き戻しリスク・ゼロ)
当初は本番の現行実装から再構成したが、**本番DBの `supabase_migrations.schema_migrations.statements` に適用時のSQL原文が保存されていた**ため、**逐語の原本に差し替え済み**(2コミット目)。オリジナルのコメント・切り戻し手順・安全弁(ハッシュ照合検証→不一致なら全ロールバック)まで完全に一致する。

- **本番**: 5本とも履歴登録済みのため**一切実行されない**(ファイルの存在が履歴照合を通すだけ)
- **staging**: 本PRで初適用され、本番と同じPIN保護(bcrypt化・ビュー保護・トリガー修正)がstagingにも入る。前提オブジェクト(ビュー・トリガー関数・pii列)の存在は確認済み

## 内容(#281/#283 の緊急セキュリティ対応・原本)
1. `130528`: `private_group_members_full` ビューの security_invoker 化
2. `131941`: 同ビューへの anon/authenticated アクセス剥奪
3. `133500`: PII同期トリガーから access_pin 同期を除去
4. `133524`: members.access_pin の平文NULL化(pii側に保全済みの行のみ・安全弁付き)
5. `142458`: PINのbcryptハッシュ化(保存RPC・認証RPC差し替え+3段階バックフィル+検証安全弁。#282用のfailed_attempts/locked_until列も土台として追加)

## マージ後の残作業(#320参照)
1. staging履歴に残る実験9本(リポジトリに無い)の整理 — Cowork側で履歴行を削除(要承認)
2. 失敗した5本のデプロイをRe-run → 滞留分(開催決定メール等)が反映
3. #316 を最新stagingでリベース・再検証

Refs #320

🤖 Generated with Claude (Cowork)