### PR TITLE
fix: リマインドメールを前日のみに変更（#389）

### DIFF
--- a/src/lib/reminderSchedule.test.ts
+++ b/src/lib/reminderSchedule.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getReminderDayMessage,
+  getReminderTargetDateJst,
+  isHardcodedTomorrowMessageMismatched,
+} from './reminderSchedule'
+
+/** JST の壁時計時刻を UTC Date にする（テスト用） */
+function jst(y: number, m: number, d: number, h = 9, min = 0): Date {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return new Date(`${y}-${pad(m)}-${pad(d)}T${pad(h)}:${pad(min)}:00+09:00`)
+}
+
+describe('getReminderTargetDateJst (#389)', () => {
+  it('水曜朝 + days_before:3 → 土曜（報告された送信）', () => {
+    // 2026-08-05 は水曜。3日後は 2026-08-08 土曜
+    expect(getReminderTargetDateJst(3, jst(2026, 8, 5, 9))).toBe('2026-08-08')
+  })
+
+  it('水曜朝 + days_before:1 → 木曜（前日のみ運用）', () => {
+    expect(getReminderTargetDateJst(1, jst(2026, 8, 5, 9))).toBe('2026-08-06')
+  })
+
+  it('金曜朝 + days_before:1 → 土曜（土曜公演の正しい前日リマインド）', () => {
+    expect(getReminderTargetDateJst(1, jst(2026, 8, 7, 9))).toBe('2026-08-08')
+  })
+
+  it('JST 18:00（UTC 09:00 cron）でも 3日前は同じ土曜', () => {
+    expect(getReminderTargetDateJst(3, jst(2026, 8, 5, 18))).toBe('2026-08-08')
+  })
+
+  it('日付境界付近（JST 00:30）でもずれない', () => {
+    expect(getReminderTargetDateJst(1, jst(2026, 8, 5, 0, 30))).toBe('2026-08-06')
+  })
+})
+
+describe('getReminderDayMessage', () => {
+  it('1日前は「明日の」', () => {
+    expect(getReminderDayMessage(1)).toContain('明日の')
+  })
+
+  it('3日前は「3日後の」であり「明日の」ではない', () => {
+    const msg = getReminderDayMessage(3)
+    expect(msg).toContain('3日後の')
+    expect(msg).not.toContain('明日の')
+  })
+})
+
+describe('isHardcodedTomorrowMessageMismatched (#389 文面矛盾)', () => {
+  const storedTemplate = '{customer_name} 様\n\n明日の公演についてリマインドいたします。\n'
+
+  it('days_before:3 で「明日の」直書きテンプレは矛盾', () => {
+    expect(isHardcodedTomorrowMessageMismatched(storedTemplate, 3)).toBe(true)
+  })
+
+  it('days_before:1（前日のみ）なら矛盾しない', () => {
+    expect(isHardcodedTomorrowMessageMismatched(storedTemplate, 1)).toBe(false)
+  })
+})

--- a/src/lib/reminderSchedule.ts
+++ b/src/lib/reminderSchedule.ts
@@ -1,0 +1,53 @@
+/**
+ * リマインドメールの対象日・文面（Edge Function と同ロジック）。
+ * auto-send-reminder-emails / send-reminder-emails の日付・文言判定の正をここに置く。
+ */
+
+/** 今日（基準日時）から daysBefore 日後の公演日を JST の YYYY-MM-DD で返す */
+export function getReminderTargetDateJst(
+  daysBefore: number,
+  now: Date = new Date()
+): string {
+  const targetDate = new Date(now.getTime() + daysBefore * 86400000)
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(targetDate)
+}
+
+/** daysBefore に応じたリマインド導入文 */
+export function getReminderDayMessage(daysBefore: number): string {
+  if (daysBefore === 1) {
+    return '明日の公演についてリマインドいたします。'
+  }
+  if (daysBefore === 2) {
+    return '明後日の公演についてリマインドいたします。'
+  }
+  if (daysBefore === 3) {
+    return '3日後の公演についてリマインドいたします。'
+  }
+  if (daysBefore === 7) {
+    return '1週間後の公演についてリマインドいたします。'
+  }
+  if (daysBefore === 14) {
+    return '2週間後の公演についてリマインドいたします。'
+  }
+  if (daysBefore === 30) {
+    return '1ヶ月後の公演についてリマインドいたします。'
+  }
+  return `${daysBefore}日後の公演についてリマインドいたします。`
+}
+
+/**
+ * カスタムテンプレに「明日の」が直書きされていると、
+ * daysBefore !== 1 のとき文面と送信タイミングが矛盾する（#389）。
+ */
+export function isHardcodedTomorrowMessageMismatched(
+  template: string,
+  daysBefore: number
+): boolean {
+  const hasTomorrow = template.includes('明日の')
+  return hasTomorrow && daysBefore !== 1
+}

--- a/supabase/functions/send-reminder-emails/index.ts
+++ b/supabase/functions/send-reminder-emails/index.ts
@@ -148,6 +148,8 @@ serve(async (req) => {
 
     // テンプレートの変数を置換（基本変数セット対応）
     const appliedTemplate = emailTemplate
+      // 送信タイミング（{day_message} を含むテンプレートのみ影響。issue #389）
+      .replace(/{day_message}/g, getDayMessage(reminderData.daysBefore ?? 1))
       // 顧客情報
       .replace(/{customer_name}/g, reminderData.customerName || 'お客様')
       .replace(/{customer_email}/g, reminderData.customerEmail || '')

--- a/supabase/migrations/20260806090000_disable_reminder_email_3days_cron.sql
+++ b/supabase/migrations/20260806090000_disable_reminder_email_3days_cron.sql
@@ -1,0 +1,120 @@
+-- =============================================================================
+-- マイグレーション: リマインドメールを「前日のみ」にする（3日前を停止）
+-- issue #389
+-- =============================================================================
+--
+-- 背景:
+--   土曜公演のリマインドが水曜に届いた。これは cron ジョブ
+--   'auto-send-reminder-emails'（body: {"days_before": 3}）が 3 日前に発火する
+--   仕様どおりの挙動だったが、email_settings.reminder_template の本文に
+--   「明日の」がハードコードされているため、文面と送信タイミングが矛盾していた。
+--
+-- PO判断:
+--   B. 3日前の送信を止めて「前日のみ」にする。
+--   前日のみになればテンプレートの「明日の」は正しい文面になるため、
+--   テンプレート本文の一括置換は行わない。
+--
+-- 変更内容:
+--   1. 'auto-send-reminder-emails'（3日前ジョブ）を unschedule（存在しなければスキップ）
+--   2. 'auto-send-reminder-emails-day-before'（前日ジョブ）を
+--      無ければ作成 / あれば schedule・command を正して active 化
+--      - schedule: '0 0 * * *'（UTC 00:00 = JST 09:00）
+--      - body: {"days_before": 1}
+--      - 接続情報は public.app_config から取得（Supabase Cloud では
+--        current_setting() が NULL を返しサイレント失敗するため）
+--
+-- 冪等性:
+--   何度実行しても安全（unschedule は存在チェック付き、作成/更新は分岐）。
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_jobid BIGINT;
+BEGIN
+  -- pg_cron が利用可能かチェック
+  BEGIN
+    PERFORM 1 FROM cron.job LIMIT 1;
+  EXCEPTION
+    WHEN undefined_table OR undefined_object THEN
+      RAISE NOTICE 'ℹ️  cron.job が存在しません（pg_cron 未導入のためスキップ）';
+      RETURN;
+  END;
+
+  -- 1. 3日前リマインド（auto-send-reminder-emails）を停止
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'auto-send-reminder-emails';
+  IF v_jobid IS NOT NULL THEN
+    PERFORM cron.unschedule(v_jobid);
+    RAISE NOTICE '🛑 3日前リマインド cron を停止しました (jobid: %)', v_jobid;
+  ELSE
+    RAISE NOTICE 'ℹ️  auto-send-reminder-emails が見つかりません（既に停止済み・スキップ）';
+  END IF;
+
+  -- 2. 前日リマインド（auto-send-reminder-emails-day-before）を有効化
+  v_jobid := NULL;
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'auto-send-reminder-emails-day-before';
+
+  IF v_jobid IS NOT NULL THEN
+    PERFORM cron.alter_job(
+      v_jobid,
+      schedule => '0 0 * * *',
+      command => $cmd$
+      SELECT net.http_post(
+        url := (SELECT value FROM public.app_config WHERE key = 'supabase_url') || '/functions/v1/auto-send-reminder-emails',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (SELECT value FROM public.app_config WHERE key = 'supabase_anon_key'),
+          'x-cron-secret', (SELECT value FROM public.app_config WHERE key = 'trigger_secret')
+        ),
+        body := '{"days_before": 1}'::jsonb
+      ) AS request_id
+      $cmd$,
+      active => true
+    );
+    RAISE NOTICE '✅ 前日リマインド cron を更新・有効化しました (jobid: %)', v_jobid;
+  ELSE
+    SELECT cron.schedule(
+      'auto-send-reminder-emails-day-before',
+      '0 0 * * *',
+      $cmd$
+      SELECT net.http_post(
+        url := (SELECT value FROM public.app_config WHERE key = 'supabase_url') || '/functions/v1/auto-send-reminder-emails',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (SELECT value FROM public.app_config WHERE key = 'supabase_anon_key'),
+          'x-cron-secret', (SELECT value FROM public.app_config WHERE key = 'trigger_secret')
+        ),
+        body := '{"days_before": 1}'::jsonb
+      ) AS request_id
+      $cmd$
+    ) INTO v_jobid;
+    RAISE NOTICE '✅ 前日リマインド cron を作成しました (jobid: %)', v_jobid;
+  END IF;
+END $$;
+
+-- 確認
+DO $$
+DECLARE
+  v_rec RECORD;
+  v_found BOOLEAN := false;
+BEGIN
+  BEGIN
+    PERFORM 1 FROM cron.job LIMIT 1;
+  EXCEPTION
+    WHEN undefined_table OR undefined_object THEN
+      RETURN;
+  END;
+
+  FOR v_rec IN
+    SELECT jobname, schedule, active
+    FROM cron.job
+    WHERE jobname LIKE 'auto-send-reminder-emails%'
+    ORDER BY jobname
+  LOOP
+    v_found := true;
+    RAISE NOTICE '📧 % : active=%, schedule=%', v_rec.jobname, v_rec.active, v_rec.schedule;
+  END LOOP;
+
+  IF NOT v_found THEN
+    RAISE WARNING '⚠️ リマインドメール cron が1件も見つかりませんでした';
+  END IF;
+END $$;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
土曜公演のリマインドが水曜に届いた件（#389）への対応です。

原因は日付バグではなく、`days_before: 3` の cron が復旧していたことと、メール設定テンプレに「明日の」がハードコードされていたことの組み合わせでした。

PO判断どおり **3日前送信を止め、前日のみ** にします。前日のみになれば「明日の」文面は正しい意味になります。

## 変更内容
- 新規マイグレ `20260806090000_disable_reminder_email_3days_cron.sql`
  - `auto-send-reminder-emails`（3日前）を unschedule
  - `auto-send-reminder-emails-day-before`（前日 / JST 09:00 / `days_before: 1`）を有効化・正規化
- `send-reminder-emails`: 将来用に `{day_message}` 置換を追加（既存テンプレは無影響）
- **テスト追加** `src/lib/reminderSchedule.ts` + `.test.ts`
  - 水曜+3日→土曜、金曜+1日→土曜
  - 「明日の」直書きテンプレが days_before:3 で矛盾すること
  - `npm run test:unit -- src/lib/reminderSchedule.test.ts` → 9件 green（この環境で実行済み）

## この環境での検証結果
- ユニットテスト: **9/9 合格**
- staging/prod への `db:push` は Keychain が無いため未実施（要手元適用）
- 本番 anon キーしか無いため、Edge Function の実送信テストは未実施（誤送信防止）

## 適用手順（DB先行）
```bash
npm run db:push:staging
# 確認後
npm run db:push:prod
```

確認クエリ:
```sql
SELECT jobname, schedule, active
FROM cron.job
WHERE jobname LIKE 'auto-send-reminder-emails%';
```

期待: `auto-send-reminder-emails-day-before` のみ active。

Closes #389

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d170d0-6165-46c7-823a-6d016645c65e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d170d0-6165-46c7-823a-6d016645c65e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

