### PR TITLE
fix: 貸切受付締切一本化の残課題（列追加・RPC集計・JST検証） #377

### DIFF
--- a/src/pages/PrivateBookingRequest/index.tsx
+++ b/src/pages/PrivateBookingRequest/index.tsx
@@ -36,6 +36,14 @@ import type { RpcGetPublicPrivateBookingAvailabilityParams } from '@/lib/rpcType
 import { toJstYmd } from '@/utils/jstDate'
 
 const MAX_TIME_SLOTS = 6
+const CANDIDATE_HORIZON_DAYS = 180
+
+/** YYYY-MM-DD の暦日加算（UTC 部品で計算するためローカルTZに依存しない） */
+function addCalendarDaysYmd(ymd: string, days: number): string {
+  const [y, m, d] = ymd.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d + days))
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}-${String(dt.getUTCDate()).padStart(2, '0')}`
+}
 
 export function PrivateBookingRequest({
   scenarioTitle,
@@ -128,13 +136,12 @@ export function PrivateBookingRequest({
   // 貸切予約の受付締切（公演日の何日前まで申込可能か）。設定 > 予約設定の値
   const deadlineDays = usePrivateBookingDeadlineDays({ organizationSlug })
 
-  // 追加可能な日付の範囲（受付締切日数後から60日後まで）
+  // 追加可能な日付の範囲（受付締切日数後から候補取得と同じ 180 日ホライズンまで）
   const dateRange = useMemo(() => {
-    const fmtJst = (d: Date) =>
-      new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Tokyo' }).format(d)
-    const today = new Date()
-    const minDate = fmtJst(new Date(today.getTime() + deadlineDays * 24 * 60 * 60 * 1000))
-    const maxDate = fmtJst(new Date(today.getTime() + Math.max(60, deadlineDays) * 24 * 60 * 60 * 1000))
+    const todayYmd = toJstYmd(new Date())
+    const minDate = addCalendarDaysYmd(todayYmd, deadlineDays)
+    const horizonMax = addCalendarDaysYmd(todayYmd, CANDIDATE_HORIZON_DAYS)
+    const maxDate = horizonMax >= minDate ? horizonMax : minDate
     return { minDate, maxDate }
   }, [deadlineDays])
 
@@ -332,6 +339,11 @@ export function PrivateBookingRequest({
     
     if (editableTimeSlots.length === 0) {
       setError('候補日時を1件以上選択してください')
+      return
+    }
+
+    if (editableTimeSlots.some((candidate) => candidate.date < dateRange.minDate)) {
+      setError(`候補日は本日より${deadlineDays}日後以降のみ選べます`)
       return
     }
 

--- a/supabase/migrations/20260717100000_private_booking_deadline_setting.sql
+++ b/supabase/migrations/20260717100000_private_booking_deadline_setting.sql
@@ -2,29 +2,29 @@
 -- 貸切予約の受付締切（日前）を設定値として全フローで参照できるようにする
 -- =============================================================================
 -- 背景:
--- - reservation_settings.private_booking_deadline_days は存在していたが、
+-- - reservation_settings.private_booking_deadline_days は
 --   SELECT ポリシーが admin 限定のため公開ページ（anon）からは読めず、
 --   フロントは 14 日をハードコードして判定していた。
--- - 既存行の値 7 は列デフォルト由来で、実際の締切判定には使われていない。
---   実効挙動（14日）に合わせて補正し、以後は設定値を正とする。
+-- - 以後はこの設定値を正とし、列デフォルトも実効挙動の 14 に揃える。
+--   既存行の値は明示設定の可能性があるため書き換えない。
 
--- 1) organization_id が未設定の行を stores から補完
+-- 1) 列が存在しない環境（fresh reset 等）に備えて追加
+ALTER TABLE public.reservation_settings
+  ADD COLUMN IF NOT EXISTS private_booking_deadline_days INTEGER DEFAULT 14;
+
+-- 2) organization_id が未設定の行を stores から補完
 UPDATE public.reservation_settings rs
 SET organization_id = s.organization_id
 FROM public.stores s
 WHERE rs.store_id = s.id
   AND rs.organization_id IS NULL;
 
--- 2) 列デフォルト由来の 7 を、これまでの実効挙動である 14 に補正
-UPDATE public.reservation_settings
-SET private_booking_deadline_days = 14
-WHERE private_booking_deadline_days = 7;
-
 ALTER TABLE public.reservation_settings
   ALTER COLUMN private_booking_deadline_days SET DEFAULT 14;
 
 -- 3) 公開ページ（anon）から締切日数を取得する RPC
 --    正規定義: supabase/rpcs/get_private_booking_deadline_days.sql
+--    予約可能店舗（active かつ office 以外）のみを集計し、設定行が無い店舗は 14 とみなす。
 CREATE OR REPLACE FUNCTION get_private_booking_deadline_days(
   p_organization_id UUID DEFAULT NULL,
   p_organization_slug TEXT DEFAULT NULL
@@ -37,12 +37,15 @@ SET search_path = public
 AS $$
   SELECT COALESCE(
     (
-      SELECT MAX(rs.private_booking_deadline_days)
-      FROM public.reservation_settings rs
-      WHERE rs.private_booking_deadline_days IS NOT NULL
+      SELECT MAX(COALESCE(rs.private_booking_deadline_days, 14))
+      FROM public.stores s
+      LEFT JOIN public.reservation_settings rs
+        ON rs.store_id = s.id
+      WHERE s.status = 'active'
+        AND s.ownership_type IS DISTINCT FROM 'office'
         AND CASE
-          WHEN p_organization_id IS NOT NULL THEN rs.organization_id = p_organization_id
-          WHEN p_organization_slug IS NOT NULL THEN rs.organization_id = (
+          WHEN p_organization_id IS NOT NULL THEN s.organization_id = p_organization_id
+          WHEN p_organization_slug IS NOT NULL THEN s.organization_id = (
             SELECT o.id FROM public.organizations o WHERE o.slug = p_organization_slug
           )
           ELSE TRUE

--- a/supabase/migrations/20260730140000_fix_get_private_booking_deadline_days_bookable_stores.sql
+++ b/supabase/migrations/20260730140000_fix_get_private_booking_deadline_days_bookable_stores.sql
@@ -1,14 +1,14 @@
--- 正規ソース。変更後は新規マイグレにこのファイル全文を貼る。
+-- =============================================================================
+-- get_private_booking_deadline_days の集計対象を予約可能店舗に修正
+-- =============================================================================
+-- 背景:
+-- - 旧実装は reservation_settings のみを集計していたため、設定行が無い店舗
+--   （＝実質 14 日運用）が MAX に含まれず、締切が短く出るケースがあった。
+--   また、閉店店舗やオフィス（予約不可）の設定値まで拾っていた。
+-- - stores を起点に LEFT JOIN し、予約可能店舗（active かつ office 以外）のみを
+--   集計する。設定行が無い店舗は 14 日として MAX に含める。
 --
--- 貸切公演の予約受付締切（公演日の何日前まで申込可能か）を返す。
--- 設定は reservation_settings.private_booking_deadline_days（店舗単位）。
--- 公開ページ（anon）からは reservation_settings を直接 SELECT できないため、
--- この RPC 経由で締切日数のみを公開する。
---
--- 集計対象は予約可能な店舗のみ（status = 'active' かつ ownership_type が 'office' 以外）。
--- 設定行が無い店舗は COALESCE(..., 14) で 14 日として MAX に含める。
--- 組織内で店舗ごとに値が異なる場合は MAX（最も厳しい締切）を採用する。
--- 対象店舗が 1 件も無い場合のフォールバックは 14 日。
+-- 正規定義: supabase/rpcs/get_private_booking_deadline_days.sql
 
 CREATE OR REPLACE FUNCTION get_private_booking_deadline_days(
   p_organization_id UUID DEFAULT NULL,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 変更内容
PR #357（貸切予約の受付締切を設定値に一本化）マージ時点で残ったレビュー指摘を修正します。

### 原因
- bootstrap の `reservation_settings` に `private_booking_deadline_days` が無く、fresh DB で当該マイグレの `UPDATE` が落ちる
- `WHERE private_booking_deadline_days = 7` の一律 14 上書きで、管理画面の明示設定 7 日が失われる
- RPC が `reservation_settings` 行だけを集計しており、(1) 非アクティブ／オフィス店舗の大きい値が組織 MAX を押し上げる (2) 設定行なしの予約可能店舗のデフォルト 14 が MAX に入らない
- 確認ページの `minDate` が瞬間+ミリ秒計算で JST 早朝に暦日がずれる
- `maxDate = max(60, deadlineDays)` のため締切 90 日設定で日付追加 UI が1日だけになる
- prefill（`?date=&slot=`）が `onSubmit` で締切検証されない

### 修正内容
- **履歴マイグレ** `20260717100000_...`: `ADD COLUMN IF NOT EXISTS` を先行、7→14 上書き削除、RPC を修正版に更新（未適用／reset 向け。staging のデータ巻き戻しはしない）
- **追加マイグレ** `20260730140000_...`: 既適用の staging 向けに RPC を `CREATE OR REPLACE`
- **RPC 正規定義**: 予約可能店舗（`status = 'active'` かつ `ownership_type IS DISTINCT FROM 'office'`）を LEFT JOIN し、`COALESCE(..., 14)` で MAX
- **貸切リクエスト確認ページ**: `toJstYmd` + 暦日加算で `minDate`、固定 180 日ホライズンで `maxDate`、`onSubmit` で締切前候補を拒否

## 関連Issue
Fixes #377

## 受入条件との対応
| 完了条件 | 対応 |
|---------|------|
| migrations だけで reset/push しても列欠落しない | 履歴マイグレに `ADD COLUMN IF NOT EXISTS` |
| 明示 7 日設定が勝手に 14 にならない | 7→14 UPDATE 削除（staging で既に書き換わった行の自動復元は対象外） |
| 非アクティブ／オフィスが MAX を押し上げない | stores 起点 + フィルタ |
| 設定行なし店舗は 14 として MAX に含む | `COALESCE(rs..., 14)` |
| 締切前 prefills が送信できない | `onSubmit` で `date < minDate` を拒否 |
| JST 早朝でも minDate が正しい | `toJstYmd` + UTC 暦日加算 |
| 締切 90 日でも日付追加が1日にならない | maxDate = today+180（`maxDate >= minDate`） |
| typecheck / lint | 通過。`test:rpcs` は本環境に Docker 無しのため未実行（シグネチャ変更なし、CI/ローカルで要確認） |

## チェックリスト

### マルチテナント対応（必須）🚨
- [x] RPC は `stores.organization_id` で組織を絞る（slug / id）
- [x] フロントの新規 INSERT/SELECT 変更なし

### セキュリティ（必須）🚨
- [x] RLS 直接変更なし（既存 SECURITY DEFINER RPC の定義更新のみ）
- [x] 公開は締切日数 INTEGER のみ

### データベース操作の確認
- [x] 既存列の IF NOT EXISTS 追加 + DEFAULT 変更のみ（新テーブルなし）
- [x] 正規定義 `supabase/rpcs/get_private_booking_deadline_days.sql` を更新

### 型安全性
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run check:jst-date` 通過

### テスト
- [ ] staging マージ後に `db push` で追加マイグレ適用を確認
- [ ] `npm run test:rpcs`（ローカル Supabase）
- [ ] 貸切リクエスト確認ページの動作確認（下記）

## 動作確認チェックリスト（staging 反映後）

### 基本確認
- [ ] ステージングにデプロイされている
- [ ] `npm run db:status` で未適用マイグレーションがない

### 変更箇所
- [ ] 【予約サイト > シナリオ詳細 > 貸切リクエスト確認】日付追加の min が締切日数後の JST 暦日であること
- [ ] 【同】日付追加の max が today+180 付近で、締切 90 日設定でも複数日選べること
- [ ] 【同】`?date=` で締切前の日付を prefills した場合、送信時にエラーになること
- [ ] 【設定 > 予約設定】明示 7 日の店舗がこの PR 適用で 14 に変わっていないこと（新規適用環境）

### リグレッション
- [ ] 【予約サイト > シナリオ詳細の貸切カレンダー】候補取得・締切表示が従来どおり動くこと
- [ ] 【貸切グループ > 候補日追加】180 日ホライズンの挙動が壊れていないこと

## 補足
- 本番 `db:push:prod` / main マージは対象外（別途明示指示）
- staging で既に 7→14 に書き換え済みの行の自動復元はしない（設定画面で手動再設定）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-630bcb39-a579-46f4-896b-edaef72449c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-630bcb39-a579-46f4-896b-edaef72449c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

