### PR TITLE
fix: シナリオ詳細の公演可能店舗にラベルを追加

### DIFF
--- a/src/pages/ScenarioDetailPage/components/ScenarioHero.tsx
+++ b/src/pages/ScenarioDetailPage/components/ScenarioHero.tsx
@@ -370,7 +370,11 @@ export const ScenarioHero = memo(function ScenarioHero({ scenario, events = [], 
             {availableStoreNames.length > 0 && (
               <div className="flex items-start gap-1.5 text-xs text-white/70">
                 <Building2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
-                <span>{availableStoreNames.join('・')}</span>
+                <span>
+                  <span className="text-white/50">公演可能店舗</span>
+                  <span className="mx-1 text-white/40">:</span>
+                  {availableStoreNames.join('・')}
+                </span>
               </div>
             )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
シナリオ詳細ヒーローで、店舗名だけ（例: 「大久保」）だと意味が分かりにくいため、「公演可能店舗:」ラベルを前置します。

## 変更内容
- `ScenarioHero.tsx`: 公演可能店舗の表示を `公演可能店舗: 大久保` 形式に変更

## 関連
- 貸切リクエスト不具合報告 (#390) の切り分け中に、表示の分かりにくさも指摘されたため先行対応

## 動作確認
- [ ] シナリオ詳細（例: 彼女といるかとチョコレート）で「公演可能店舗: 大久保」と見えること
- [ ] 複数店舗のシナリオでは「公演可能店舗: A・B」と並ぶこと
- [ ] 公演可能店舗未設定のシナリオでは当該行が出ないこと（従来どおり）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d170d0-6165-46c7-823a-6d016645c65e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d170d0-6165-46c7-823a-6d016645c65e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

