### PR TITLE
【🛑チェック失敗】fix: リマインドメール5ヶ月停止の修正

### DIFF
--- a/supabase/functions/auto-send-reminder-emails/index.ts
+++ b/supabase/functions/auto-send-reminder-emails/index.ts
@@ -50,7 +50,7 @@ serve(async (req) => {
           name,
           address
         ),
-        scenarios:scenario_id (
+        scenario_masters:scenario_master_id (
           id,
           title
         )
@@ -105,7 +105,7 @@ serve(async (req) => {
                 storeId: event.store_id,
                 customerEmail: reservation.customers.email,
                 customerName: reservation.customers.name,
-                scenarioTitle: event.scenarios?.title || event.scenario,
+                scenarioTitle: event.scenario_masters?.title || event.scenario,
                 eventDate: event.date,
                 startTime: event.start_time,
                 endTime: event.end_time,
@@ -153,11 +153,11 @@ serve(async (req) => {
 
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
-    console.error('Error:', sanitizeErrorMessage(msg))
+    console.error('auto-send-reminder-emails Error:', msg)
     return new Response(
-      JSON.stringify({ 
-        success: false, 
-        error: sanitizeErrorMessage(msg || 'リマインダーメール送信に失敗しました') 
+      JSON.stringify({
+        success: false,
+        error: sanitizeErrorMessage(msg || 'リマインダーメール送信に失敗しました')
       }),
       {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/migrations/20260804120000_fix_reminder_email_cron.sql
+++ b/supabase/migrations/20260804120000_fix_reminder_email_cron.sql
@@ -1,0 +1,21 @@
+-- Fix reminder email cron job 47: update stale hardcoded secret and add days_before: 3
+-- Job 47 was using an old x-cron-secret that no longer matches the CRON_SECRET env var (→ 401 every run).
+-- Also, the deployed function now defaults to days_before=1, so the 3-day reminder needs it explicit.
+
+SELECT cron.unschedule('auto-send-reminder-emails');
+
+SELECT cron.schedule(
+  'auto-send-reminder-emails',
+  '0 9 * * *',
+  $$
+  SELECT net.http_post(
+    url := (SELECT value FROM public.app_config WHERE key = 'supabase_url') || '/functions/v1/auto-send-reminder-emails',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT value FROM public.app_config WHERE key = 'supabase_anon_key'),
+      'x-cron-secret', (SELECT value FROM public.app_config WHERE key = 'trigger_secret')
+    ),
+    body := '{"days_before": 3}'::jsonb
+  ) AS request_id;
+  $$
+);


### PR DESCRIPTION
## Summary
- `schedule_events.scenario_id → scenarios` の外部キーが削除され `scenario_master_id → scenario_masters` に移行されていたが、`auto-send-reminder-emails` のPostgRESTクエリが旧リレーションのまま残っていた
- `sanitizeErrorMessage` がPGRSTエラーを「エラーが発生しました」に置き換えるため、2月18日から5ヶ月間気づけなかった
- cron job 47 の `x-cron-secret` が古いハードコード値のまま → 毎回401
- cron job 47 の `days_before` 未指定 → デフォルト1になり3日前リマインドが消滅

## Changes
1. `scenarios:scenario_id` → `scenario_masters:scenario_master_id` にクエリ修正
2. `event.scenarios?.title` → `event.scenario_masters?.title` に参照修正
3. cron job 47 を `app_config` のtrigger_secret参照に統一 + `days_before: 3` 明示
4. catch節で生のエラーメッセージをconsole.errorに出力（次回以降の診断用）

## Test plan
- [ ] PRマージ後のCI deployでedge function更新を確認
- [ ] migration適用後、cron job 47 が更新されていることを確認
- [ ] 翌朝09:00 JST（1日前リマインド）のログでステータス200を確認
- [ ] 翌日18:00 JST（3日前リマインド）のログでステータス200を確認
- [ ] email_logsテーブルにemail_type='reminder'の新規レコードが入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)