### PR TITLE
【🛑チェック失敗】fix: リマインドを中止以外の全公演の予約者へ送信

### DIFF
--- a/supabase/functions/auto-send-reminder-emails/index.ts
+++ b/supabase/functions/auto-send-reminder-emails/index.ts
@@ -57,7 +57,6 @@ serve(async (req) => {
       `)
       .eq('date', targetDateStr)
       .eq('is_cancelled', false)
-      .eq('is_reservation_enabled', true)
 
     if (eventsError) throw eventsError
 


### PR DESCRIPTION
## Summary
- `is_reservation_enabled` フィルタを除去
- 中止(`is_cancelled = true`)以外の全公演で、confirmed/pending/gm_confirmed の予約者にリマインドを送信
- 満席で予約受付が閉じた公演の予約者にもリマインドが届くようになる

## 背景
明日(8/5)のデータで、`is_reservation_enabled = false` の公演に9件の予約があり、現状これらの予約者にリマインドが届いていなかった。

## Test plan
- [ ] デプロイ後のテスト呼び出しで200を確認
- [ ] 翌朝のcron実行でemail_logsに全予約者分のリマインドが記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)