### PR TITLE
fix(mypage): ハンドルネーム編集が反映されない問題を修正 (#382)

### DIFF
--- a/src/contexts/auth/resolveUserFromSession.ts
+++ b/src/contexts/auth/resolveUserFromSession.ts
@@ -229,6 +229,9 @@ export async function resolveUserFromSession(
               .from('customers')
               .select('name, nickname')
               .eq('user_id', supabaseUser.id)
+              .order('updated_at', { ascending: false })
+              .order('created_at', { ascending: true })
+              .limit(1)
               .maybeSingle()
             
             if (data) {

--- a/src/pages/MyPage/hooks/useMyPageDataQuery.ts
+++ b/src/pages/MyPage/hooks/useMyPageDataQuery.ts
@@ -92,11 +92,13 @@ export function useMyPageDataQuery(userId: string | undefined, email: string | u
           if (linkError) logger.warn('顧客レコードの自動紐付け/統合に失敗:', linkError)
           else linkedUserIds.add(userId)
         }
-        const { data } = await supabase.from('customers').select('id, name, nickname, avatar_url, user_id, organization_id').eq('user_id', userId).maybeSingle()
+        // 同一 user_id の重複行が残っていても表示が非決定的にならないよう1件に絞る (#382)
+        const { data, error } = await supabase.from('customers').select('id, name, nickname, avatar_url, user_id, organization_id').eq('user_id', userId).order('updated_at', { ascending: false }).order('created_at', { ascending: true }).limit(1).maybeSingle()
+        if (error && error.code !== 'PGRST116') logger.warn('顧客情報の取得に失敗:', error)
         if (data) customer = data
       }
       if (!customer && email) {
-        const { data, error } = await supabase.from('customers').select('id, name, nickname, avatar_url, user_id, organization_id').ilike('email', email).maybeSingle()
+        const { data, error } = await supabase.from('customers').select('id, name, nickname, avatar_url, user_id, organization_id').ilike('email', email).order('updated_at', { ascending: false }).order('created_at', { ascending: true }).limit(1).maybeSingle()
         if (error && error.code !== 'PGRST116') throw error
         if (data) customer = data
       }

--- a/src/pages/MyPage/pages/SettingsPage.tsx
+++ b/src/pages/MyPage/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -27,6 +28,8 @@ import {
   MSG_CANNOT_CLEAR_REGISTERED_PHONE,
   hasNonEmptyCustomerPhone,
 } from '@/lib/customerPhonePolicy'
+import { invalidateEverywhere } from '@/lib/queryInvalidation'
+import { myPageKeys } from '../hooks/useMyPageDataQuery'
 
 type DialogType =
   | 'profile'
@@ -40,6 +43,7 @@ type DialogType =
 export function SettingsPage() {
   const { user, signOut } = useAuth()
   const { organizationId } = useOrganization()
+  const queryClient = useQueryClient()
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [customerInfo, setCustomerInfo] = useState<any>(null)
@@ -154,8 +158,13 @@ export function SettingsPage() {
       } else if (user?.email) {
         query = query.eq('email', user.email)
       }
-      
-      const { data, error } = await query.maybeSingle()
+
+      // 同一 user_id の重複が残っていても表示・編集対象がぶれないよう最新1件に絞る (#382)
+      const { data, error } = await query
+        .order('updated_at', { ascending: false })
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle()
 
       if (error) throw error
 
@@ -204,6 +213,24 @@ export function SettingsPage() {
     setSaving(true)
     try {
       if (customerInfo) {
+        // 保存直前に重複行を統合し、統合後に残った行を対象にする。統合で customerInfo.id 側が
+        // 削除されている可能性があるため、id を引き直す (#382)
+        let targetCustomerId = customerInfo.id
+        if (user?.id) {
+          const { error: linkError } = await supabase.rpc('link_current_user_to_customer')
+          if (linkError) logger.warn('顧客レコードの自動紐付け/統合に失敗:', linkError)
+
+          const { data: resolvedCust } = await supabase
+            .from('customers')
+            .select('id')
+            .eq('user_id', user.id)
+            .order('updated_at', { ascending: false })
+            .order('created_at', { ascending: true })
+            .limit(1)
+            .maybeSingle()
+          if (resolvedCust?.id) targetCustomerId = resolvedCust.id
+        }
+
         let profileUpdate = supabase
           .from('customers')
           .update({
@@ -215,7 +242,7 @@ export function SettingsPage() {
             email: user?.email || null,
             updated_at: new Date().toISOString(),
           })
-          .eq('id', customerInfo.id)
+          .eq('id', targetCustomerId)
         if (user?.id) {
           profileUpdate = profileUpdate.eq('user_id', user.id)
         }
@@ -249,6 +276,9 @@ export function SettingsPage() {
           .from('customers')
           .select('id')
           .eq('user_id', user.id)
+          .order('updated_at', { ascending: false })
+          .order('created_at', { ascending: true })
+          .limit(1)
           .maybeSingle()
         
         const { data: savedRows, error } = existingCust
@@ -292,6 +322,9 @@ export function SettingsPage() {
         showToast.success('プロフィールを作成しました')
       }
 
+      // マイページヘッダー等の表示名は mypage-data クエリ経由。グローバル既定が
+      // refetchOnMount:false のため refetchType:'all' で非アクティブ画面まで再取得させる (#382)
+      await invalidateEverywhere(queryClient, myPageKeys.data(user?.id ?? '', user?.email ?? ''))
       fetchCustomerInfo()
       setActiveDialog(null)
     } catch (error: any) {

--- a/supabase/migrations/20260802130000_link_customer_merge_same_user_id_duplicates.sql
+++ b/supabase/migrations/20260802130000_link_customer_merge_same_user_id_duplicates.sql
@@ -1,0 +1,172 @@
+-- link_current_user_to_customer RPC に「同一 user_id の重複行」の統合を追加する (#382)。
+--
+-- 背景:
+--   マイページ設定でニックネームを保存しても表示に反映されないケースがあった。原因の一つが
+--   同じ user_id を持つ customers 行が複数存在する状態で、従来の RPC は未紐付け
+--   (user_id IS NULL) の同一メール行しか統合しなかったため重複が残り続けていた。
+--   重複があると .maybeSingle() が非決定的な行を返し、更新した行と表示に使う行が食い違う。
+--
+-- 本改修:
+--   本人行（primary）を updated_at DESC / created_at ASC で決定したうえで、同じ user_id を持つ
+--   他の行も primary へ統合（子テーブルの付け替え → 空プロフィール欄の補完 → 重複行の削除）する。
+--   統合処理は未紐付け行の統合と完全に同一のため、両者を1つのループに統一した（挙動は従来と同じ）。
+--
+-- 安全性:
+--   RLS ポリシーは変更しない。関数は従来どおり SECURITY DEFINER。照合キーは auth.users から
+--   取得した本人の検証済みメールのみ。#341 の advisory lock も維持する。
+
+CREATE OR REPLACE FUNCTION public.link_current_user_to_customer()
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid         uuid := auth.uid();
+  v_email       text;
+  v_role        app_role;
+  v_customer_id uuid;
+  v_dup_id      uuid;
+  v_match_count integer;
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN NULL;  -- 未ログイン
+  END IF;
+
+  -- 本人の検証済みメールを auth.users から取得
+  SELECT lower(email) INTO v_email
+  FROM auth.users
+  WHERE id = v_uid;
+
+  IF v_email IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- 同一メールの紐付け/統合処理を直列化（複数タブ/デバイスからの並行呼び出し対策 #341）。
+  -- トランザクション終了時に自動解放される。異なるメールはロックが競合しない。
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_email, 0));
+
+  -- 呼び出しユーザー自身の role（staff/admin/license_admin が自分用の customer 行を
+  -- 誤って組織から外さないためのガード。20260521030000 と同じ条件）
+  SELECT role INTO v_role
+  FROM public.users
+  WHERE id = v_uid;
+
+  -- 既に本人の顧客行が紐付いている場合（冪等）。最後に更新された行を本人行(primary)とする (#382)
+  SELECT id INTO v_customer_id
+  FROM public.customers
+  WHERE user_id = v_uid
+  ORDER BY updated_at DESC NULLS LAST, created_at ASC
+  LIMIT 1;
+
+  IF v_customer_id IS NOT NULL THEN
+    SELECT count(*) INTO v_match_count
+    FROM public.customers
+    WHERE user_id IS NULL
+      AND lower(email) = v_email;
+
+    -- 統合対象:
+    --   1. 同じ user_id を持つ他の行（本人行の重複。件数に関わらず全て統合する #382）
+    --   2. 同一メールの未紐付け行が「ちょうど1件」だけ残っている場合のその行
+    --      （重複メール・複数組織ゲスト重複は曖昧とみなしスキップ）
+    FOR v_dup_id IN
+      SELECT d.id
+      FROM (
+        SELECT id, updated_at, created_at
+        FROM public.customers
+        WHERE user_id = v_uid
+          AND id <> v_customer_id
+        UNION ALL
+        SELECT id, updated_at, created_at
+        FROM public.customers
+        WHERE v_match_count = 1
+          AND user_id IS NULL
+          AND lower(email) = v_email
+      ) d
+      ORDER BY d.updated_at DESC NULLS LAST, d.created_at ASC
+    LOOP
+      -- reservations（ON DELETE RESTRICT なので先に付け替え）
+      UPDATE public.reservations SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- customer_org_stats（PK: customer_id, organization_id）
+      INSERT INTO public.customer_org_stats (customer_id, organization_id, notes, visit_count, total_spent, last_visit)
+      SELECT v_customer_id, organization_id, notes, visit_count, total_spent, last_visit
+      FROM public.customer_org_stats
+      WHERE customer_id = v_dup_id
+      ON CONFLICT (customer_id, organization_id) DO NOTHING;
+
+      -- scenario_likes (UNIQUE: customer_id, scenario_id)
+      DELETE FROM public.scenario_likes
+      WHERE customer_id = v_dup_id
+        AND scenario_id IN (SELECT scenario_id FROM public.scenario_likes WHERE customer_id = v_customer_id);
+      UPDATE public.scenario_likes SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- scenario_ratings (UNIQUE: customer_id, scenario_master_id)
+      DELETE FROM public.scenario_ratings
+      WHERE customer_id = v_dup_id
+        AND scenario_master_id IN (SELECT scenario_master_id FROM public.scenario_ratings WHERE customer_id = v_customer_id);
+      UPDATE public.scenario_ratings SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- customer_played_overrides (UNIQUE: customer_id, scenario_master_id)
+      DELETE FROM public.customer_played_overrides
+      WHERE customer_id = v_dup_id
+        AND scenario_master_id IN (SELECT scenario_master_id FROM public.customer_played_overrides WHERE customer_id = v_customer_id);
+      UPDATE public.customer_played_overrides SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- customer_memos (UNIQUE: customer_id, organization_id)
+      DELETE FROM public.customer_memos
+      WHERE customer_id = v_dup_id
+        AND organization_id IN (SELECT organization_id FROM public.customer_memos WHERE customer_id = v_customer_id);
+      UPDATE public.customer_memos SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- ユニーク制約の無い CASCADE テーブル
+      UPDATE public.customer_coupons          SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.manual_play_history        SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.album_character_records    SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.user_notifications         SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.waitlist                   SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- 本人行の空プロフィール欄を、統合元(重複行)の値で補完する。本人行に既に値があれば
+      -- 上書きしない（本人行は最終更新が最も新しい行なので、本人が設定した値を優先）。
+      -- ゲスト予約時に入力した氏名/ニックネーム等の保全のため (#334 / #288)
+      UPDATE public.customers dst
+      SET name       = COALESCE(NULLIF(btrim(dst.name), ''),     NULLIF(btrim(src.name), ''),     dst.name),
+          nickname   = COALESCE(NULLIF(btrim(dst.nickname), ''), NULLIF(btrim(src.nickname), ''), dst.nickname),
+          phone      = COALESCE(NULLIF(btrim(dst.phone), ''),    NULLIF(btrim(src.phone), ''),    dst.phone),
+          address    = COALESCE(NULLIF(btrim(dst.address), ''),  NULLIF(btrim(src.address), ''),  dst.address),
+          line_id    = COALESCE(NULLIF(btrim(dst.line_id), ''),  NULLIF(btrim(src.line_id), ''),  dst.line_id),
+          avatar_url = COALESCE(NULLIF(btrim(dst.avatar_url), ''), NULLIF(btrim(src.avatar_url), ''), dst.avatar_url),
+          updated_at = NOW()
+      FROM public.customers src
+      WHERE dst.id = v_customer_id
+        AND src.id = v_dup_id;
+
+      -- 統合済みの重複行を削除（残る customer_org_stats 等は CASCADE で削除される）
+      DELETE FROM public.customers WHERE id = v_dup_id;
+    END LOOP;
+
+    RETURN v_customer_id;
+  END IF;
+
+  -- 未紐付けの候補が「ちょうど1件」のときのみ紐付ける（組織横断でグローバルにチェック。
+  -- 重複メール・複数組織ゲスト重複は曖昧とみなしスキップ）
+  SELECT count(*) INTO v_match_count
+  FROM public.customers
+  WHERE user_id IS NULL
+    AND lower(email) = v_email;
+
+  IF v_match_count = 1 THEN
+    UPDATE public.customers
+    SET user_id = v_uid,
+        organization_id = CASE WHEN v_role = 'customer' THEN NULL ELSE organization_id END,
+        updated_at = NOW()
+    WHERE user_id IS NULL
+      AND lower(email) = v_email
+    RETURNING id INTO v_customer_id;
+  END IF;
+
+  RETURN v_customer_id;  -- 照合不能・曖昧なら NULL
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.link_current_user_to_customer() TO authenticated;

--- a/supabase/rpcs/link_current_user_to_customer.sql
+++ b/supabase/rpcs/link_current_user_to_customer.sql
@@ -1,0 +1,166 @@
+-- =============================================================================
+-- link_current_user_to_customer: ログイン中ユーザーと customers 行の紐付け/重複統合
+-- 正規ソース: supabase/rpcs/link_current_user_to_customer.sql
+-- 用途: マイページ表示・プロフィール保存時に呼び出し、本人の customers 行を1件に収束させる。
+--       - 未紐付け(user_id IS NULL)の同一メール行が「ちょうど1件」なら本人へ紐付け/統合
+--       - 同じ user_id を持つ重複行があれば本人行(primary)へ統合 (#382)
+--       クライアント直 UPDATE は RLS(user_id = auth.uid()) で弾かれるため SECURITY DEFINER。
+-- 履歴: 20260706220000（新規） / 20260709031500（プロフィール欄の保全）
+--       / 20260709120000（advisory lock #341） / 20260802130000（同一 user_id 重複の統合 #382）
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.link_current_user_to_customer()
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid         uuid := auth.uid();
+  v_email       text;
+  v_role        app_role;
+  v_customer_id uuid;
+  v_dup_id      uuid;
+  v_match_count integer;
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN NULL;  -- 未ログイン
+  END IF;
+
+  -- 本人の検証済みメールを auth.users から取得
+  SELECT lower(email) INTO v_email
+  FROM auth.users
+  WHERE id = v_uid;
+
+  IF v_email IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- 同一メールの紐付け/統合処理を直列化（複数タブ/デバイスからの並行呼び出し対策 #341）。
+  -- トランザクション終了時に自動解放される。異なるメールはロックが競合しない。
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_email, 0));
+
+  -- 呼び出しユーザー自身の role（staff/admin/license_admin が自分用の customer 行を
+  -- 誤って組織から外さないためのガード。20260521030000 と同じ条件）
+  SELECT role INTO v_role
+  FROM public.users
+  WHERE id = v_uid;
+
+  -- 既に本人の顧客行が紐付いている場合（冪等）。最後に更新された行を本人行(primary)とする (#382)
+  SELECT id INTO v_customer_id
+  FROM public.customers
+  WHERE user_id = v_uid
+  ORDER BY updated_at DESC NULLS LAST, created_at ASC
+  LIMIT 1;
+
+  IF v_customer_id IS NOT NULL THEN
+    SELECT count(*) INTO v_match_count
+    FROM public.customers
+    WHERE user_id IS NULL
+      AND lower(email) = v_email;
+
+    -- 統合対象:
+    --   1. 同じ user_id を持つ他の行（本人行の重複。件数に関わらず全て統合する #382）
+    --   2. 同一メールの未紐付け行が「ちょうど1件」だけ残っている場合のその行
+    --      （重複メール・複数組織ゲスト重複は曖昧とみなしスキップ）
+    FOR v_dup_id IN
+      SELECT d.id
+      FROM (
+        SELECT id, updated_at, created_at
+        FROM public.customers
+        WHERE user_id = v_uid
+          AND id <> v_customer_id
+        UNION ALL
+        SELECT id, updated_at, created_at
+        FROM public.customers
+        WHERE v_match_count = 1
+          AND user_id IS NULL
+          AND lower(email) = v_email
+      ) d
+      ORDER BY d.updated_at DESC NULLS LAST, d.created_at ASC
+    LOOP
+      -- reservations（ON DELETE RESTRICT なので先に付け替え）
+      UPDATE public.reservations SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- customer_org_stats（PK: customer_id, organization_id）
+      INSERT INTO public.customer_org_stats (customer_id, organization_id, notes, visit_count, total_spent, last_visit)
+      SELECT v_customer_id, organization_id, notes, visit_count, total_spent, last_visit
+      FROM public.customer_org_stats
+      WHERE customer_id = v_dup_id
+      ON CONFLICT (customer_id, organization_id) DO NOTHING;
+
+      -- scenario_likes (UNIQUE: customer_id, scenario_id)
+      DELETE FROM public.scenario_likes
+      WHERE customer_id = v_dup_id
+        AND scenario_id IN (SELECT scenario_id FROM public.scenario_likes WHERE customer_id = v_customer_id);
+      UPDATE public.scenario_likes SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- scenario_ratings (UNIQUE: customer_id, scenario_master_id)
+      DELETE FROM public.scenario_ratings
+      WHERE customer_id = v_dup_id
+        AND scenario_master_id IN (SELECT scenario_master_id FROM public.scenario_ratings WHERE customer_id = v_customer_id);
+      UPDATE public.scenario_ratings SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- customer_played_overrides (UNIQUE: customer_id, scenario_master_id)
+      DELETE FROM public.customer_played_overrides
+      WHERE customer_id = v_dup_id
+        AND scenario_master_id IN (SELECT scenario_master_id FROM public.customer_played_overrides WHERE customer_id = v_customer_id);
+      UPDATE public.customer_played_overrides SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- customer_memos (UNIQUE: customer_id, organization_id)
+      DELETE FROM public.customer_memos
+      WHERE customer_id = v_dup_id
+        AND organization_id IN (SELECT organization_id FROM public.customer_memos WHERE customer_id = v_customer_id);
+      UPDATE public.customer_memos SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- ユニーク制約の無い CASCADE テーブル
+      UPDATE public.customer_coupons          SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.manual_play_history        SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.album_character_records    SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.user_notifications         SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+      UPDATE public.waitlist                   SET customer_id = v_customer_id WHERE customer_id = v_dup_id;
+
+      -- 本人行の空プロフィール欄を、統合元(重複行)の値で補完する。本人行に既に値があれば
+      -- 上書きしない（本人行は最終更新が最も新しい行なので、本人が設定した値を優先）。
+      -- ゲスト予約時に入力した氏名/ニックネーム等の保全のため (#334 / #288)
+      UPDATE public.customers dst
+      SET name       = COALESCE(NULLIF(btrim(dst.name), ''),     NULLIF(btrim(src.name), ''),     dst.name),
+          nickname   = COALESCE(NULLIF(btrim(dst.nickname), ''), NULLIF(btrim(src.nickname), ''), dst.nickname),
+          phone      = COALESCE(NULLIF(btrim(dst.phone), ''),    NULLIF(btrim(src.phone), ''),    dst.phone),
+          address    = COALESCE(NULLIF(btrim(dst.address), ''),  NULLIF(btrim(src.address), ''),  dst.address),
+          line_id    = COALESCE(NULLIF(btrim(dst.line_id), ''),  NULLIF(btrim(src.line_id), ''),  dst.line_id),
+          avatar_url = COALESCE(NULLIF(btrim(dst.avatar_url), ''), NULLIF(btrim(src.avatar_url), ''), dst.avatar_url),
+          updated_at = NOW()
+      FROM public.customers src
+      WHERE dst.id = v_customer_id
+        AND src.id = v_dup_id;
+
+      -- 統合済みの重複行を削除（残る customer_org_stats 等は CASCADE で削除される）
+      DELETE FROM public.customers WHERE id = v_dup_id;
+    END LOOP;
+
+    RETURN v_customer_id;
+  END IF;
+
+  -- 未紐付けの候補が「ちょうど1件」のときのみ紐付ける（組織横断でグローバルにチェック。
+  -- 重複メール・複数組織ゲスト重複は曖昧とみなしスキップ）
+  SELECT count(*) INTO v_match_count
+  FROM public.customers
+  WHERE user_id IS NULL
+    AND lower(email) = v_email;
+
+  IF v_match_count = 1 THEN
+    UPDATE public.customers
+    SET user_id = v_uid,
+        organization_id = CASE WHEN v_role = 'customer' THEN NULL ELSE organization_id END,
+        updated_at = NOW()
+    WHERE user_id IS NULL
+      AND lower(email) = v_email
+    RETURNING id INTO v_customer_id;
+  END IF;
+
+  RETURN v_customer_id;  -- 照合不能・曖昧なら NULL
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.link_current_user_to_customer() TO authenticated;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
顧客がマイページ設定でハンドルネーム（ニックネーム）を編集しても表示に反映されない不具合（#382）を修正します。

## 原因
1. 同一 `user_id` を持つ `customers` 行が複数残ると、取得の `.maybeSingle()` が非決定的になり、**更新した行と表示に使う行が食い違う**ことがあった。既存の `link_current_user_to_customer` は未紐付け（`user_id IS NULL`）の同一メール行しか統合しておらず、同一 `user_id` の重複は残っていた。
2. プロフィール保存後に React Query の `mypage-data` を無効化していなかった。グローバル既定（`staleTime: 5分` / `refetchOnMount: false`）のため、マイページヘッダーの表示名が古いキャッシュのまま残る。

## 修正内容
- **DB (SECURITY DEFINER RPC)**: `link_current_user_to_customer` に同一 `user_id` 重複行の統合を追加。primary は `updated_at DESC, created_at ASC` で決定し、子レコード付け替え → 空プロフィール補完 → 重複削除。RLS は変更しない。
- **SettingsPage**: 保存直前に統合 RPC → 対象行を引き直し → UPDATE。成功後に `invalidateEverywhere(['mypage-data'])`。取得は最新1件に固定。
- **useMyPageDataQuery / resolveUserFromSession**: 顧客取得を同じ順序の最新1件に揃える。

## 受入条件との対応
| 調査項目 | 結果 |
|---------|------|
| nickname が customers に UPDATE されるか | UPDATE 経路は存在。対象行の取り違えが問題だったため、統合＋対象再解決で修正 |
| 同一 user_id の複数行 | RPC で統合するよう拡張 |
| RLS 無言失敗 | 既存の 0件更新検知・RLS エラー分岐を維持 |
| 成功後に旧値が戻る切り分け | キャッシュ未無効化も原因。`refetchType: 'all'` で解消 |
| 表示側の別ソース | マイページ表示名は `customers.nickname` 優先。取得順を統一 |

## デプロイ注意
- **マイグレーションあり**: staging マージ後に `npm run db:push:staging` を先に適用すること（DB → フロントの順）。
- 本番反映時も DB 先行。

## テスト計画
- [ ] 【マイページ > 設定 > プロフィール編集】ニックネームを変更して保存 → 成功トースト後、マイページ上部の「○○ さん」が新ニックネームになる
- [ ] 同上のあとブラウザ再読み込みしても新ニックネームのまま
- [ ] 【マイページ > 設定】本名・電話など他項目の保存が従来どおり動く
- [ ] `npm run db:status` で当該マイグレーションが適用済み
- [ ] （可能なら）同一 user_id の重複行がある顧客で、保存後に1行へ収束し表示が一致する

Fixes #382

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6a4d005-c608-41c5-8ead-926b171817c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6a4d005-c608-41c5-8ead-926b171817c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

