### PR TITLE
【▶1】fix: 公開ラインナップの検索状態にクリア導線を追加

### DIFF
--- a/src/pages/PublicBookingTop/components/LineupView.tsx
+++ b/src/pages/PublicBookingTop/components/LineupView.tsx
@@ -20,6 +20,7 @@ interface LineupViewProps {
   isFavorite: (scenarioId: string) => boolean
   onToggleFavorite: (scenarioId: string, e: React.MouseEvent) => void
   searchTerm?: string
+  onClearSearch?: () => void
   organizationSlug?: string
   organizationName?: string | null
   selectedStoreIds?: string[]
@@ -41,6 +42,7 @@ export const LineupView = memo(function LineupView({
   isFavorite,
   onToggleFavorite,
   searchTerm = '',
+  onClearSearch,
   organizationSlug,
   organizationName,
   selectedStoreIds = [],
@@ -142,7 +144,12 @@ export const LineupView = memo(function LineupView({
             </div>
           ) : (
             <div className="text-center py-12 text-muted-foreground">
-              <p>該当するシナリオが見つかりませんでした</p>
+              <p className="mb-3">該当するシナリオが見つかりませんでした</p>
+              {onClearSearch && (
+                <Button variant="outline" size="sm" onClick={onClearSearch}>
+                  検索条件をクリア
+                </Button>
+              )}
             </div>
           )}
         </section>

--- a/src/pages/PublicBookingTop/components/SearchBar.tsx
+++ b/src/pages/PublicBookingTop/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { Search, BookOpen } from 'lucide-react'
+import { Search, BookOpen, X } from 'lucide-react'
 import { memo, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { MYPAGE_THEME as THEME } from '@/lib/theme'
@@ -38,8 +38,18 @@ export const SearchBar = memo(function SearchBar({
           placeholder="シナリオを検索..."
           value={searchTerm}
           onChange={(e) => onSearchChange(e.target.value)}
-          className="pl-8 sm:pl-9 pr-3 text-sm h-10 md:h-9"
+          className="pl-8 sm:pl-9 pr-8 text-sm h-10 md:h-9"
         />
+        {searchTerm.length > 0 && (
+          <button
+            type="button"
+            onClick={() => onSearchChange('')}
+            aria-label="検索条件をクリア"
+            className="absolute right-2 sm:right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
       </div>
       <Button
         variant="outline"

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -515,6 +515,7 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
                 isFavorite={isFavorite}
                 onToggleFavorite={handleToggleFavorite}
                 searchTerm={searchTerm}
+                onClearSearch={() => setSearchTerm('')}
                 organizationSlug={organizationSlug}
                 organizationName={organizationName}
                 selectedStoreIds={selectedStoreIds}


### PR DESCRIPTION
## Summary
- 検索語がセッションに残って通常一覧が消えたように見える場合、検索欄と0件表示から即時クリアできるようにします
- 公開ラインナップのデータ取得条件は変更せず、Issue #344 のブラウザ状態起因ケースを緩和します

## Test plan
- [ ] 公開予約ページ > ラインナップで検索語を入力するとクリアボタンが表示される
- [ ] 検索結果0件で「検索条件をクリア」を押すと通常一覧へ戻る
- [ ] ページ再訪時に検索語が残っていても、上記導線から復帰できる
- [ ] シークレットウィンドウでも一覧件数を確認し、本番データ側の問題がないことを切り分ける

Refs #344

Made with [Cursor](https://cursor.com)