### PR TITLE
fix: 体験済みチェックの自力解除を可能にする (#362)

### DIFF
--- a/src/components/modals/PlayedRegistrationDialog.tsx
+++ b/src/components/modals/PlayedRegistrationDialog.tsx
@@ -8,6 +8,7 @@ import { showToast } from '@/utils/toast'
 import { logger } from '@/utils/logger'
 import { MAX_MANUAL_PLAY_HISTORY_PER_CUSTOMER } from '@/constants/album'
 import { countManualPlayHistoryForCustomer, isManualPlayHistoryAtCap } from '@/lib/manualPlayHistoryLimit'
+import { removePlayedOverride } from '@/lib/playedOverrides'
 
 interface PlayedRegistrationDialogProps {
   open: boolean
@@ -52,6 +53,13 @@ export function PlayedRegistrationDialog({
         })
 
       if (error) throw error
+
+      // 過去に「未体験に戻した」override が残っていると再登録が体験済みに反映されないため削除（行が無ければ無視）
+      try {
+        await removePlayedOverride(customerId, scenarioMasterId)
+      } catch (overrideError) {
+        logger.warn('体験済み override 削除に失敗（無視）:', overrideError)
+      }
 
       onOpenChange(false)
       showToast.success('体験済みに登録しました')

--- a/src/hooks/usePlayedScenarios.ts
+++ b/src/hooks/usePlayedScenarios.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
 import { logger } from '@/utils/logger'
 import { MAX_MANUAL_PLAY_HISTORY_PER_CUSTOMER } from '@/constants/album'
-import { fetchPlayedOverrideIds } from '@/lib/playedOverrides'
+import { fetchPlayedOverrideIds, addPlayedOverride } from '@/lib/playedOverrides'
 
 /**
  * ユーザーの体験済みシナリオIDを管理するフック
@@ -91,5 +91,27 @@ export function usePlayedScenarios() {
     setPlayedScenarioIds(prev => new Set([...prev, scenarioMasterId]))
   }, [])
 
-  return { isPlayed, customerId, markAsPlayed, refreshPlayed: fetchPlayedScenarios, playedScenarioIds, loading }
+  /**
+   * 体験済みを解除（未体験に戻す）。override を追加し、ローカル状態も更新する。
+   * customerId が無い場合は throw（呼び出し側で toast）。
+   */
+  const unmarkAsPlayed = useCallback(async (scenarioMasterId: string): Promise<void> => {
+    if (!customerId) {
+      throw new Error('顧客情報が見つかりません')
+    }
+    // optimistic: 先にローカルから外し、失敗時は戻す
+    setPlayedScenarioIds(prev => {
+      const next = new Set(prev)
+      next.delete(scenarioMasterId)
+      return next
+    })
+    try {
+      await addPlayedOverride(customerId, scenarioMasterId)
+    } catch (error) {
+      setPlayedScenarioIds(prev => new Set([...prev, scenarioMasterId]))
+      throw error
+    }
+  }, [customerId])
+
+  return { isPlayed, customerId, markAsPlayed, unmarkAsPlayed, refreshPlayed: fetchPlayedScenarios, playedScenarioIds, loading }
 }

--- a/src/pages/PlatformTop/index.tsx
+++ b/src/pages/PlatformTop/index.tsx
@@ -249,8 +249,9 @@ export function PlatformTop() {
   const navigate = useNavigate()
   const { user } = useAuth()
   const { favorites, toggleFavorite } = useFavorites()
-  const { isPlayed, customerId, markAsPlayed } = usePlayedScenarios()
+  const { isPlayed, customerId, markAsPlayed, unmarkAsPlayed } = usePlayedScenarios()
   const [playedDialogTarget, setPlayedDialogTarget] = useState<{ id: string; title: string } | null>(null)
+  const [togglingPlayedIds, setTogglingPlayedIds] = useState<Set<string>>(new Set())
   const [selectedRegion, setSelectedRegion] = useState('all')
   const [isExpanded, setIsExpanded] = useState(() => {
     if (!isBrowserReloadNavigation()) return false
@@ -365,7 +366,19 @@ export function PlatformTop() {
   const handlePlayedClick = (scenarioId: string, scenarioTitle: string, e: React.MouseEvent) => {
     e.stopPropagation()
     if (!user) { showToast.error('ログインが必要です'); return }
-    if (isPlayed(scenarioId)) { showToast.info('既に体験済みとして登録されています'); return }
+    if (isPlayed(scenarioId)) {
+      if (togglingPlayedIds.has(scenarioId)) return
+      setTogglingPlayedIds(prev => new Set(prev).add(scenarioId))
+      unmarkAsPlayed(scenarioId)
+        .then(() => showToast.success('未体験に戻しました'))
+        .catch(() => showToast.error('未体験への変更に失敗しました'))
+        .finally(() => setTogglingPlayedIds(prev => {
+          const next = new Set(prev)
+          next.delete(scenarioId)
+          return next
+        }))
+      return
+    }
     setPlayedDialogTarget({ id: scenarioId, title: scenarioTitle })
   }
 

--- a/src/pages/PublicBookingTop/components/LineupView.tsx
+++ b/src/pages/PublicBookingTop/components/LineupView.tsx
@@ -54,9 +54,11 @@ export const LineupView = memo(function LineupView({
   const isSearching = searchTerm.length > 0
 
   const { user } = useAuth()
-  const { isPlayed, customerId, markAsPlayed } = usePlayedScenarios()
+  const { isPlayed, customerId, markAsPlayed, unmarkAsPlayed } = usePlayedScenarios()
   const [playedDialogTarget, setPlayedDialogTarget] = useState<{ id: string; title: string } | null>(null)
+  const [togglingPlayedIds, setTogglingPlayedIds] = useState<Set<string>>(new Set())
 
+  // 体験済みトグル: 体験済みなら解除、未体験なら登録ダイアログを開く
   const handleTogglePlayed = (scenarioId: string, scenarioTitle: string, e: React.MouseEvent) => {
     e.stopPropagation()
     if (!user) {
@@ -64,7 +66,16 @@ export const LineupView = memo(function LineupView({
       return
     }
     if (isPlayed(scenarioId)) {
-      showToast.info('既に体験済みとして登録されています')
+      if (togglingPlayedIds.has(scenarioId)) return
+      setTogglingPlayedIds(prev => new Set(prev).add(scenarioId))
+      unmarkAsPlayed(scenarioId)
+        .then(() => showToast.success('未体験に戻しました'))
+        .catch(() => showToast.error('未体験への変更に失敗しました'))
+        .finally(() => setTogglingPlayedIds(prev => {
+          const next = new Set(prev)
+          next.delete(scenarioId)
+          return next
+        }))
       return
     }
     setPlayedDialogTarget({ id: scenarioId, title: scenarioTitle })

--- a/src/pages/PublicBookingTop/components/ScenarioCard.tsx
+++ b/src/pages/PublicBookingTop/components/ScenarioCard.tsx
@@ -261,7 +261,9 @@ export const ScenarioCard = memo(function ScenarioCard({
                 onClick={handlePlayedClick}
                 onTouchEnd={(e) => e.stopPropagation()}
                 className={`flex-shrink-0 p-1 transition-colors rounded ${onTogglePlayed ? 'hover:bg-green-50 cursor-pointer' : 'cursor-default'}`}
-                title={isPlayed ? '体験済み' : '未体験（クリックで登録）'}
+                title={onTogglePlayed
+                  ? (isPlayed ? '体験済み（クリックで解除）' : '未体験（クリックで登録）')
+                  : (isPlayed ? '体験済み' : '未体験')}
               >
                 <CheckCheck className={`h-4 w-4 ${isPlayed ? 'text-green-500' : 'text-gray-300 hover:text-green-300'}`} />
               </button>

--- a/src/pages/PublicBookingTop/index.tsx
+++ b/src/pages/PublicBookingTop/index.tsx
@@ -191,8 +191,29 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
   
   // お気に入り機能
   const { isFavorite, toggleFavorite } = useFavorites()
-  const { isPlayed, customerId: playedCustomerId, markAsPlayed, playedScenarioIds } = usePlayedScenarios()
+  const { isPlayed, customerId: playedCustomerId, markAsPlayed, unmarkAsPlayed, playedScenarioIds } = usePlayedScenarios()
   const [playedDialogTarget, setPlayedDialogTarget] = useState<{ id: string; title: string } | null>(null)
+  const [togglingPlayedIds, setTogglingPlayedIds] = useState<Set<string>>(new Set())
+
+  // 体験済みトグル: 体験済みなら解除、未体験なら登録ダイアログを開く
+  const handleTogglePlayed = useCallback((id: string, title: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!user) { showToast.error('ログインが必要です'); return }
+    if (isPlayed(id)) {
+      if (togglingPlayedIds.has(id)) return
+      setTogglingPlayedIds(prev => new Set(prev).add(id))
+      unmarkAsPlayed(id)
+        .then(() => showToast.success('未体験に戻しました'))
+        .catch(() => showToast.error('未体験への変更に失敗しました'))
+        .finally(() => setTogglingPlayedIds(prev => {
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        }))
+      return
+    }
+    setPlayedDialogTarget({ id, title })
+  }, [user, isPlayed, unmarkAsPlayed, togglingPlayedIds])
 
   // カレンダー・リスト用の表示フィルタ
   const [hideSoldOut, setHideSoldOut] = useState(false)
@@ -493,12 +514,7 @@ export function PublicBookingTop({ onScenarioSelect, organizationSlug }: PublicB
                     isFavorite={isFavorite(scenario.scenario_id)}
                     isPlayed={isPlayed(scenario.scenario_id)}
                     onToggleFavorite={handleToggleFavorite}
-                    onTogglePlayed={(id, title, e) => {
-                      e.stopPropagation()
-                      if (!user) { showToast.error('ログインが必要です'); return }
-                      if (isPlayed(id)) { showToast.info('既に体験済みとして登録されています'); return }
-                      setPlayedDialogTarget({ id, title })
-                    }}
+                    onTogglePlayed={handleTogglePlayed}
                   />
                 ))}
               </div>

--- a/src/pages/ScenarioDetailGlobal/index.tsx
+++ b/src/pages/ScenarioDetailGlobal/index.tsx
@@ -6,7 +6,7 @@
  */
 import { useState, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Header } from '@/components/layout/Header'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -30,6 +30,7 @@ import { saveScrollPositionForCurrentUrl } from '@/hooks/useScrollRestoration'
 import { useReportRouteScrollRestoration } from '@/contexts/RouteScrollRestorationContext'
 import { MAX_MANUAL_PLAY_HISTORY_PER_CUSTOMER } from '@/constants/album'
 import { countManualPlayHistoryForCustomer, isManualPlayHistoryAtCap } from '@/lib/manualPlayHistoryLimit'
+import { addPlayedOverride, removePlayedOverride } from '@/lib/playedOverrides'
 import { getAvailableSeats } from '@/lib/participantUtils'
 
 interface ScenarioDetailGlobalProps {
@@ -255,6 +256,9 @@ async function fetchScenarioDetail(scenarioSlug: string): Promise<ScenarioDetail
 async function checkIsPlayed(email: string, scenarioId: string): Promise<boolean> {
   const { data: customer } = await supabase.from('customers').select('id').eq('email', email).maybeSingle()
   if (!customer) return false
+  // 本人/スタッフが「未体験に戻した」場合は override が優先（予約/手動より先に判定）
+  const { data: override } = await supabase.from('customer_played_overrides').select('id').eq('customer_id', customer.id).eq('scenario_master_id', scenarioId).limit(1).maybeSingle()
+  if (override) return false
   const { data: reservation } = await supabase.from('reservations').select('id').eq('customer_id', customer.id).eq('scenario_master_id', scenarioId).in('status', ['confirmed', 'gm_confirmed']).lte('requested_datetime', new Date().toISOString()).limit(1).maybeSingle()
   if (reservation) return true
   const { data: manual } = await supabase.from('manual_play_history').select('id').eq('customer_id', customer.id).eq('scenario_master_id', scenarioId).limit(1).maybeSingle()
@@ -263,6 +267,7 @@ async function checkIsPlayed(email: string, scenarioId: string): Promise<boolean
 
 export function ScenarioDetailGlobal({ scenarioSlug, onClose }: ScenarioDetailGlobalProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { user } = useAuth()
   const { isFavorite, toggleFavorite } = useFavorites()
   const [isSynopsisExpanded, setIsSynopsisExpanded] = useState(false)
@@ -295,15 +300,42 @@ export function ScenarioDetailGlobal({ scenarioSlug, onClose }: ScenarioDetailGl
         customer_id: customer.id, scenario_title: data.scenario.title, scenario_master_id: data.scenario.id, played_at: playedDate || null, venue: null,
       })
       if (error) throw error
+      // 過去に「未体験に戻した」override が残っていると体験済みに反映されないため削除（行が無ければ無視）
+      try {
+        await removePlayedOverride(customer.id, data.scenario.id)
+      } catch (overrideError) {
+        logger.warn('体験済み override 削除に失敗（無視）:', overrideError)
+      }
     },
     onSuccess: () => {
       setPlayedOverride(true)
       setIsPlayedDialogOpen(false)
+      queryClient.setQueryData(['scenario-is-played', user?.email, data?.scenario?.id], true)
+      queryClient.invalidateQueries({ queryKey: ['scenario-is-played', user?.email, data?.scenario?.id], refetchType: 'all' })
       showToast.success('体験済みに登録しました')
     },
     onError: (error: any) => {
       logger.error('体験済み登録エラー:', error)
       showToast.error(error.message || '登録に失敗しました')
+    },
+  })
+
+  const unmarkPlayedMutation = useMutation({
+    mutationFn: async () => {
+      if (!user?.email || !data?.scenario) throw new Error('データが不足しています')
+      const { data: customer } = await supabase.from('customers').select('id').eq('email', user.email).maybeSingle()
+      if (!customer) throw new Error('顧客情報が見つかりません')
+      await addPlayedOverride(customer.id, data.scenario.id)
+    },
+    onSuccess: () => {
+      setPlayedOverride(false)
+      queryClient.setQueryData(['scenario-is-played', user?.email, data?.scenario?.id], false)
+      queryClient.invalidateQueries({ queryKey: ['scenario-is-played', user?.email, data?.scenario?.id], refetchType: 'all' })
+      showToast.success('未体験に戻しました')
+    },
+    onError: (error: any) => {
+      logger.error('未体験変更エラー:', error)
+      showToast.error('未体験への変更に失敗しました')
     },
   })
 
@@ -361,7 +393,12 @@ export function ScenarioDetailGlobal({ scenarioSlug, onClose }: ScenarioDetailGl
 
   const handlePlayedClick = () => {
     if (!user) { showToast.error('ログインが必要です'); return }
-    if (isPlayed) { showToast.info('既に体験済みとして登録されています'); return }
+    // 体験済みならクリックで解除（override を追加）
+    if (isPlayed) {
+      if (unmarkPlayedMutation.isPending) return
+      unmarkPlayedMutation.mutate()
+      return
+    }
     setPlayedDate(new Date().toISOString().split('T')[0])
     setIsPlayedDialogOpen(true)
   }

--- a/src/pages/ScenarioDetailPage/components/ScenarioHero.tsx
+++ b/src/pages/ScenarioDetailPage/components/ScenarioHero.tsx
@@ -18,6 +18,7 @@ import { formatDuration, formatPlayerCount } from '../utils/formatters'
 import { getOptimizedImageUrl } from '@/utils/imageUtils'
 import { MAX_MANUAL_PLAY_HISTORY_PER_CUSTOMER } from '@/constants/album'
 import { countManualPlayHistoryForCustomer, isManualPlayHistoryAtCap } from '@/lib/manualPlayHistoryLimit'
+import { addPlayedOverride, removePlayedOverride } from '@/lib/playedOverrides'
 
 // 難易度ラベル
 const DIFFICULTY_LABELS: Record<number, { label: string; color: string }> = {
@@ -72,6 +73,8 @@ export const ScenarioHero = memo(function ScenarioHero({ scenario, events = [], 
   const [selectedStoreId, setSelectedStoreId] = useState('')
   const [allStores, setAllStores] = useState<Store[]>([])
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [customerId, setCustomerId] = useState<string | null>(null)
+  const [isTogglingPlayed, setIsTogglingPlayed] = useState(false)
   
   // 体験済みかどうかチェック
   useEffect(() => {
@@ -87,6 +90,7 @@ export const ScenarioHero = memo(function ScenarioHero({ scenario, events = [], 
           .maybeSingle()
         
         if (!customer) return
+        setCustomerId(customer.id)
 
         // 本人/スタッフが「未体験に戻した」場合は override が優先（予約/手動より先に判定）
         const { data: override } = await supabase
@@ -164,13 +168,39 @@ export const ScenarioHero = memo(function ScenarioHero({ scenario, events = [], 
     navigate(`/group/create?${params.toString()}`)
   }
   
-  const handlePlayedClick = () => {
+  const handlePlayedClick = async () => {
     if (!user) {
       showToast.error('ログインが必要です')
       return
     }
+    // 体験済みならクリックで解除（override を追加）
     if (isPlayed) {
-      showToast.info('既に体験済みとして登録されています')
+      if (isTogglingPlayed) return
+      let cid = customerId
+      if (!cid && user.email) {
+        const { data: customer } = await supabase
+          .from('customers')
+          .select('id')
+          .eq('email', user.email)
+          .maybeSingle()
+        cid = customer?.id ?? null
+        if (cid) setCustomerId(cid)
+      }
+      if (!cid) {
+        showToast.error('未体験への変更に失敗しました')
+        return
+      }
+      setIsTogglingPlayed(true)
+      try {
+        await addPlayedOverride(cid, scenario.scenario_master_id)
+        setIsPlayed(false)
+        showToast.success('未体験に戻しました')
+      } catch (error) {
+        logger.error('未体験変更エラー:', error)
+        showToast.error('未体験への変更に失敗しました')
+      } finally {
+        setIsTogglingPlayed(false)
+      }
       return
     }
     setPlayedDate('')
@@ -219,7 +249,14 @@ export const ScenarioHero = memo(function ScenarioHero({ scenario, events = [], 
         })
       
       if (error) throw error
-      
+
+      // 過去に「未体験に戻した」override が残っていると体験済みに反映されないため削除（行が無ければ無視）
+      try {
+        await removePlayedOverride(customer.id, scenario.scenario_master_id)
+      } catch (overrideError) {
+        logger.warn('体験済み override 削除に失敗（無視）:', overrideError)
+      }
+
       setIsPlayed(true)
       setIsPlayedDialogOpen(false)
       showToast.success('体験済みに登録しました')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
顧客が公開予約トップ／シナリオ詳細で体験済みチェックを外そうとしても、「既に体験済みとして登録されています」と早期 return しており、自力解除できなかった問題を修正します。

## 原因
- `PublicBookingTop` / `LineupView` / `PlatformTop` / `ScenarioHero` / `ScenarioDetailGlobal` の体験済みボタンが登録専用で、解除パスが未実装
- `ScenarioDetailGlobal` の `checkIsPlayed` が `customer_played_overrides` を差し引いておらず、マイページで未体験に戻しても詳細で体験済みのままになる場合があった

## 修正内容
- `usePlayedScenarios.unmarkAsPlayed` を追加し、`addPlayedOverride` で未体験扱いにする
- 上記各画面で体験済みクリック時に解除（トースト・二重クリック防止付き）
- 再登録時は `removePlayedOverride` で既存 override を消し、再登録が反映されるようにする
- `ScenarioDetailGlobal` は override 差し引き＋キャッシュ即時更新

## 受入条件との対応
- [x] 顧客自身の操作で体験済みマークを外せる
- [x] 以降は未体験として扱われる（予約サイト／詳細でも反映）
- [x] 再登録で再び体験済みにできる

## テスト
- [x] `npm run typecheck`
- [x] `npm run lint`

Fixes #362
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca713a88-cd06-4a3f-ae22-071ef583299d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca713a88-cd06-4a3f-ae22-071ef583299d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

